### PR TITLE
Improve error output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,16 +22,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "739f4a8db6605981345c5654f3a85b056ce52f37a39d34da03f25bf2151ea16e"
 
 [[package]]
-name = "annotate-snippets"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c96c3d1062ea7101741480185a6a1275eab01cbe8b20e378d1311bc056d2e08"
-dependencies = [
- "unicode-width",
- "yansi-term",
-]
-
-[[package]]
 name = "ansi_term"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -53,6 +43,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "072df7202e63b127ab55acfe16ce97013d5b97bf160489336d3f1840fd78e99e"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "ariadne"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7080ae01b2f0c312065d4914cd0f0de045eb8832e9415b355106a6cff3073cb4"
+dependencies = [
+ "yansi",
 ]
 
 [[package]]
@@ -852,7 +851,7 @@ dependencies = [
 name = "toc_driver"
 version = "0.1.0"
 dependencies = [
- "annotate-snippets",
+ "ariadne",
  "toc_analysis",
  "toc_ast_db",
  "toc_hir",
@@ -1148,10 +1147,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "yansi-term"
-version = "0.1.2"
+name = "yansi"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe5c30ade05e61656247b2e334a031dfd0cc466fadef865bdcdea8d537951bf1"
-dependencies = [
- "winapi",
-]
+checksum = "9fc79f4a1e39857fc00c3f662cbf2651c771f00e9c15fe2abc341806bd46bd71"

--- a/compiler/toc_analysis/src/const_eval/snapshots/toc_analysis__const_eval__test__error_no_const_expr-2.snap
+++ b/compiler/toc_analysis/src/const_eval/snapshots/toc_analysis__const_eval__test__error_no_const_expr-2.snap
@@ -9,6 +9,4 @@ expression: "var a := 1\nconst b := a\nconst c := b\n"
 
 error in file FileId(1) at 22..23: reference cannot be computed at compile-time
 | note in file FileId(1) for 4..5: `a` declared here
-error in file FileId(1) at 22..23: reference cannot be computed at compile-time
-| note in file FileId(1) for 4..5: `a` declared here
 

--- a/compiler/toc_analysis/src/const_eval/snapshots/toc_analysis__const_eval__test__error_propagation.snap
+++ b/compiler/toc_analysis/src/const_eval/snapshots/toc_analysis__const_eval__test__error_propagation.snap
@@ -7,5 +7,4 @@ expression: "const a := 1 div 0\nconst b := a\n"
 "b"@(FileId(1), 25..26) -> ConstError { kind: DivByZero, span: (FileId(1), 13..16) }
 
 error in file FileId(1) at 13..16: division by zero in compile-time expression
-error in file FileId(1) at 13..16: division by zero in compile-time expression
 

--- a/compiler/toc_analysis/src/const_eval/test.rs
+++ b/compiler/toc_analysis/src/const_eval/test.rs
@@ -2,7 +2,7 @@ use std::cell::RefCell;
 
 use toc_hir::library::{LibraryId, LoweredLibrary};
 use toc_hir_db::db::HirDatabase;
-use toc_reporting::{MessageSink, ReportMessage};
+use toc_reporting::{MessageBundle, MessageSink};
 use unindent::unindent;
 
 use crate::{const_eval::Const, db::ConstEval, test_db::TestDb};
@@ -90,10 +90,10 @@ fn do_const_eval(source: &str) -> String {
     let results = results.into_inner();
 
     // Errors are bundled into the const error context
-    stringify_const_eval_results(&results, &reporter.finish())
+    stringify_const_eval_results(&results, reporter.finish())
 }
 
-fn stringify_const_eval_results(results: &str, messages: &[ReportMessage]) -> String {
+fn stringify_const_eval_results(results: &str, messages: MessageBundle) -> String {
     // Pretty print const eval ctx
     // Want:
     // - Evaluation state of all accessible DefIds

--- a/compiler/toc_analysis/src/query.rs
+++ b/compiler/toc_analysis/src/query.rs
@@ -1,9 +1,9 @@
 //! Analysis query implementation
 
-use toc_reporting::CompileResult;
+use toc_reporting::{CompileResult, MessageBundle};
 
 pub(crate) fn analyze_libraries(db: &dyn crate::db::HirAnalysis) -> CompileResult<()> {
-    let mut messages = vec![];
+    let mut messages = MessageBundle::default();
 
     let res = db.library_graph();
     let lib_graph = res.result();

--- a/compiler/toc_analysis/src/ty/rules.rs
+++ b/compiler/toc_analysis/src/ty/rules.rs
@@ -616,35 +616,37 @@ pub fn report_invalid_bin_op(err: InvalidBinaryOp, op_span: Span, reporter: &mut
     };
 
     if unsupported {
-        reporter.error("operation is not type-checked yet", op_span);
+        reporter.error(
+            "unsupported operation",
+            "operation is not type-checked yet",
+            op_span,
+        );
         return;
     }
 
     let msg = reporter.error_detailed(&format!("incompatible types for {}", op_name), op_span);
     let msg = match op {
         // Arithmetic operators
-        expr::BinaryOp::Add => {
-            msg.with_info("operands must both be numbers, strings, or sets", None)
-        }
+        expr::BinaryOp::Add => msg.with_info("operands must both be numbers, strings, or sets"),
         expr::BinaryOp::Sub | expr::BinaryOp::Mul => {
-            msg.with_info("operands must both be numbers or sets", None)
+            msg.with_info("operands must both be numbers or sets")
         }
         expr::BinaryOp::Div
         | expr::BinaryOp::RealDiv
         | expr::BinaryOp::Mod
         | expr::BinaryOp::Rem
-        | expr::BinaryOp::Exp => msg.with_info("operands must both be numbers", None),
+        | expr::BinaryOp::Exp => msg.with_info("operands must both be numbers"),
         // Bitwise operators (integer, integer => nat)
         // + Logical operators (boolean, boolean => boolean)
         expr::BinaryOp::And | expr::BinaryOp::Or | expr::BinaryOp::Xor => {
-            msg.with_info("operands must both be integers or booleans", None)
+            msg.with_info("operands must both be integers or booleans")
         }
         // Pure bitwise operators
         expr::BinaryOp::Shl | expr::BinaryOp::Shr => {
-            msg.with_info("operands must both be integers", None)
+            msg.with_info("operands must both be integers")
         }
         // Pure logical operator
-        expr::BinaryOp::Imply => msg.with_info("operands must both be booleans", None),
+        expr::BinaryOp::Imply => msg.with_info("operands must both be booleans"),
         // Comparison (a, b => boolean where a, b: Comparable)
         expr::BinaryOp::Less => todo!(),
         expr::BinaryOp::LessEq => todo!(),
@@ -717,9 +719,9 @@ pub fn report_invalid_unary_op(err: InvalidUnaryOp, op_span: Span, reporter: &mu
 
     let msg = reporter.error_detailed(&format!("incompatible types for {}", op_name), op_span);
     let msg = match op {
-        expr::UnaryOp::Not => msg.with_info("operand must be an integer or boolean", None),
+        expr::UnaryOp::Not => msg.with_info("operand must be an integer or boolean"),
         expr::UnaryOp::Identity | expr::UnaryOp::Negate => {
-            msg.with_info("operand must be a number", None)
+            msg.with_info("operand must be a number")
         }
     };
     msg.finish();

--- a/compiler/toc_analysis/src/typeck.rs
+++ b/compiler/toc_analysis/src/typeck.rs
@@ -160,10 +160,8 @@ impl TypeCheck<'_> {
             self.state()
                 .reporter
                 .error_detailed("mismatched types", init_span)
-                .with_note(
-                    "initializer's type is incompatible with this type",
-                    spec_span,
-                )
+                .with_error("the type of this expression...", init_span)
+                .with_note("is incompatible with this type", spec_span)
                 .finish();
 
             // Don't need to worry about ConstValue being anything,
@@ -205,13 +203,11 @@ impl TypeCheck<'_> {
                     .lookup_in(&self.library.span_map);
 
                 // TODO: Stringify lhs for more clarity on the error location
+                // TODO: If it's a ref expr, get the definition point
                 self.state()
                     .reporter
                     .error_detailed("cannot assign into expression on left hand side", asn_span)
-                    .with_note(
-                        "this expression cannot be used as a variable reference",
-                        left_span,
-                    )
+                    .with_note("not a reference to a variable", left_span)
                     .finish();
             }
         }
@@ -253,11 +249,9 @@ impl TypeCheck<'_> {
                     self.state()
                         .reporter
                         .error_detailed("invalid put option", span)
+                        .with_error("this is the invalid option", span)
                         .with_note("cannot specify fraction width for this type", item_span)
-                        .with_info(
-                            "fraction width can only be specified for numeric put types",
-                            None,
-                        )
+                        .with_info("fraction width can only be specified for numeric put types")
                         .finish();
                 }
 
@@ -267,11 +261,9 @@ impl TypeCheck<'_> {
                     self.state()
                         .reporter
                         .error_detailed("invalid put option", span)
+                        .with_error("this is the invalid option", span)
                         .with_note("cannot specify exponent width for this type", item_span)
-                        .with_info(
-                            "exponent width can only be specified for numeric types",
-                            None,
-                        )
+                        .with_info("exponent width can only be specified for numeric types")
                         .finish();
                 }
             }
@@ -317,13 +309,11 @@ impl TypeCheck<'_> {
                 let get_item_span = body.expr(item.expr).span.lookup_in(&self.library.span_map);
 
                 // TODO: Stringify item for more clarity on the error location
+                // TODO: If it's a ref expr, get the definition point
                 self.state()
                     .reporter
-                    .error_detailed("cannot assign into get item expression", get_item_span)
-                    .with_note(
-                        "this expression cannot be used as a variable reference",
-                        get_item_span,
-                    )
+                    .error_detailed("cannot assign into expression", get_item_span)
+                    .with_error("not a reference to a variable", get_item_span)
                     .finish();
             }
 
@@ -351,7 +341,7 @@ impl TypeCheck<'_> {
             self.state()
                 .reporter
                 .error_detailed("mismatched types", ty_span)
-                .with_note("expected integer type", ty_span)
+                .with_error("expected integer type", ty_span)
                 .finish();
         }
     }
@@ -428,9 +418,11 @@ impl TypeCheck<'_> {
                 .span
                 .lookup_in(&self.library.span_map);
 
-            self.state()
-                .reporter
-                .error(&format!("`{}` is not declared", def_info.name.item()), span);
+            self.state().reporter.error(
+                &format!("`{}` is not declared", def_info.name.item()),
+                "not found in this scope",
+                span,
+            );
         }
     }
 
@@ -486,11 +478,8 @@ impl TypeCheck<'_> {
             self.state()
                 .reporter
                 .error_detailed("invalid character count size", expr_span)
-                .with_note(&format!("computed count is {}", int), expr_span)
-                .with_info(
-                    &format!("valid sizes are between 1 to {}", size_limit - 1),
-                    None,
-                )
+                .with_error(&format!("computed count is {}", int), expr_span)
+                .with_info(&format!("valid sizes are between 1 to {}", size_limit - 1))
                 .finish();
         }
     }

--- a/compiler/toc_analysis/src/typeck.rs
+++ b/compiler/toc_analysis/src/typeck.rs
@@ -206,7 +206,7 @@ impl TypeCheck<'_> {
                 // TODO: If it's a ref expr, get the definition point
                 self.state()
                     .reporter
-                    .error_detailed("cannot assign into expression on left hand side", asn_span)
+                    .error_detailed("cannot assign into expression", asn_span)
                     .with_note("not a reference to a variable", left_span)
                     .finish();
             }

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_boolean_err.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_boolean_err.snap
@@ -13,10 +13,14 @@ expression: "var r : real\nvar i : int\nvar n : nat\n\nvar _e00 : boolean := 1\n
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 60..61: mismatched types
-| note in file FileId(1) for 49..56: initializer's type is incompatible with this type
+| error in file FileId(1) for 60..61: the type of this expression...
+| note in file FileId(1) for 49..56: is incompatible with this type
 error in file FileId(1) at 84..85: mismatched types
-| note in file FileId(1) for 73..80: initializer's type is incompatible with this type
+| error in file FileId(1) for 84..85: the type of this expression...
+| note in file FileId(1) for 73..80: is incompatible with this type
 error in file FileId(1) at 108..109: mismatched types
-| note in file FileId(1) for 97..104: initializer's type is incompatible with this type
+| error in file FileId(1) for 108..109: the type of this expression...
+| note in file FileId(1) for 97..104: is incompatible with this type
 error in file FileId(1) at 132..133: mismatched types
-| note in file FileId(1) for 121..128: initializer's type is incompatible with this type
+| error in file FileId(1) for 132..133: the type of this expression...
+| note in file FileId(1) for 121..128: is incompatible with this type

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_char_1_err.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_char_1_err.snap
@@ -9,4 +9,5 @@ expression: "const N := 1\nvar c5 : char(5)\n\nvar _e00 : char(N) := c5\n"
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 53..55: mismatched types
-| note in file FileId(1) for 42..49: initializer's type is incompatible with this type
+| error in file FileId(1) for 53..55: the type of this expression...
+| note in file FileId(1) for 42..49: is incompatible with this type

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_char_256_err.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_char_256_err.snap
@@ -15,10 +15,14 @@ expression: "const N := 256\nvar c : char\nvar c5 : char(5)\nvar c257 : char(257
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 108..109: mismatched types
-| note in file FileId(1) for 97..104: initializer's type is incompatible with this type
+| error in file FileId(1) for 108..109: the type of this expression...
+| note in file FileId(1) for 97..104: is incompatible with this type
 error in file FileId(1) at 132..134: mismatched types
-| note in file FileId(1) for 121..128: initializer's type is incompatible with this type
+| error in file FileId(1) for 132..134: the type of this expression...
+| note in file FileId(1) for 121..128: is incompatible with this type
 error in file FileId(1) at 157..161: mismatched types
-| note in file FileId(1) for 146..153: initializer's type is incompatible with this type
+| error in file FileId(1) for 157..161: the type of this expression...
+| note in file FileId(1) for 146..153: is incompatible with this type
 error in file FileId(1) at 184..186: mismatched types
-| note in file FileId(1) for 173..180: initializer's type is incompatible with this type
+| error in file FileId(1) for 184..186: the type of this expression...
+| note in file FileId(1) for 173..180: is incompatible with this type

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_char_3_err.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_char_3_err.snap
@@ -15,10 +15,14 @@ expression: "const N := 3\nvar c : char\nvar c1 : char(1)\nvar c5 : char(5)\nvar
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 102..103: mismatched types
-| note in file FileId(1) for 91..98: initializer's type is incompatible with this type
+| error in file FileId(1) for 102..103: the type of this expression...
+| note in file FileId(1) for 91..98: is incompatible with this type
 error in file FileId(1) at 126..128: mismatched types
-| note in file FileId(1) for 115..122: initializer's type is incompatible with this type
+| error in file FileId(1) for 126..128: the type of this expression...
+| note in file FileId(1) for 115..122: is incompatible with this type
 error in file FileId(1) at 151..153: mismatched types
-| note in file FileId(1) for 140..147: initializer's type is incompatible with this type
+| error in file FileId(1) for 151..153: the type of this expression...
+| note in file FileId(1) for 140..147: is incompatible with this type
 error in file FileId(1) at 176..178: mismatched types
-| note in file FileId(1) for 165..172: initializer's type is incompatible with this type
+| error in file FileId(1) for 176..178: the type of this expression...
+| note in file FileId(1) for 165..172: is incompatible with this type

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_char_err.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_char_err.snap
@@ -10,6 +10,8 @@ expression: "var c5 : char(5)\nvar s5 : string(5)\n\nvar _e00 : char := s5\nvar 
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 56..58: mismatched types
-| note in file FileId(1) for 48..52: initializer's type is incompatible with this type
+| error in file FileId(1) for 56..58: the type of this expression...
+| note in file FileId(1) for 48..52: is incompatible with this type
 error in file FileId(1) at 78..80: mismatched types
-| note in file FileId(1) for 70..74: initializer's type is incompatible with this type
+| error in file FileId(1) for 78..80: the type of this expression...
+| note in file FileId(1) for 70..74: is incompatible with this type

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_int_err.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_int_err.snap
@@ -10,6 +10,8 @@ expression: "var b : boolean\nvar r : real\n\nvar _e00 : int := b\nvar _e01 : in
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 48..49: mismatched types
-| note in file FileId(1) for 41..44: initializer's type is incompatible with this type
+| error in file FileId(1) for 48..49: the type of this expression...
+| note in file FileId(1) for 41..44: is incompatible with this type
 error in file FileId(1) at 68..69: mismatched types
-| note in file FileId(1) for 61..64: initializer's type is incompatible with this type
+| error in file FileId(1) for 68..69: the type of this expression...
+| note in file FileId(1) for 61..64: is incompatible with this type

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_nat_err.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_nat_err.snap
@@ -10,6 +10,8 @@ expression: "var b : boolean\nvar r : real\n\nvar _e00 : nat := b\nvar _e01 : na
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 48..49: mismatched types
-| note in file FileId(1) for 41..44: initializer's type is incompatible with this type
+| error in file FileId(1) for 48..49: the type of this expression...
+| note in file FileId(1) for 41..44: is incompatible with this type
 error in file FileId(1) at 68..69: mismatched types
-| note in file FileId(1) for 61..64: initializer's type is incompatible with this type
+| error in file FileId(1) for 68..69: the type of this expression...
+| note in file FileId(1) for 61..64: is incompatible with this type

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_real_err.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_real_err.snap
@@ -8,4 +8,5 @@ expression: "var b : boolean\n\nvar _e00 : real := b\n"
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 36..37: mismatched types
-| note in file FileId(1) for 28..32: initializer's type is incompatible with this type
+| error in file FileId(1) for 36..37: the type of this expression...
+| note in file FileId(1) for 28..32: is incompatible with this type

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_string_1_err.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_string_1_err.snap
@@ -9,4 +9,5 @@ expression: "const N := 1\nvar c5 : char(5)\n\nvar _e00 : string(N) := c5 % [not
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 55..57: mismatched types
-| note in file FileId(1) for 42..51: initializer's type is incompatible with this type
+| error in file FileId(1) for 55..57: the type of this expression...
+| note in file FileId(1) for 42..51: is incompatible with this type

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_string_255_err.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_string_255_err.snap
@@ -9,4 +9,5 @@ expression: "const N := 255\nvar c256 : char(256)\n\nvar _e00 : string(N) := c25
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 61..65: mismatched types
-| note in file FileId(1) for 48..57: initializer's type is incompatible with this type
+| error in file FileId(1) for 61..65: the type of this expression...
+| note in file FileId(1) for 48..57: is incompatible with this type

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_string_3_err.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_string_3_err.snap
@@ -9,4 +9,5 @@ expression: "const N := 3\nvar c5 : char(5)\n\nvar _e00 : string(N) := c5 % [not
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 55..57: mismatched types
-| note in file FileId(1) for 42..51: initializer's type is incompatible with this type
+| error in file FileId(1) for 55..57: the type of this expression...
+| note in file FileId(1) for 42..51: is incompatible with this type

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_string_err.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_string_err.snap
@@ -8,4 +8,5 @@ expression: "var cmx : char(256)\n\nvar _e00 : string := cmx % [not captured by 
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 42..45: mismatched types
-| note in file FileId(1) for 32..38: initializer's type is incompatible with this type
+| error in file FileId(1) for 42..45: the type of this expression...
+| note in file FileId(1) for 32..38: is incompatible with this type

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_string_err_lhs.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_string_err_lhs.snap
@@ -8,4 +8,5 @@ expression: "var cmx : char(256)\n\nvar _e00 : string(*) := cmx % [not captured 
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 45..48: mismatched types
-| note in file FileId(1) for 32..41: initializer's type is incompatible with this type
+| error in file FileId(1) for 45..48: the type of this expression...
+| note in file FileId(1) for 32..41: is incompatible with this type

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__block_stmt_check.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__block_stmt_check.snap
@@ -7,4 +7,5 @@ expression: "begin var k : char := 'baz' end"
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 22..27: mismatched types
-| note in file FileId(1) for 14..18: initializer's type is incompatible with this type
+| error in file FileId(1) for 22..27: the type of this expression...
+| note in file FileId(1) for 14..18: is incompatible with this type

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__sized_char_max_sized.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__sized_char_max_sized.snap
@@ -7,5 +7,5 @@ expression: "var _ : char(32768)"
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 13..18: invalid character count size
-| note in file FileId(1) for 13..18: computed count is 32768
+| error in file FileId(1) for 13..18: computed count is 32768
 | info: valid sizes are between 1 to 32767

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__sized_char_zero_sized.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__sized_char_zero_sized.snap
@@ -7,5 +7,5 @@ expression: "var _ : char(0)"
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 13..14: invalid character count size
-| note in file FileId(1) for 13..14: computed count is 0
+| error in file FileId(1) for 13..14: computed count is 0
 | info: valid sizes are between 1 to 32767

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__sized_string_max_sized.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__sized_string_max_sized.snap
@@ -7,5 +7,5 @@ expression: "var _ : string(256)"
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 15..18: invalid character count size
-| note in file FileId(1) for 15..18: computed count is 256
+| error in file FileId(1) for 15..18: computed count is 256
 | info: valid sizes are between 1 to 255

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__sized_string_over_sized.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__sized_string_over_sized.snap
@@ -7,5 +7,5 @@ expression: "var _ : string(512)"
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 15..18: invalid character count size
-| note in file FileId(1) for 15..18: computed count is 512
+| error in file FileId(1) for 15..18: computed count is 512
 | info: valid sizes are between 1 to 255

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__sized_string_zero_sized.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__sized_string_zero_sized.snap
@@ -7,5 +7,5 @@ expression: "var _ : string(0)"
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 15..16: invalid character count size
-| note in file FileId(1) for 15..16: computed count is 0
+| error in file FileId(1) for 15..16: computed count is 0
 | info: valid sizes are between 1 to 255

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_assignment_invalid_compound_add.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_assignment_invalid_compound_add.snap
@@ -7,5 +7,5 @@ expression: "var lhs : real\nvar rhs : boolean\nlhs += rhs\n"
 "rhs"@(FileId(1), 19..22) [Declared]: ref_mut boolean
 "<root>"@(dummy) [Declared]: <error>
 
-error in file FileId(1) at 37..38: incompatible types for addition
+error in file FileId(1) at 37..39: incompatible types for addition
 | info: operands must both be numbers, strings, or sets

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_assignment_lhs_not_mut_is_const.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_assignment_lhs_not_mut_is_const.snap
@@ -7,5 +7,5 @@ expression: "const j : int := 2\nconst k : int := 3\nk := j\n"
 "k"@(FileId(1), 25..26) [Declared]: ref int
 "<root>"@(dummy) [Declared]: <error>
 
-error in file FileId(1) at 40..42: cannot assign into expression on left hand side
-| note in file FileId(1) for 38..39: this expression cannot be used as a variable reference
+error in file FileId(1) at 40..42: cannot assign into expression
+| note in file FileId(1) for 38..39: not a reference to a variable

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_const_incompatible.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_const_incompatible.snap
@@ -7,4 +7,5 @@ expression: "const k : char := 20"
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 18..20: mismatched types
-| note in file FileId(1) for 10..14: initializer's type is incompatible with this type
+| error in file FileId(1) for 18..20: the type of this expression...
+| note in file FileId(1) for 10..14: is incompatible with this type

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_get_stmt_wrong_ref_const.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_get_stmt_wrong_ref_const.snap
@@ -6,5 +6,5 @@ expression: "const i : int := 1\nget i\n"
 "i"@(FileId(1), 6..7) [Declared]: ref int
 "<root>"@(dummy) [Declared]: <error>
 
-error in file FileId(1) at 23..24: cannot assign into get item expression
-| note in file FileId(1) for 23..24: this expression cannot be used as a variable reference
+error in file FileId(1) at 23..24: cannot assign into expression
+| error in file FileId(1) for 23..24: not a reference to a variable

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_get_stmt_wrong_ref_literal.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_get_stmt_wrong_ref_literal.snap
@@ -5,5 +5,5 @@ expression: "get 1\n"
 ---
 "<root>"@(dummy) [Declared]: <error>
 
-error in file FileId(1) at 4..5: cannot assign into get item expression
-| note in file FileId(1) for 4..5: this expression cannot be used as a variable reference
+error in file FileId(1) at 4..5: cannot assign into expression
+| error in file FileId(1) for 4..5: not a reference to a variable

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_get_stmt_wrong_ref_value.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_get_stmt_wrong_ref_value.snap
@@ -6,5 +6,5 @@ expression: "var i : int := 1\nget i + i\n"
 "i"@(FileId(1), 4..5) [Declared]: ref_mut int
 "<root>"@(dummy) [Declared]: <error>
 
-error in file FileId(1) at 21..26: cannot assign into get item expression
-| note in file FileId(1) for 21..26: this expression cannot be used as a variable reference
+error in file FileId(1) at 21..26: cannot assign into expression
+| error in file FileId(1) for 21..26: not a reference to a variable

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_get_stmt_wrong_type_stream.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_get_stmt_wrong_type_stream.snap
@@ -7,4 +7,4 @@ expression: "var s : real\nget : s, skip\n"
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 19..20: mismatched types
-| note in file FileId(1) for 19..20: expected integer type
+| error in file FileId(1) for 19..20: expected integer type

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_get_stmt_wrong_type_width.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_get_stmt_wrong_type_width.snap
@@ -8,4 +8,4 @@ expression: "var w : real\nvar i : int\nget i : w\n"
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 33..34: mismatched types
-| note in file FileId(1) for 33..34: expected integer type
+| error in file FileId(1) for 33..34: expected integer type

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_put_stmt_invalid_extended_opts.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_put_stmt_invalid_extended_opts.snap
@@ -10,26 +10,34 @@ expression: "% TODO: Uncomment enum lines once enum types are lowered & checked\
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 177..178: invalid put option
+| error in file FileId(1) for 177..178: this is the invalid option
 | note in file FileId(1) for 169..170: cannot specify fraction width for this type
 | info: fraction width can only be specified for numeric put types
 error in file FileId(1) at 181..182: invalid put option
+| error in file FileId(1) for 181..182: this is the invalid option
 | note in file FileId(1) for 169..170: cannot specify exponent width for this type
 | info: exponent width can only be specified for numeric types
 error in file FileId(1) at 196..197: invalid put option
+| error in file FileId(1) for 196..197: this is the invalid option
 | note in file FileId(1) for 187..189: cannot specify fraction width for this type
 | info: fraction width can only be specified for numeric put types
 error in file FileId(1) at 200..201: invalid put option
+| error in file FileId(1) for 200..201: this is the invalid option
 | note in file FileId(1) for 187..189: cannot specify exponent width for this type
 | info: exponent width can only be specified for numeric types
 error in file FileId(1) at 214..215: invalid put option
+| error in file FileId(1) for 214..215: this is the invalid option
 | note in file FileId(1) for 206..207: cannot specify fraction width for this type
 | info: fraction width can only be specified for numeric put types
 error in file FileId(1) at 218..219: invalid put option
+| error in file FileId(1) for 218..219: this is the invalid option
 | note in file FileId(1) for 206..207: cannot specify exponent width for this type
 | info: exponent width can only be specified for numeric types
 error in file FileId(1) at 233..234: invalid put option
+| error in file FileId(1) for 233..234: this is the invalid option
 | note in file FileId(1) for 224..226: cannot specify fraction width for this type
 | info: fraction width can only be specified for numeric put types
 error in file FileId(1) at 237..238: invalid put option
+| error in file FileId(1) for 237..238: this is the invalid option
 | note in file FileId(1) for 224..226: cannot specify exponent width for this type
 | info: exponent width can only be specified for numeric types

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_put_stmt_wrong_type_exp_width.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_put_stmt_wrong_type_exp_width.snap
@@ -7,4 +7,4 @@ expression: "var e : real\nput 1 : 0 : 0 : e\n"
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 29..30: mismatched types
-| note in file FileId(1) for 29..30: expected integer type
+| error in file FileId(1) for 29..30: expected integer type

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_put_stmt_wrong_type_fract.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_put_stmt_wrong_type_fract.snap
@@ -7,4 +7,4 @@ expression: "var f : real\nput 1 : 0 : f\n"
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 25..26: mismatched types
-| note in file FileId(1) for 25..26: expected integer type
+| error in file FileId(1) for 25..26: expected integer type

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_put_stmt_wrong_type_stream.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_put_stmt_wrong_type_stream.snap
@@ -7,4 +7,4 @@ expression: "var s : real\nput : s,  1\n"
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 19..20: mismatched types
-| note in file FileId(1) for 19..20: expected integer type
+| error in file FileId(1) for 19..20: expected integer type

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_put_stmt_wrong_type_width.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_put_stmt_wrong_type_width.snap
@@ -7,4 +7,4 @@ expression: "var w : real\nput 1 : w\n"
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 21..22: mismatched types
-| note in file FileId(1) for 21..22: expected integer type
+| error in file FileId(1) for 21..22: expected integer type

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_var_incompatible.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_var_incompatible.snap
@@ -7,4 +7,5 @@ expression: "var k : char := 20"
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 16..18: mismatched types
-| note in file FileId(1) for 8..12: initializer's type is incompatible with this type
+| error in file FileId(1) for 16..18: the type of this expression...
+| note in file FileId(1) for 8..12: is incompatible with this type

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__undeclared_symbol-2.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__undeclared_symbol-2.snap
@@ -8,3 +8,4 @@ expression: "var a := a"
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 9..10: `a` is not declared
+| error in file FileId(1) for 9..10: not found in this scope

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__undeclared_symbol.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__undeclared_symbol.snap
@@ -8,3 +8,4 @@ expression: "var a := b"
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 9..10: `b` is not declared
+| error in file FileId(1) for 9..10: not found in this scope

--- a/compiler/toc_analysis/src/typeck/test.rs
+++ b/compiler/toc_analysis/src/typeck/test.rs
@@ -2,7 +2,7 @@
 
 use toc_hir::symbol::DefId;
 use toc_hir_db::db::HirDatabase;
-use toc_reporting::ReportMessage;
+use toc_reporting::MessageBundle;
 use unindent::unindent;
 
 use crate::db::HirAnalysis;
@@ -51,7 +51,7 @@ fn do_typecheck(source: &str) -> String {
 fn stringify_typeck_results(
     db: &TestDb,
     lib: toc_hir::library::LibraryId,
-    messages: &[ReportMessage],
+    messages: &MessageBundle,
 ) -> String {
     let mut s = String::new();
     // Pretty print typectx

--- a/compiler/toc_ast_db/src/db.rs
+++ b/compiler/toc_ast_db/src/db.rs
@@ -46,4 +46,7 @@ pub trait SpanMapping: toc_vfs::db::FileSystem {
         file: toc_span::FileId,
         index: usize,
     ) -> Option<LspPosition>;
+
+    #[salsa::invoke(span::query::map_byte_index_to_character)]
+    fn map_byte_index_to_character(&self, file: toc_span::FileId, index: usize) -> Option<usize>;
 }

--- a/compiler/toc_ast_db/src/db.rs
+++ b/compiler/toc_ast_db/src/db.rs
@@ -1,6 +1,5 @@
 //! AST Query system definitions
 
-use std::ops::Range;
 use std::sync::Arc;
 
 use toc_reporting::CompileResult;
@@ -8,7 +7,7 @@ use toc_salsa::salsa;
 use toc_span::FileId;
 use toc_vfs::db::FileSystem;
 
-use crate::span::{LineInfo, LspPosition};
+use crate::span::{LineInfo, LineMapping, LspPosition};
 use crate::{source, span, SourceRoots};
 
 #[salsa::query_group(SourceParserStorage)]
@@ -32,19 +31,19 @@ pub trait SourceParser: FileSystem {
 
 #[salsa::query_group(SpanMappingStorage)]
 pub trait SpanMapping: toc_vfs::db::FileSystem {
-    #[salsa::invoke(span::query::line_ranges)]
-    fn line_ranges(&self, file_id: toc_span::FileId) -> Arc<Vec<Range<usize>>>;
+    #[salsa::invoke(span::query::line_mapping)]
+    fn line_mapping(&self, file_id: toc_span::FileId) -> Arc<LineMapping>;
 
     #[salsa::invoke(span::query::file_path)]
     fn file_path(&self, file_id: toc_span::FileId) -> Arc<String>;
 
     #[salsa::invoke(span::query::map_byte_index)]
-    fn map_byte_index(&self, file: toc_span::FileId, byte_idx: usize) -> Option<LineInfo>;
+    fn map_byte_index(&self, file: toc_span::FileId, index: usize) -> Option<LineInfo>;
 
     #[salsa::invoke(span::query::map_byte_index_to_position)]
     fn map_byte_index_to_position(
         &self,
         file: toc_span::FileId,
-        byte_idx: usize,
+        index: usize,
     ) -> Option<LspPosition>;
 }

--- a/compiler/toc_ast_db/src/span.rs
+++ b/compiler/toc_ast_db/src/span.rs
@@ -1,6 +1,7 @@
 //! Span mapping related structures
 
 use std::ops::Range;
+use std::sync::Arc;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct LspPosition {
@@ -20,33 +21,85 @@ pub struct LineInfo {
     pub line_span: Range<usize>,
 }
 
-pub(crate) mod query {
-    //! Span query impls
-    use std::ops::Range;
-    use std::sync::Arc;
+impl LineInfo {
+    pub fn new(line: usize, line_span: Range<usize>) -> Self {
+        Self { line, line_span }
+    }
+}
 
-    use crate::db;
-    use crate::span::{LineInfo, LspPosition};
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LineMapping {
+    source: Arc<String>,
+    line_starts: Vec<usize>,
+}
 
-    pub(crate) fn line_ranges(
-        db: &dyn db::SpanMapping,
-        file_id: toc_span::FileId,
-    ) -> Arc<Vec<Range<usize>>> {
-        let source = &db.file_source(file_id).0;
-        let mut line_ranges = vec![];
-        let mut line_start = 0;
+impl LineMapping {
+    fn from_source(source: Arc<String>) -> Self {
+        let mut line_starts = vec![];
+        let mut start = 0;
         let line_ends = source.char_indices().filter(|(_, c)| matches!(c, '\n'));
 
         for (at_newline, _) in line_ends {
-            let line_end = at_newline + 1;
-            line_ranges.push(line_start..line_end);
-            line_start = line_end;
+            line_starts.push(start);
+            start = at_newline + 1;
         }
 
-        // Use a line span covering the rest of the file
-        line_ranges.push(line_start..source.len());
+        // Use a line start covering the rest of the file
+        line_starts.push(start);
+        Self {
+            source,
+            line_starts,
+        }
+    }
 
-        Arc::new(line_ranges)
+    fn map_index(&self, index: usize) -> Option<LineInfo> {
+        if !self.source.is_char_boundary(index) {
+            // Outside of the file or not a char boundary
+            return None;
+        }
+
+        let (line, end) = self
+            .line_starts
+            .iter()
+            .enumerate()
+            .find(|(_line, start)| index < **start)
+            .map(|(line, start)| (line - 1, *start))
+            .unwrap_or((self.line_starts.len() - 1, self.source.len()));
+
+        // `line_starts` is always greater than 1, it's ok to unwrap
+        // also bounded by `line_starts.len()`
+        let start = *self.line_starts.get(line).expect("no line infos");
+
+        Some(LineInfo {
+            line,
+            line_span: start..end,
+        })
+    }
+
+    fn map_index_to_position(&self, index: usize) -> Option<LspPosition> {
+        let info = self.map_index(index)?;
+        let source_slice = &self.source[info.line_span.start..index];
+
+        // Get character count in UTF-16 chars
+        let column_offset = source_slice.encode_utf16().count();
+
+        Some(LspPosition::new(info.line as u32, column_offset as u32))
+    }
+}
+
+pub(crate) mod query {
+    //! Span query impls
+    use std::sync::Arc;
+
+    use crate::db;
+    use crate::span::{LineInfo, LineMapping, LspPosition};
+
+    pub(crate) fn line_mapping(
+        db: &dyn db::SpanMapping,
+        file_id: toc_span::FileId,
+    ) -> Arc<LineMapping> {
+        let source = db.file_source(file_id).0;
+        Arc::new(LineMapping::from_source(source))
     }
 
     pub(crate) fn file_path(db: &dyn db::SpanMapping, file_id: toc_span::FileId) -> Arc<String> {
@@ -56,30 +109,140 @@ pub(crate) mod query {
     pub(crate) fn map_byte_index(
         db: &dyn db::SpanMapping,
         file_id: toc_span::FileId,
-        byte_idx: usize,
+        index: usize,
     ) -> Option<LineInfo> {
-        db.line_ranges(file_id)
-            .iter()
-            .enumerate()
-            .find(|(_line, range)| (range.start..=range.end).contains(&byte_idx))
-            .map(|(line, range)| LineInfo {
-                line,
-                line_span: range.clone(),
-            })
+        db.line_mapping(file_id).map_index(index)
     }
 
     pub(crate) fn map_byte_index_to_position(
         db: &dyn db::SpanMapping,
         file_id: toc_span::FileId,
-        byte_idx: usize,
+        index: usize,
     ) -> Option<LspPosition> {
-        let info = db.map_byte_index(file_id, byte_idx).unwrap();
+        db.line_mapping(file_id).map_index_to_position(index)
+    }
+}
 
-        let source_slice = &db.file_source(file_id).0[info.line_span.start..byte_idx];
+#[cfg(test)]
+mod test {
+    use std::sync::Arc;
 
-        // Get character count in UTF-16 chars
-        let column_offset = source_slice.encode_utf16().count();
+    use crate::span::{LineInfo, LineMapping, LspPosition};
 
-        Some(LspPosition::new(info.line as u32, column_offset as u32))
+    #[test]
+    fn empty_file() {
+        let map = LineMapping::from_source(Arc::new("".into()));
+
+        assert_eq!(map.map_index(0), Some(LineInfo::new(0, 0..0)));
+        assert_eq!(map.map_index(1), None);
+        assert_eq!(map.map_index(2), None);
+
+        assert_eq!(map.map_index_to_position(0), Some(LspPosition::new(0, 0)));
+        assert_eq!(map.map_index_to_position(1), None);
+        assert_eq!(map.map_index_to_position(2), None);
+    }
+
+    #[test]
+    fn single_line() {
+        let source = Arc::new("abcdefg".to_string());
+        let map = LineMapping::from_source(source.clone());
+
+        assert_eq!(map.map_index(0), Some(LineInfo::new(0, 0..source.len())));
+        assert_eq!(map.map_index(1), Some(LineInfo::new(0, 0..source.len())));
+        assert_eq!(map.map_index(2), Some(LineInfo::new(0, 0..source.len())));
+        assert_eq!(
+            map.map_index(source.len()),
+            Some(LineInfo::new(0, 0..source.len()))
+        );
+        assert_eq!(map.map_index(source.len() + 1), None);
+
+        assert_eq!(map.map_index_to_position(0), Some(LspPosition::new(0, 0)));
+        assert_eq!(map.map_index_to_position(1), Some(LspPosition::new(0, 1)));
+        assert_eq!(map.map_index_to_position(2), Some(LspPosition::new(0, 2)));
+        assert_eq!(
+            map.map_index_to_position(source.len()),
+            Some(LspPosition::new(0, source.len() as u32))
+        );
+    }
+
+    #[test]
+    fn only_newline() {
+        let source = Arc::new("\n".to_string());
+        let map = LineMapping::from_source(source);
+
+        assert_eq!(map.map_index(0), Some(LineInfo::new(0, 0..1)));
+        assert_eq!(map.map_index(1), Some(LineInfo::new(1, 1..1)));
+        assert_eq!(map.map_index(2), None);
+
+        assert_eq!(map.map_index_to_position(0), Some(LspPosition::new(0, 0)));
+        assert_eq!(map.map_index_to_position(1), Some(LspPosition::new(1, 0)));
+    }
+
+    #[test]
+    fn newline_and_text() {
+        let source = Arc::new("abcd\nab".to_string());
+        let map = LineMapping::from_source(source);
+
+        assert_eq!(map.map_index(0), Some(LineInfo::new(0, 0..5)));
+        assert_eq!(map.map_index(1), Some(LineInfo::new(0, 0..5)));
+        assert_eq!(map.map_index(2), Some(LineInfo::new(0, 0..5)));
+        assert_eq!(map.map_index(3), Some(LineInfo::new(0, 0..5)));
+        assert_eq!(map.map_index(4), Some(LineInfo::new(0, 0..5)));
+        assert_eq!(map.map_index(5), Some(LineInfo::new(1, 5..7)));
+        assert_eq!(map.map_index(6), Some(LineInfo::new(1, 5..7)));
+        assert_eq!(map.map_index(7), Some(LineInfo::new(1, 5..7)));
+        assert_eq!(map.map_index(8), None);
+
+        assert_eq!(map.map_index_to_position(0), Some(LspPosition::new(0, 0)));
+        assert_eq!(map.map_index_to_position(1), Some(LspPosition::new(0, 1)));
+        assert_eq!(map.map_index_to_position(5), Some(LspPosition::new(1, 0)));
+        assert_eq!(map.map_index_to_position(6), Some(LspPosition::new(1, 1)));
+    }
+
+    #[test]
+    fn with_unicode() {
+        // |a|£|_|£|_|💖|_|_|_|a|\n|a|
+        let source = Arc::new("a££💖a\na".to_string());
+        let map = LineMapping::from_source(source.clone());
+
+        // start of first 'a'
+        assert_eq!(map.map_index(0), Some(LineInfo::new(0, 0..11)));
+        // start of first pound
+        assert_eq!(map.map_index(1), Some(LineInfo::new(0, 0..11)));
+        assert_eq!(map.map_index(2), None);
+        // start of second pound
+        assert_eq!(map.map_index(3), Some(LineInfo::new(0, 0..11)));
+        assert_eq!(map.map_index(4), None);
+        // start of heart
+        assert_eq!(map.map_index(5), Some(LineInfo::new(0, 0..11)));
+        for i in 6..9 {
+            assert_eq!(map.map_index(i), None);
+        }
+        // start of second 'a'
+        assert_eq!(map.map_index(9), Some(LineInfo::new(0, 0..11)));
+        // newline
+        assert_eq!(map.map_index(10), Some(LineInfo::new(0, 0..11)));
+        // start of third 'a'
+        assert_eq!(map.map_index(11), Some(LineInfo::new(1, 11..12)));
+        // eof
+        assert_eq!(map.map_index(12), Some(LineInfo::new(1, 11..12)));
+        assert_eq!(map.map_index(13), None);
+
+        // a
+        assert_eq!(map.map_index_to_position(0), Some(LspPosition::new(0, 0)));
+        // £
+        assert_eq!(map.map_index_to_position(1), Some(LspPosition::new(0, 1)));
+        // £
+        assert_eq!(map.map_index_to_position(3), Some(LspPosition::new(0, 2)));
+        // 💖
+        assert_eq!(map.map_index_to_position(5), Some(LspPosition::new(0, 3)));
+        // a
+        assert_eq!(map.map_index_to_position(9), Some(LspPosition::new(0, 5)));
+        // \n
+        assert_eq!(map.map_index_to_position(10), Some(LspPosition::new(0, 6)));
+        // a
+        assert_eq!(map.map_index_to_position(11), Some(LspPosition::new(1, 0)));
+        // eof
+        assert_eq!(map.map_index_to_position(12), Some(LspPosition::new(1, 1)));
     }
 }

--- a/compiler/toc_ast_db/src/span.rs
+++ b/compiler/toc_ast_db/src/span.rs
@@ -85,6 +85,19 @@ impl LineMapping {
 
         Some(LspPosition::new(info.line as u32, column_offset as u32))
     }
+
+    fn map_index_to_character(&self, index: usize) -> Option<usize> {
+        if !self.source.is_char_boundary(index) {
+            return None;
+        }
+
+        let source_slice = &self.source[0..index];
+
+        // Get character count in UTF-32 chars
+        let char_index = source_slice.chars().count();
+
+        Some(char_index)
+    }
 }
 
 pub(crate) mod query {
@@ -120,6 +133,14 @@ pub(crate) mod query {
         index: usize,
     ) -> Option<LspPosition> {
         db.line_mapping(file_id).map_index_to_position(index)
+    }
+
+    pub(crate) fn map_byte_index_to_character(
+        db: &dyn db::SpanMapping,
+        file_id: toc_span::FileId,
+        index: usize,
+    ) -> Option<usize> {
+        db.line_mapping(file_id).map_index_to_character(index)
     }
 }
 

--- a/compiler/toc_driver/Cargo.toml
+++ b/compiler/toc_driver/Cargo.toml
@@ -16,5 +16,6 @@ toc_vfs = { path = "../toc_vfs" }
 toc_analysis = { path = "../toc_analysis" }
 toc_span = { path = "../toc_span" }
 toc_ast_db = { path = "../toc_ast_db" }
-annotate-snippets = { version = "0.9.0", features = ["color"] }
 toc_salsa = { path = "../toc_salsa" }
+
+ariadne = { version = "0.1" }

--- a/compiler/toc_driver/src/main.rs
+++ b/compiler/toc_driver/src/main.rs
@@ -62,15 +62,12 @@ fn main() {
     let analyze_res = db.analyze_libraries();
 
     // We only need to get the messages for the queries at the end of the chain
-    let mut msgs = analyze_res.messages().iter().collect::<Vec<_>>();
-
-    // Sort by start order
-    msgs.sort_by_key(|msg| msg.span().range.start());
+    let msgs = analyze_res.messages();
 
     let mut has_errors = false;
     let mut cache = VfsCache::new(&db);
 
-    for msg in msgs {
+    for msg in msgs.iter() {
         has_errors |= matches!(msg.kind(), toc_reporting::AnnotateKind::Error);
         emit_message(&db, &mut cache, msg);
     }

--- a/compiler/toc_driver/src/main.rs
+++ b/compiler/toc_driver/src/main.rs
@@ -87,7 +87,7 @@ fn message_into_string(db: &MainDatabase, msg: &toc_reporting::ReportMessage) ->
     // Build a set of common snippets for consecutive annotations
     struct FileSpan {
         path: Arc<String>,
-        source: Arc<(String, Option<toc_vfs::LoadError>)>,
+        source: Arc<String>,
         source_range: Range<usize>,
         line_range: Range<usize>,
     }
@@ -118,7 +118,7 @@ fn message_into_string(db: &MainDatabase, msg: &toc_reporting::ReportMessage) ->
             let start_info = db.map_byte_index(file_id, start as usize).unwrap();
             let end_info = db.map_byte_index(file_id, end as usize).unwrap();
 
-            let source = db.file_source(file_id);
+            let source = db.file_source(file_id).0;
             let source_range = start_info.line_span.start..end_info.line_span.end;
             let path = db.file_path(file_id);
 
@@ -154,7 +154,7 @@ fn message_into_string(db: &MainDatabase, msg: &toc_reporting::ReportMessage) ->
         } = file_span;
         let (start, end) = (u32::from(span.range.start()), u32::from(span.range.end()));
 
-        let snippet_slice = &source.0[source_range.clone()];
+        let snippet_slice = &source[source_range.clone()];
         let range_base = source_range.start;
         let real_slice = (start as usize - range_base)..(end as usize - range_base);
 
@@ -179,7 +179,7 @@ fn message_into_string(db: &MainDatabase, msg: &toc_reporting::ReportMessage) ->
             ..
         } = file_span;
 
-        let slice_text = &(source.0)[source_range.clone()];
+        let slice_text = &source[source_range.clone()];
         let can_fold = (line_range.end - line_range.start) > 10;
 
         Slice {

--- a/compiler/toc_hir_db/src/query.rs
+++ b/compiler/toc_hir_db/src/query.rs
@@ -6,7 +6,7 @@ use toc_hir::{
     library_graph::{GraphBuilder, LibraryGraph},
     symbol::DefId,
 };
-use toc_reporting::CompileResult;
+use toc_reporting::{CompileResult, MessageBundle};
 
 use crate::db::HirDatabase;
 
@@ -17,15 +17,13 @@ pub fn library_query(db: &dyn HirDatabase, library: LibraryId) -> LoweredLibrary
 }
 
 pub fn library_graph_query(db: &dyn HirDatabase) -> CompileResult<LibraryGraph> {
-    let mut messages = vec![];
+    let mut messages = MessageBundle::default();
     let source_roots = db.source_roots();
     let mut graph = GraphBuilder::new();
 
     for root in source_roots.roots() {
         graph.add_library(root);
-
-        let res = db.lower_library(root);
-        res.bundle_messages(&mut messages);
+        db.lower_library(root).bundle_messages(&mut messages);
     }
 
     CompileResult::new(graph.finish(), messages)

--- a/compiler/toc_hir_lowering/src/lower/stmt.rs
+++ b/compiler/toc_hir_lowering/src/lower/stmt.rs
@@ -66,7 +66,11 @@ impl super::BodyLowering<'_, '_> {
 
     fn unsupported_stmt(&mut self, span: SpanId) -> Option<stmt::StmtKind> {
         let span = self.ctx.library.lookup_span(span);
-        self.ctx.messages.error("unsupported statement", span);
+        self.ctx.messages.error(
+            "unsupported statement",
+            "this statement is not handled yet",
+            span,
+        );
         None
     }
 

--- a/compiler/toc_hir_lowering/src/lower/stmt.rs
+++ b/compiler/toc_hir_lowering/src/lower/stmt.rs
@@ -139,7 +139,7 @@ impl super::BodyLowering<'_, '_> {
     fn lower_assign_stmt(&mut self, stmt: ast::AssignStmt) -> Option<stmt::StmtKind> {
         let (op, asn_span) = {
             let asn_op = stmt.asn_op()?;
-            let span = self.ctx.intern_range(asn_op.asn_node()?.text_range());
+            let span = self.ctx.intern_range(asn_op.syntax().text_range());
 
             (asn_op.asn_kind().and_then(asn_to_bin_op), span)
         };

--- a/compiler/toc_hir_lowering/src/lower/ty.rs
+++ b/compiler/toc_hir_lowering/src/lower/ty.rs
@@ -29,7 +29,9 @@ impl super::BodyLowering<'_, '_> {
     }
 
     fn unsupported_ty(&mut self, span: Span) -> Option<ty::TypeKind> {
-        self.ctx.messages.error("unsupported type", span);
+        self.ctx
+            .messages
+            .error("unsupported type", "this type is not handled yet", span);
         None
     }
 

--- a/compiler/toc_hir_lowering/tests/lowering.rs
+++ b/compiler/toc_hir_lowering/tests/lowering.rs
@@ -407,6 +407,8 @@ fn lower_binary_expr() {
     assert_lower("a := a + a");
     // missing operand, should still be present
     assert_lower("a := () + ");
+    // invalid infix, okay to be missing
+    assert_lower("a := 1 not 1 ");
 }
 
 #[test]

--- a/compiler/toc_hir_lowering/tests/lowering.rs
+++ b/compiler/toc_hir_lowering/tests/lowering.rs
@@ -286,6 +286,8 @@ fn lower_char_literal() {
     assert_lower(r#"a := 'abcd""#);
     // ... or that are completely empty
     assert_lower(r#"a := ''"#);
+    // ... or that are completely empty without an ending delimiter
+    assert_lower(r#"a := '"#);
 }
 
 #[test]

--- a/compiler/toc_hir_lowering/tests/lowering.rs
+++ b/compiler/toc_hir_lowering/tests/lowering.rs
@@ -44,7 +44,7 @@ fn assert_lower(src: &str) -> LowerResult {
     let lowered = db.lower_library(root_file);
 
     let mut s = toc_hir_pretty::pretty_print_tree(lowered.result());
-    for err in lowered.messages() {
+    for err in lowered.messages().iter() {
         s.push_str(&format!("{}\n", err));
     }
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_binary_expr-2.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_binary_expr-2.snap
@@ -11,6 +11,8 @@ Library@(dummy)
           Name@(FileId(1), 0..1): "a"@(FileId(1), 0..1), undeclared
           Binary@(FileId(1), 5..9): Add
             Paren@(FileId(1), 5..7)
-error in file FileId(1) at 6..7: expected expression, but found ‘)’
-error in file FileId(1) at 8..9: expected ‘)’, but found ‘+’
+error in file FileId(1) at 6..7: unexpected token
+| error in file FileId(1) for 6..7: expected expression, but found ‘)’
+error in file FileId(1) at 8..9: unexpected token
+| error in file FileId(1) for 8..9: expected ‘)’, but found ‘+’
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_binary_expr-2.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_binary_expr-2.snap
@@ -13,5 +13,4 @@ Library@(dummy)
             Paren@(FileId(1), 5..7)
 error in file FileId(1) at 6..7: expected expression, but found ‘)’
 error in file FileId(1) at 8..9: expected ‘)’, but found ‘+’
-error in file FileId(1) at 9..10: expected expression after here
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_binary_expr-3.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_binary_expr-3.snap
@@ -1,0 +1,13 @@
+---
+source: compiler/toc_hir_lowering/tests/lowering.rs
+expression: "a := 1 not 1 "
+
+---
+Library@(dummy)
+  Root@(dummy): FileId(1) -> ItemId(0)
+    Module@(FileId(1), 0..13): "<root>"@(dummy)
+      StmtBody@(FileId(1), 0..12): []
+        Assign@(FileId(1), 0..12)
+          Name@(FileId(1), 0..1): "a"@(FileId(1), 0..1), undeclared
+error in file FileId(1) at 11..12: expected ‘in’ or ‘=’, but found int literal
+

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_binary_expr-3.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_binary_expr-3.snap
@@ -9,5 +9,6 @@ Library@(dummy)
       StmtBody@(FileId(1), 0..12): []
         Assign@(FileId(1), 0..12)
           Name@(FileId(1), 0..1): "a"@(FileId(1), 0..1), undeclared
-error in file FileId(1) at 11..12: expected ‘in’ or ‘=’, but found int literal
+error in file FileId(1) at 11..12: unexpected token
+| error in file FileId(1) for 11..12: expected ‘in’ or ‘=’, but found int literal
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_char_literal-2.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_char_literal-2.snap
@@ -10,5 +10,6 @@ Library@(dummy)
         Assign@(FileId(1), 0..11)
           Name@(FileId(1), 0..1): "a"@(FileId(1), 0..1), undeclared
           Literal@(FileId(1), 5..11): CharSeq("abcd ")
-error in file FileId(1) at 5..11: invalid char literal: missing terminator character
+error in file FileId(1) at 5..11: invalid char literal
+| error in file FileId(1) for 5..11: missing terminator character
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_char_literal-3.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_char_literal-3.snap
@@ -10,5 +10,6 @@ Library@(dummy)
         Assign@(FileId(1), 0..11)
           Name@(FileId(1), 0..1): "a"@(FileId(1), 0..1), undeclared
           Literal@(FileId(1), 5..11): CharSeq("abcd\"")
-error in file FileId(1) at 5..11: invalid char literal: missing terminator character
+error in file FileId(1) at 5..11: invalid char literal
+| error in file FileId(1) for 5..11: missing terminator character
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_char_literal-4.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_char_literal-4.snap
@@ -9,5 +9,6 @@ Library@(dummy)
       StmtBody@(FileId(1), 0..7): []
         Assign@(FileId(1), 0..7)
           Name@(FileId(1), 0..1): "a"@(FileId(1), 0..1), undeclared
-error in file FileId(1) at 5..6: invalid char literal: no characters in literal
+error in file FileId(1) at 5..7: invalid char literal
+| error in file FileId(1) for 5..6: no characters in literal
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_char_literal-5.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_char_literal-5.snap
@@ -1,6 +1,6 @@
 ---
 source: compiler/toc_hir_lowering/tests/lowering.rs
-expression: "a := \""
+expression: "a := '"
 
 ---
 Library@(dummy)
@@ -9,7 +9,6 @@ Library@(dummy)
       StmtBody@(FileId(1), 0..6): []
         Assign@(FileId(1), 0..6)
           Name@(FileId(1), 0..1): "a"@(FileId(1), 0..1), undeclared
-          Literal@(FileId(1), 5..6): String("")
-error in file FileId(1) at 5..6: invalid string literal
+error in file FileId(1) at 5..6: invalid char literal
 | error in file FileId(1) for 5..6: missing terminator character
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_char_seq_escapes-46.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_char_seq_escapes-46.snap
@@ -10,6 +10,7 @@ Library@(dummy)
         Assign@(FileId(1), 0..7)
           Name@(FileId(1), 0..1): "a"@(FileId(1), 0..1), undeclared
           Literal@(FileId(1), 5..7): String("")
-error in file FileId(1) at 5..7: invalid string literal: missing terminator character
-error in file FileId(1) at 6..7: invalid string literal: unknown backslash escape
+error in file FileId(1) at 5..7: invalid string literal
+| error in file FileId(1) for 6..7: unknown backslash escape
+| error in file FileId(1) for 5..7: missing terminator character
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_char_seq_escapes-46.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_char_seq_escapes-46.snap
@@ -10,6 +10,6 @@ Library@(dummy)
         Assign@(FileId(1), 0..7)
           Name@(FileId(1), 0..1): "a"@(FileId(1), 0..1), undeclared
           Literal@(FileId(1), 5..7): String("")
-error in file FileId(1) at 6..7: invalid string literal: unknown backslash escape
 error in file FileId(1) at 5..7: invalid string literal: missing terminator character
+error in file FileId(1) at 6..7: invalid string literal: unknown backslash escape
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_char_seq_escapes-47.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_char_seq_escapes-47.snap
@@ -10,6 +10,6 @@ Library@(dummy)
         Assign@(FileId(1), 0..7)
           Name@(FileId(1), 0..1): "a"@(FileId(1), 0..1), undeclared
           Literal@(FileId(1), 5..7): String("")
-error in file FileId(1) at 6..7: invalid string literal: unknown caret escape
 error in file FileId(1) at 5..7: invalid string literal: missing terminator character
+error in file FileId(1) at 6..7: invalid string literal: unknown caret escape
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_char_seq_escapes-47.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_char_seq_escapes-47.snap
@@ -10,6 +10,7 @@ Library@(dummy)
         Assign@(FileId(1), 0..7)
           Name@(FileId(1), 0..1): "a"@(FileId(1), 0..1), undeclared
           Literal@(FileId(1), 5..7): String("")
-error in file FileId(1) at 5..7: invalid string literal: missing terminator character
-error in file FileId(1) at 6..7: invalid string literal: unknown caret escape
+error in file FileId(1) at 5..7: invalid string literal
+| error in file FileId(1) for 6..7: unknown caret escape
+| error in file FileId(1) for 5..7: missing terminator character
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_char_seq_escapes-48.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_char_seq_escapes-48.snap
@@ -10,6 +10,6 @@ Library@(dummy)
         Assign@(FileId(1), 0..8)
           Name@(FileId(1), 0..1): "a"@(FileId(1), 0..1), undeclared
           Literal@(FileId(1), 5..8): String("\"")
-error in file FileId(1) at 6..8: invalid string literal: unknown caret escape
 error in file FileId(1) at 5..8: invalid string literal: missing terminator character
+error in file FileId(1) at 6..8: invalid string literal: unknown caret escape
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_char_seq_escapes-48.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_char_seq_escapes-48.snap
@@ -10,6 +10,7 @@ Library@(dummy)
         Assign@(FileId(1), 0..8)
           Name@(FileId(1), 0..1): "a"@(FileId(1), 0..1), undeclared
           Literal@(FileId(1), 5..8): String("\"")
-error in file FileId(1) at 5..8: invalid string literal: missing terminator character
-error in file FileId(1) at 6..8: invalid string literal: unknown caret escape
+error in file FileId(1) at 5..8: invalid string literal
+| error in file FileId(1) for 6..8: unknown caret escape
+| error in file FileId(1) for 5..8: missing terminator character
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_char_seq_escapes-49.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_char_seq_escapes-49.snap
@@ -10,5 +10,6 @@ Library@(dummy)
         Assign@(FileId(1), 0..11)
           Name@(FileId(1), 0..1): "a"@(FileId(1), 0..1), undeclared
           Literal@(FileId(1), 5..11): String("�")
-error in file FileId(1) at 6..10: invalid string literal: octal character value is greater than \377 (decimal 255)
+error in file FileId(1) at 5..11: invalid string literal
+| error in file FileId(1) for 6..10: octal character value is greater than \377 (decimal 255)
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_char_seq_escapes-50.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_char_seq_escapes-50.snap
@@ -10,5 +10,6 @@ Library@(dummy)
         Assign@(FileId(1), 0..15)
           Name@(FileId(1), 0..1): "a"@(FileId(1), 0..1), undeclared
           Literal@(FileId(1), 5..15): String("�")
-error in file FileId(1) at 6..14: invalid string literal: unicode codepoint value is greater than U+10FFFF
+error in file FileId(1) at 5..15: invalid string literal
+| error in file FileId(1) for 6..14: unicode codepoint value is greater than U+10FFFF
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_char_seq_escapes-51.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_char_seq_escapes-51.snap
@@ -10,5 +10,6 @@ Library@(dummy)
         Assign@(FileId(1), 0..16)
           Name@(FileId(1), 0..1): "a"@(FileId(1), 0..1), undeclared
           Literal@(FileId(1), 5..16): String("�")
-error in file FileId(1) at 6..15: invalid string literal: unicode codepoint value is greater than U+10FFFF
+error in file FileId(1) at 5..16: invalid string literal
+| error in file FileId(1) for 6..15: unicode codepoint value is greater than U+10FFFF
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_char_seq_escapes-52.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_char_seq_escapes-52.snap
@@ -10,5 +10,6 @@ Library@(dummy)
         Assign@(FileId(1), 0..17)
           Name@(FileId(1), 0..1): "a"@(FileId(1), 0..1), undeclared
           Literal@(FileId(1), 5..17): String("�")
-error in file FileId(1) at 6..16: invalid string literal: unicode codepoint value is greater than U+10FFFF
+error in file FileId(1) at 5..17: invalid string literal
+| error in file FileId(1) for 6..16: unicode codepoint value is greater than U+10FFFF
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_char_seq_escapes-53.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_char_seq_escapes-53.snap
@@ -10,5 +10,6 @@ Library@(dummy)
         Assign@(FileId(1), 0..13)
           Name@(FileId(1), 0..1): "a"@(FileId(1), 0..1), undeclared
           Literal@(FileId(1), 5..13): String("�")
-error in file FileId(1) at 6..12: invalid string literal: surrogate chars are not allowed in char sequences
+error in file FileId(1) at 5..13: invalid string literal
+| error in file FileId(1) for 6..12: surrogate chars are not allowed in char sequences
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_char_seq_escapes-54.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_char_seq_escapes-54.snap
@@ -10,5 +10,6 @@ Library@(dummy)
         Assign@(FileId(1), 0..13)
           Name@(FileId(1), 0..1): "a"@(FileId(1), 0..1), undeclared
           Literal@(FileId(1), 5..13): String("�")
-error in file FileId(1) at 6..12: invalid string literal: surrogate chars are not allowed in char sequences
+error in file FileId(1) at 5..13: invalid string literal
+| error in file FileId(1) for 6..12: surrogate chars are not allowed in char sequences
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_char_seq_escapes-55.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_char_seq_escapes-55.snap
@@ -10,5 +10,6 @@ Library@(dummy)
         Assign@(FileId(1), 0..13)
           Name@(FileId(1), 0..1): "a"@(FileId(1), 0..1), undeclared
           Literal@(FileId(1), 5..13): String("�")
-error in file FileId(1) at 6..12: invalid string literal: surrogate chars are not allowed in char sequences
+error in file FileId(1) at 5..13: invalid string literal
+| error in file FileId(1) for 6..12: surrogate chars are not allowed in char sequences
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_char_seq_escapes-56.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_char_seq_escapes-56.snap
@@ -10,5 +10,6 @@ Library@(dummy)
         Assign@(FileId(1), 0..13)
           Name@(FileId(1), 0..1): "a"@(FileId(1), 0..1), undeclared
           Literal@(FileId(1), 5..13): String("�")
-error in file FileId(1) at 6..12: invalid string literal: surrogate chars are not allowed in char sequences
+error in file FileId(1) at 5..13: invalid string literal
+| error in file FileId(1) for 6..12: surrogate chars are not allowed in char sequences
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_char_seq_escapes-57.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_char_seq_escapes-57.snap
@@ -10,5 +10,6 @@ Library@(dummy)
         Assign@(FileId(1), 0..9)
           Name@(FileId(1), 0..1): "a"@(FileId(1), 0..1), undeclared
           Literal@(FileId(1), 5..9): String("8")
-error in file FileId(1) at 6..8: invalid string literal: unknown backslash escape
+error in file FileId(1) at 5..9: invalid string literal
+| error in file FileId(1) for 6..8: unknown backslash escape
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_char_seq_escapes-58.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_char_seq_escapes-58.snap
@@ -10,5 +10,6 @@ Library@(dummy)
         Assign@(FileId(1), 0..9)
           Name@(FileId(1), 0..1): "a"@(FileId(1), 0..1), undeclared
           Literal@(FileId(1), 5..9): String("~")
-error in file FileId(1) at 6..8: invalid string literal: unknown caret escape
+error in file FileId(1) at 5..9: invalid string literal
+| error in file FileId(1) for 6..8: unknown caret escape
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_char_seq_escapes-59.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_char_seq_escapes-59.snap
@@ -10,5 +10,6 @@ Library@(dummy)
         Assign@(FileId(1), 0..9)
           Name@(FileId(1), 0..1): "a"@(FileId(1), 0..1), undeclared
           Literal@(FileId(1), 5..9): String("x")
-error in file FileId(1) at 6..8: invalid string literal: missing hex digits after here
+error in file FileId(1) at 5..9: invalid string literal
+| error in file FileId(1) for 6..8: missing hex digits after here
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_char_seq_escapes-60.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_char_seq_escapes-60.snap
@@ -10,5 +10,6 @@ Library@(dummy)
         Assign@(FileId(1), 0..9)
           Name@(FileId(1), 0..1): "a"@(FileId(1), 0..1), undeclared
           Literal@(FileId(1), 5..9): String("u")
-error in file FileId(1) at 6..8: invalid string literal: missing hex digits after here
+error in file FileId(1) at 5..9: invalid string literal
+| error in file FileId(1) for 6..8: missing hex digits after here
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_char_seq_escapes-61.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_char_seq_escapes-61.snap
@@ -10,5 +10,6 @@ Library@(dummy)
         Assign@(FileId(1), 0..9)
           Name@(FileId(1), 0..1): "a"@(FileId(1), 0..1), undeclared
           Literal@(FileId(1), 5..9): String("U")
-error in file FileId(1) at 6..8: invalid string literal: missing hex digits after here
+error in file FileId(1) at 5..9: invalid string literal
+| error in file FileId(1) for 6..8: missing hex digits after here
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_get_stmt-3.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_get_stmt-3.snap
@@ -7,5 +7,6 @@ Library@(dummy)
   Root@(dummy): FileId(1) -> ItemId(0)
     Module@(FileId(1), 0..3): "<root>"@(dummy)
       StmtBody@(FileId(1), 0..3): []
-error in file FileId(1) at 0..3: expected expression after here
+error in file FileId(1) at 0..3: unexpected end of file
+| error in file FileId(1) for 0..3: expected expression after here
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_int_literal-2.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_int_literal-2.snap
@@ -10,5 +10,6 @@ Library@(dummy)
         Assign@(FileId(1), 0..25)
           Name@(FileId(1), 0..1): "a"@(FileId(1), 0..1), undeclared
           Literal@(FileId(1), 5..25): Integer(0)
-error in file FileId(1) at 5..25: int literal is too large
+error in file FileId(1) at 5..25: invalid int literal
+| error in file FileId(1) for 5..25: number is too large
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_int_radix_literal-2.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_int_radix_literal-2.snap
@@ -10,5 +10,6 @@ Library@(dummy)
         Assign@(FileId(1), 0..28)
           Name@(FileId(1), 0..1): "a"@(FileId(1), 0..1), undeclared
           Literal@(FileId(1), 5..28): Integer(0)
-error in file FileId(1) at 5..28: explicit int literal is too large
+error in file FileId(1) at 5..28: invalid int literal
+| error in file FileId(1) for 8..28: number is too large
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_int_radix_literal-3.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_int_radix_literal-3.snap
@@ -10,5 +10,6 @@ Library@(dummy)
         Assign@(FileId(1), 0..8)
           Name@(FileId(1), 0..1): "a"@(FileId(1), 0..1), undeclared
           Literal@(FileId(1), 5..8): Integer(0)
-error in file FileId(1) at 5..8: explicit int literal is missing radix digits
+error in file FileId(1) at 5..8: invalid int literal
+| error in file FileId(1) for 5..8: missing radix digits
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_int_radix_literal-4.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_int_radix_literal-4.snap
@@ -10,5 +10,6 @@ Library@(dummy)
         Assign@(FileId(1), 0..8)
           Name@(FileId(1), 0..1): "a"@(FileId(1), 0..1), undeclared
           Literal@(FileId(1), 5..8): Integer(0)
-error in file FileId(1) at 5..8: explicit int literal is missing radix digits
+error in file FileId(1) at 5..8: invalid int literal
+| error in file FileId(1) for 5..8: missing radix digits
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_int_radix_literal-5.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_int_radix_literal-5.snap
@@ -10,5 +10,6 @@ Library@(dummy)
         Assign@(FileId(1), 0..12)
           Name@(FileId(1), 0..1): "a"@(FileId(1), 0..1), undeclared
           Literal@(FileId(1), 5..12): Integer(0)
-error in file FileId(1) at 5..12: base for explicit int literal is not between 2 - 36
+error in file FileId(1) at 5..12: invalid int literal
+| error in file FileId(1) for 5..7: base for explicit int literal is not between 2 - 36
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_int_radix_literal-5.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_int_radix_literal-5.snap
@@ -11,5 +11,5 @@ Library@(dummy)
           Name@(FileId(1), 0..1): "a"@(FileId(1), 0..1), undeclared
           Literal@(FileId(1), 5..12): Integer(0)
 error in file FileId(1) at 5..12: invalid int literal
-| error in file FileId(1) for 5..7: base for explicit int literal is not between 2 - 36
+| error in file FileId(1) for 5..7: base is not between 2 - 36
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_int_radix_literal-6.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_int_radix_literal-6.snap
@@ -11,5 +11,5 @@ Library@(dummy)
           Name@(FileId(1), 0..1): "a"@(FileId(1), 0..1), undeclared
           Literal@(FileId(1), 5..11): Integer(0)
 error in file FileId(1) at 5..11: invalid int literal
-| error in file FileId(1) for 5..6: base for explicit int literal is not between 2 - 36
+| error in file FileId(1) for 5..6: base is not between 2 - 36
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_int_radix_literal-6.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_int_radix_literal-6.snap
@@ -10,5 +10,6 @@ Library@(dummy)
         Assign@(FileId(1), 0..11)
           Name@(FileId(1), 0..1): "a"@(FileId(1), 0..1), undeclared
           Literal@(FileId(1), 5..11): Integer(0)
-error in file FileId(1) at 5..11: base for explicit int literal is not between 2 - 36
+error in file FileId(1) at 5..11: invalid int literal
+| error in file FileId(1) for 5..6: base for explicit int literal is not between 2 - 36
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_int_radix_literal-7.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_int_radix_literal-7.snap
@@ -11,5 +11,5 @@ Library@(dummy)
           Name@(FileId(1), 0..1): "a"@(FileId(1), 0..1), undeclared
           Literal@(FileId(1), 5..11): Integer(0)
 error in file FileId(1) at 5..11: invalid int literal
-| error in file FileId(1) for 5..6: base for explicit int literal is not between 2 - 36
+| error in file FileId(1) for 5..6: base is not between 2 - 36
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_int_radix_literal-7.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_int_radix_literal-7.snap
@@ -10,5 +10,6 @@ Library@(dummy)
         Assign@(FileId(1), 0..11)
           Name@(FileId(1), 0..1): "a"@(FileId(1), 0..1), undeclared
           Literal@(FileId(1), 5..11): Integer(0)
-error in file FileId(1) at 5..11: base for explicit int literal is not between 2 - 36
+error in file FileId(1) at 5..11: invalid int literal
+| error in file FileId(1) for 5..6: base for explicit int literal is not between 2 - 36
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_int_radix_literal-8.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_int_radix_literal-8.snap
@@ -10,5 +10,6 @@ Library@(dummy)
         Assign@(FileId(1), 0..30)
           Name@(FileId(1), 0..1): "a"@(FileId(1), 0..1), undeclared
           Literal@(FileId(1), 5..30): Integer(0)
-error in file FileId(1) at 5..30: base for explicit int literal is not between 2 - 36
+error in file FileId(1) at 5..30: invalid int literal
+| error in file FileId(1) for 5..25: base for explicit int literal is not between 2 - 36
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_int_radix_literal-8.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_int_radix_literal-8.snap
@@ -11,5 +11,5 @@ Library@(dummy)
           Name@(FileId(1), 0..1): "a"@(FileId(1), 0..1), undeclared
           Literal@(FileId(1), 5..30): Integer(0)
 error in file FileId(1) at 5..30: invalid int literal
-| error in file FileId(1) for 5..25: base for explicit int literal is not between 2 - 36
+| error in file FileId(1) for 5..25: base is not between 2 - 36
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_int_radix_literal-9.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_int_radix_literal-9.snap
@@ -10,5 +10,6 @@ Library@(dummy)
         Assign@(FileId(1), 0..15)
           Name@(FileId(1), 0..1): "a"@(FileId(1), 0..1), undeclared
           Literal@(FileId(1), 5..15): Integer(0)
-error in file FileId(1) at 11..12: invalid digit for the specified base
+error in file FileId(1) at 5..15: invalid int literal
+| error in file FileId(1) for 11..12: `a` is not a digit in base 10
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_multiple_invalid_char_seq_escapes.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_multiple_invalid_char_seq_escapes.snap
@@ -10,7 +10,8 @@ Library@(dummy)
         Assign@(FileId(1), 0..19)
           Name@(FileId(1), 0..1): "a"@(FileId(1), 0..1), undeclared
           Literal@(FileId(1), 5..19): CharSeq("��!")
-error in file FileId(1) at 6..10: invalid char literal: octal character value is greater than \377 (decimal 255)
-error in file FileId(1) at 10..16: invalid char literal: surrogate chars are not allowed in char sequences
-error in file FileId(1) at 16..18: invalid char literal: unknown backslash escape
+error in file FileId(1) at 5..19: invalid char literal
+| error in file FileId(1) for 6..10: octal character value is greater than \377 (decimal 255)
+| error in file FileId(1) for 10..16: surrogate chars are not allowed in char sequences
+| error in file FileId(1) for 16..18: unknown backslash escape
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_paren_expr-3.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_paren_expr-3.snap
@@ -10,5 +10,6 @@ Library@(dummy)
         Assign@(FileId(1), 0..7)
           Name@(FileId(1), 0..1): "a"@(FileId(1), 0..1), undeclared
           Paren@(FileId(1), 5..7)
-error in file FileId(1) at 6..7: expected expression, but found ‘)’
+error in file FileId(1) at 6..7: unexpected token
+| error in file FileId(1) for 6..7: expected expression, but found ‘)’
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_put_stmt-3.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_put_stmt-3.snap
@@ -7,5 +7,6 @@ Library@(dummy)
   Root@(dummy): FileId(1) -> ItemId(0)
     Module@(FileId(1), 0..3): "<root>"@(dummy)
       StmtBody@(FileId(1), 0..3): []
-error in file FileId(1) at 0..3: expected expression after here
+error in file FileId(1) at 0..3: unexpected end of file
+| error in file FileId(1) for 0..3: expected expression after here
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_put_stmt-4.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_put_stmt-4.snap
@@ -11,5 +11,6 @@ Library@(dummy)
           Literal@(FileId(1), 4..5): Integer(1)
           Literal@(FileId(1), 8..9): Integer(1)
           Literal@(FileId(1), 15..16): Integer(1)
-error in file FileId(1) at 13..14: expected expression, but found ‘:’
+error in file FileId(1) at 13..14: unexpected token
+| error in file FileId(1) for 13..14: expected expression, but found ‘:’
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_put_stmt-5.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_put_stmt-5.snap
@@ -11,5 +11,4 @@ Library@(dummy)
           Literal@(FileId(1), 4..5): Integer(1)
           Literal@(FileId(1), 8..9): Integer(1)
 error in file FileId(1) at 13..14: expected expression, but found ‘:’
-error in file FileId(1) at 14..15: expected expression after here
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_put_stmt-5.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_put_stmt-5.snap
@@ -10,5 +10,6 @@ Library@(dummy)
         Put@(FileId(1), 0..14): newline
           Literal@(FileId(1), 4..5): Integer(1)
           Literal@(FileId(1), 8..9): Integer(1)
-error in file FileId(1) at 13..14: expected expression, but found ‘:’
+error in file FileId(1) at 13..14: unexpected token
+| error in file FileId(1) for 13..14: expected expression, but found ‘:’
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_put_stmt-6.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_put_stmt-6.snap
@@ -9,6 +9,8 @@ Library@(dummy)
       StmtBody@(FileId(1), 0..13): []
         Put@(FileId(1), 0..13): newline
           Literal@(FileId(1), 4..5): Integer(1)
-error in file FileId(1) at 9..10: expected expression, but found ‘:’
-error in file FileId(1) at 12..13: expected expression, but found ‘:’
+error in file FileId(1) at 9..10: unexpected token
+| error in file FileId(1) for 9..10: expected expression, but found ‘:’
+error in file FileId(1) at 12..13: unexpected token
+| error in file FileId(1) for 12..13: expected expression, but found ‘:’
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_put_stmt-6.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_put_stmt-6.snap
@@ -11,5 +11,4 @@ Library@(dummy)
           Literal@(FileId(1), 4..5): Integer(1)
 error in file FileId(1) at 9..10: expected expression, but found ‘:’
 error in file FileId(1) at 12..13: expected expression, but found ‘:’
-error in file FileId(1) at 13..14: expected expression after here
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_real_literal-10.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_real_literal-10.snap
@@ -10,5 +10,6 @@ Library@(dummy)
         Assign@(FileId(1), 0..10)
           Name@(FileId(1), 0..1): "a"@(FileId(1), 0..1), undeclared
           Literal@(FileId(1), 5..10): Real(0.0)
-error in file FileId(1) at 5..10: real literal is too large
+error in file FileId(1) at 5..10: invalid real literal
+| error in file FileId(1) for 5..10: number is too large
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_real_literal-11.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_real_literal-11.snap
@@ -10,5 +10,6 @@ Library@(dummy)
         Assign@(FileId(1), 0..12)
           Name@(FileId(1), 0..1): "a"@(FileId(1), 0..1), undeclared
           Literal@(FileId(1), 5..12): Real(0.0)
-error in file FileId(1) at 5..12: real literal is too large
+error in file FileId(1) at 5..12: invalid real literal
+| error in file FileId(1) for 5..12: number is too large
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_real_literal-6.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_real_literal-6.snap
@@ -10,5 +10,6 @@ Library@(dummy)
         Assign@(FileId(1), 0..8)
           Name@(FileId(1), 0..1): "a"@(FileId(1), 0..1), undeclared
           Literal@(FileId(1), 5..8): Real(0.0)
-error in file FileId(1) at 5..8: real literal is missing exponent digits
+error in file FileId(1) at 5..8: invalid real literal
+| error in file FileId(1) for 5..8: missing exponent digits
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_real_literal-7.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_real_literal-7.snap
@@ -10,5 +10,6 @@ Library@(dummy)
         Assign@(FileId(1), 0..8)
           Name@(FileId(1), 0..1): "a"@(FileId(1), 0..1), undeclared
           Literal@(FileId(1), 5..8): Real(0.0)
-error in file FileId(1) at 5..8: real literal is missing exponent digits
+error in file FileId(1) at 5..8: invalid real literal
+| error in file FileId(1) for 5..8: missing exponent digits
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_real_literal-8.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_real_literal-8.snap
@@ -10,5 +10,6 @@ Library@(dummy)
         Assign@(FileId(1), 0..7)
           Name@(FileId(1), 0..1): "a"@(FileId(1), 0..1), undeclared
           Literal@(FileId(1), 5..7): Real(0.0)
-error in file FileId(1) at 5..7: real literal is missing exponent digits
+error in file FileId(1) at 5..7: invalid real literal
+| error in file FileId(1) for 5..7: missing exponent digits
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_real_literal-9.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_real_literal-9.snap
@@ -10,5 +10,6 @@ Library@(dummy)
         Assign@(FileId(1), 0..9)
           Name@(FileId(1), 0..1): "a"@(FileId(1), 0..1), undeclared
           Literal@(FileId(1), 5..9): Real(0.0)
-error in file FileId(1) at 5..9: real literal is missing exponent digits
+error in file FileId(1) at 5..9: invalid real literal
+| error in file FileId(1) for 5..9: missing exponent digits
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_self_expr.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_self_expr.snap
@@ -10,4 +10,5 @@ Library@(dummy)
         Assign@(FileId(1), 0..9)
           Name@(FileId(1), 0..1): "a"@(FileId(1), 0..1), undeclared
 error in file FileId(1) at 5..9: unsupported expression
+| error in file FileId(1) for 5..9: this expression is not supported yet
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_string_literal-2.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_string_literal-2.snap
@@ -10,5 +10,6 @@ Library@(dummy)
         Assign@(FileId(1), 0..11)
           Name@(FileId(1), 0..1): "a"@(FileId(1), 0..1), undeclared
           Literal@(FileId(1), 5..11): String("abcd ")
-error in file FileId(1) at 5..11: invalid string literal: missing terminator character
+error in file FileId(1) at 5..11: invalid string literal
+| error in file FileId(1) for 5..11: missing terminator character
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_string_literal-3.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_string_literal-3.snap
@@ -10,5 +10,6 @@ Library@(dummy)
         Assign@(FileId(1), 0..11)
           Name@(FileId(1), 0..1): "a"@(FileId(1), 0..1), undeclared
           Literal@(FileId(1), 5..11): String("abcd'")
-error in file FileId(1) at 5..11: invalid string literal: missing terminator character
+error in file FileId(1) at 5..11: invalid string literal
+| error in file FileId(1) for 5..11: missing terminator character
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_unary_expr-2.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_unary_expr-2.snap
@@ -10,5 +10,6 @@ Library@(dummy)
         Assign@(FileId(1), 0..6)
           Name@(FileId(1), 0..1): "a"@(FileId(1), 0..1), undeclared
           Unary@(FileId(1), 5..6): Identity
-error in file FileId(1) at 5..6: expected expression after here
+error in file FileId(1) at 5..6: unexpected end of file
+| error in file FileId(1) for 5..6: expected expression after here
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_var_def-3.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_var_def-3.snap
@@ -7,5 +7,6 @@ Library@(dummy)
   Root@(dummy): FileId(1) -> ItemId(0)
     Module@(FileId(1), 0..3): "<root>"@(dummy)
       StmtBody@(FileId(1), 0..3): []
-error in file FileId(1) at 0..3: expected identifier after here
+error in file FileId(1) at 0..3: unexpected end of file
+| error in file FileId(1) for 0..3: expected identifier after here
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_var_def-5.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_var_def-5.snap
@@ -7,5 +7,6 @@ Library@(dummy)
   Root@(dummy): FileId(1) -> ItemId(0)
     Module@(FileId(1), 0..5): "<root>"@(dummy)
       StmtBody@(FileId(1), 0..5): []
-error in file FileId(1) at 4..5: expected ‘,’, ‘:’ or ‘:=’ after here
+error in file FileId(1) at 4..5: unexpected end of file
+| error in file FileId(1) for 4..5: expected ‘,’, ‘:’ or ‘:=’ after here
 

--- a/compiler/toc_parser/src/grammar/expr/test.rs
+++ b/compiler/toc_parser/src/grammar/expr/test.rs
@@ -4982,7 +4982,9 @@ fn parse_not_eq_after_higher_precedence_op() {
 
 #[test]
 fn parse_invalid_tilde_before_indirect() {
-    check("_:=A~B@()", expect![[r#"
+    check(
+        "_:=A~B@()",
+        expect![[r#"
         Source@0..9
           StmtList@0..9
             AssignStmt@0..9
@@ -5004,12 +5006,15 @@ fn parse_invalid_tilde_before_indirect() {
                   At@6..7 "@"
                   LeftParen@7..8 "("
                   RightParen@8..9 ")"
-        error at 5..6: expected ‘in’ or ‘=’, but found identifier"#]]);
+        error at 5..6: expected ‘in’ or ‘=’, but found identifier"#]],
+    );
 }
 
 #[test]
 fn parse_invalid_not_before_indirect() {
-    check("_:=A not B@()", expect![[r#"
+    check(
+        "_:=A not B@()",
+        expect![[r#"
         Source@0..13
           StmtList@0..13
             AssignStmt@0..13
@@ -5033,5 +5038,6 @@ fn parse_invalid_not_before_indirect() {
                   At@10..11 "@"
                   LeftParen@11..12 "("
                   RightParen@12..13 ")"
-        error at 9..10: expected ‘in’ or ‘=’, but found identifier"#]]);
+        error at 9..10: expected ‘in’ or ‘=’, but found identifier"#]],
+    );
 }

--- a/compiler/toc_parser/src/grammar/expr/test.rs
+++ b/compiler/toc_parser/src/grammar/expr/test.rs
@@ -1397,13 +1397,15 @@ fn recover_tilde_as_infix() {
                       Identifier@0..1 "_"
                   AsnOp@1..3
                     Assign@1..3 ":="
-                  LiteralExpr@3..4
-                    IntLiteral@3..4 "1"
-                  Whitespace@4..5 " "
-                  Error@5..8
-                    Tilde@5..6 "~"
+                  BinaryExpr@3..8
+                    LiteralExpr@3..4
+                      IntLiteral@3..4 "1"
+                    Whitespace@4..5 " "
+                    Error@5..6
+                      Tilde@5..6 "~"
                     Whitespace@6..7 " "
-                    IntLiteral@7..8 "2"
+                    LiteralExpr@7..8
+                      IntLiteral@7..8 "2"
             error at 7..8: expected ‘in’ or ‘=’, but found int literal"#]],
     );
 }
@@ -1421,13 +1423,15 @@ fn recover_not_as_infix() {
                       Identifier@0..1 "_"
                   AsnOp@1..3
                     Assign@1..3 ":="
-                  LiteralExpr@3..4
-                    IntLiteral@3..4 "1"
-                  Whitespace@4..5 " "
-                  Error@5..10
-                    KwNot@5..8 "not"
+                  BinaryExpr@3..10
+                    LiteralExpr@3..4
+                      IntLiteral@3..4 "1"
+                    Whitespace@4..5 " "
+                    Error@5..8
+                      KwNot@5..8 "not"
                     Whitespace@8..9 " "
-                    IntLiteral@9..10 "2"
+                    LiteralExpr@9..10
+                      IntLiteral@9..10 "2"
             error at 9..10: expected ‘in’ or ‘=’, but found int literal"#]],
     );
 }
@@ -4974,4 +4978,60 @@ fn parse_not_eq_after_higher_precedence_op() {
                     LiteralExpr@16..17
                       IntLiteral@16..17 "0""#]],
     );
+}
+
+#[test]
+fn parse_invalid_tilde_before_indirect() {
+    check("_:=A~B@()", expect![[r#"
+        Source@0..9
+          StmtList@0..9
+            AssignStmt@0..9
+              NameExpr@0..1
+                Name@0..1
+                  Identifier@0..1 "_"
+              AsnOp@1..3
+                Assign@1..3 ":="
+              BinaryExpr@3..9
+                NameExpr@3..4
+                  Name@3..4
+                    Identifier@3..4 "A"
+                Error@4..5
+                  Tilde@4..5 "~"
+                IndirectExpr@5..9
+                  NameExpr@5..6
+                    Name@5..6
+                      Identifier@5..6 "B"
+                  At@6..7 "@"
+                  LeftParen@7..8 "("
+                  RightParen@8..9 ")"
+        error at 5..6: expected ‘in’ or ‘=’, but found identifier"#]]);
+}
+
+#[test]
+fn parse_invalid_not_before_indirect() {
+    check("_:=A not B@()", expect![[r#"
+        Source@0..13
+          StmtList@0..13
+            AssignStmt@0..13
+              NameExpr@0..1
+                Name@0..1
+                  Identifier@0..1 "_"
+              AsnOp@1..3
+                Assign@1..3 ":="
+              BinaryExpr@3..13
+                NameExpr@3..4
+                  Name@3..4
+                    Identifier@3..4 "A"
+                Whitespace@4..5 " "
+                Error@5..8
+                  KwNot@5..8 "not"
+                Whitespace@8..9 " "
+                IndirectExpr@9..13
+                  NameExpr@9..10
+                    Name@9..10
+                      Identifier@9..10 "B"
+                  At@10..11 "@"
+                  LeftParen@11..12 "("
+                  RightParen@12..13 ")"
+        error at 9..10: expected ‘in’ or ‘=’, but found identifier"#]]);
 }

--- a/compiler/toc_parser/src/grammar/expr/test.rs
+++ b/compiler/toc_parser/src/grammar/expr/test.rs
@@ -1406,7 +1406,8 @@ fn recover_tilde_as_infix() {
                     Whitespace@6..7 " "
                     LiteralExpr@7..8
                       IntLiteral@7..8 "2"
-            error at 7..8: expected ‘in’ or ‘=’, but found int literal"#]],
+            error at 7..8: unexpected token
+            | error for 7..8: expected ‘in’ or ‘=’, but found int literal"#]],
     );
 }
 
@@ -1432,7 +1433,8 @@ fn recover_not_as_infix() {
                     Whitespace@8..9 " "
                     LiteralExpr@9..10
                       IntLiteral@9..10 "2"
-            error at 9..10: expected ‘in’ or ‘=’, but found int literal"#]],
+            error at 9..10: unexpected token
+            | error for 9..10: expected ‘in’ or ‘=’, but found int literal"#]],
     );
 }
 
@@ -1581,7 +1583,8 @@ fn recover_infix_missing_rhs() {
                     Assign@1..3 ":="
                   UnaryExpr@3..6
                     KwNot@3..6 "not"
-            error at 3..6: expected expression after here"#]],
+            error at 3..6: unexpected end of file
+            | error for 3..6: expected expression after here"#]],
     );
 }
 
@@ -1673,7 +1676,8 @@ fn recover_just_right_paren() {
                     Assign@1..3 ":="
                   Error@3..4
                     RightParen@3..4 ")"
-            error at 3..4: expected expression, but found ‘)’"#]],
+            error at 3..4: unexpected token
+            | error for 3..4: expected expression, but found ‘)’"#]],
     )
 }
 
@@ -1697,7 +1701,8 @@ fn recover_too_many_right_parens() {
                     RightParen@5..6 ")"
                 Error@6..7
                   RightParen@6..7 ")"
-            error at 6..7: expected statement, but found ‘)’"#]],
+            error at 6..7: unexpected token
+            | error for 6..7: expected statement, but found ‘)’"#]],
     )
 }
 
@@ -1718,7 +1723,8 @@ fn recover_missing_closing_paren() {
                     LeftParen@3..4 "("
                     LiteralExpr@4..5
                       IntLiteral@4..5 "1"
-            error at 4..5: expected ‘)’ after here"#]],
+            error at 4..5: unexpected end of file
+            | error for 4..5: expected ‘)’ after here"#]],
     );
 }
 
@@ -1741,7 +1747,8 @@ fn recover_missing_closing_paren_and_rhs() {
                       LiteralExpr@4..5
                         IntLiteral@4..5 "1"
                       Plus@5..6 "+"
-            error at 5..6: expected expression after here"#]],
+            error at 5..6: unexpected end of file
+            | error for 5..6: expected expression after here"#]],
     );
 }
 
@@ -1762,7 +1769,8 @@ fn recover_missing_rhs() {
                     LiteralExpr@3..4
                       IntLiteral@3..4 "1"
                     Plus@4..5 "+"
-            error at 4..5: expected expression after here"#]],
+            error at 4..5: unexpected end of file
+            | error for 4..5: expected expression after here"#]],
     );
 }
 
@@ -1840,7 +1848,8 @@ fn recover_field_expr_missing_field() {
                       Name@3..4
                         Identifier@3..4 "a"
                     Dot@4..5 "."
-            error at 4..5: expected identifier after here"#]],
+            error at 4..5: unexpected end of file
+            | error for 4..5: expected identifier after here"#]],
     );
 }
 
@@ -1864,7 +1873,8 @@ fn recover_field_missing_closing_paren_and_field() {
                         Name@4..5
                           Identifier@4..5 "a"
                       Dot@5..6 "."
-            error at 5..6: expected identifier after here"#]],
+            error at 5..6: unexpected end of file
+            | error for 5..6: expected identifier after here"#]],
     );
 }
 
@@ -1942,7 +1952,8 @@ fn recover_arrow_expr_missing_field() {
                       Name@3..4
                         Identifier@3..4 "a"
                     Arrow@4..6 "->"
-            error at 4..6: expected identifier after here"#]],
+            error at 4..6: unexpected end of file
+            | error for 4..6: expected identifier after here"#]],
     );
 }
 
@@ -1966,7 +1977,8 @@ fn recover_arrow_missing_closing_paren_and_field() {
                         Name@4..5
                           Identifier@4..5 "a"
                       Arrow@5..7 "->"
-            error at 5..7: expected identifier after here"#]],
+            error at 5..7: unexpected end of file
+            | error for 5..7: expected identifier after here"#]],
     );
 }
 
@@ -2196,7 +2208,8 @@ fn recover_call_expr_missing_closing_paren() {
                       Param@5..6
                         LiteralExpr@5..6
                           IntLiteral@5..6 "1"
-            error at 5..6: expected ‘..’, ‘,’ or ‘)’ after here"#]],
+            error at 5..6: unexpected end of file
+            | error for 5..6: expected ‘..’, ‘,’ or ‘)’ after here"#]],
     );
 }
 
@@ -2225,7 +2238,8 @@ fn recover_call_expr_missing_last_arg() {
                         Comma@6..7 ","
                       Param@7..7
                       RightParen@7..8 ")"
-            error at 7..8: expected expression, but found ‘)’"#]],
+            error at 7..8: unexpected token
+            | error for 7..8: expected expression, but found ‘)’"#]],
     );
 }
 
@@ -2253,7 +2267,8 @@ fn recover_call_expr_missing_last_arg_and_closing_paren() {
                           IntLiteral@5..6 "1"
                         Comma@6..7 ","
                       Param@7..7
-            error at 6..7: expected expression after here"#]],
+            error at 6..7: unexpected end of file
+            | error for 6..7: expected expression after here"#]],
     );
 }
 
@@ -2285,8 +2300,10 @@ fn recover_call_expr_missing_delim() {
                     IntLiteral@7..8 "1"
                 Error@8..9
                   RightParen@8..9 ")"
-            error at 7..8: expected ‘..’, ‘,’ or ‘)’, but found int literal
-            error at 8..9: expected statement, but found ‘)’"#]],
+            error at 7..8: unexpected token
+            | error for 7..8: expected ‘..’, ‘,’ or ‘)’, but found int literal
+            error at 8..9: unexpected token
+            | error for 8..9: expected statement, but found ‘)’"#]],
     );
 }
 
@@ -2319,7 +2336,8 @@ fn recover_call_expr_missing_param() {
                         LiteralExpr@8..9
                           IntLiteral@8..9 "1"
                       RightParen@9..10 ")"
-            error at 7..8: expected expression, but found ‘,’"#]],
+            error at 7..8: unexpected token
+            | error for 7..8: expected expression, but found ‘,’"#]],
     );
 }
 
@@ -2354,8 +2372,10 @@ fn recover_call_expr_missing_params() {
                         LiteralExpr@9..10
                           IntLiteral@9..10 "1"
                       RightParen@10..11 ")"
-            error at 7..8: expected expression, but found ‘,’
-            error at 8..9: expected expression, but found ‘,’"#]],
+            error at 7..8: unexpected token
+            | error for 7..8: expected expression, but found ‘,’
+            error at 8..9: unexpected token
+            | error for 8..9: expected expression, but found ‘,’"#]],
     );
 }
 
@@ -2549,7 +2569,8 @@ fn recover_deref_missing_rhs() {
                     Caret@3..4 "^"
                     DerefExpr@4..5
                       Caret@4..5 "^"
-            error at 4..5: expected expression after here"#]],
+            error at 4..5: unexpected end of file
+            | error for 4..5: expected expression after here"#]],
     );
 }
 
@@ -2661,7 +2682,8 @@ fn recover_init_expr_missing_expr_in_list() {
                       LiteralExpr@11..12
                         IntLiteral@11..12 "3"
                     RightParen@12..13 ")"
-            error at 10..11: expected expression, but found ‘,’"#]],
+            error at 10..11: unexpected token
+            | error for 10..11: expected expression, but found ‘,’"#]],
     );
 }
 #[test]
@@ -2693,8 +2715,10 @@ fn recover_init_expr_missing_delimiter() {
                     IntLiteral@13..14 "3"
                 Error@14..15
                   RightParen@14..15 ")"
-            error at 13..14: expected ‘)’, but found int literal
-            error at 14..15: expected statement, but found ‘)’"#]],
+            error at 13..14: unexpected token
+            | error for 13..14: expected ‘)’, but found int literal
+            error at 14..15: unexpected token
+            | error for 14..15: expected statement, but found ‘)’"#]],
     );
 }
 
@@ -2721,7 +2745,8 @@ fn recover_init_expr_missing_right_paren() {
                       Whitespace@10..11 " "
                       LiteralExpr@11..12
                         IntLiteral@11..12 "2"
-            error at 11..12: expected ‘)’ after here"#]],
+            error at 11..12: unexpected end of file
+            | error for 11..12: expected ‘)’ after here"#]],
     );
 }
 
@@ -2748,8 +2773,10 @@ fn recover_init_expr_missing_left_paren() {
                       Whitespace@10..11 " "
                       LiteralExpr@11..12
                         IntLiteral@11..12 "2"
-            error at 8..9: expected ‘(’, but found int literal
-            error at 11..12: expected ‘)’ after here"#]],
+            error at 8..9: unexpected token
+            | error for 8..9: expected ‘(’, but found int literal
+            error at 11..12: unexpected end of file
+            | error for 11..12: expected ‘)’ after here"#]],
     );
 }
 
@@ -2771,7 +2798,8 @@ fn recover_init_expr_empty() {
                     LeftParen@7..8 "("
                     ExprList@8..8
                     RightParen@8..9 ")"
-            error at 8..9: expected expression, but found ‘)’"#]],
+            error at 8..9: unexpected token
+            | error for 8..9: expected expression, but found ‘)’"#]],
     );
 }
 
@@ -2794,7 +2822,8 @@ fn recover_init_expr_just_comma() {
                     ExprList@8..9
                       Comma@8..9 ","
                     RightParen@9..10 ")"
-            error at 8..9: expected expression, but found ‘,’"#]],
+            error at 8..9: unexpected token
+            | error for 8..9: expected expression, but found ‘,’"#]],
     )
 }
 
@@ -3444,7 +3473,8 @@ fn recover_chained_indirect_tails() {
                     LiteralExpr@14..15
                       IntLiteral@14..15 "2"
                     RightParen@15..16 ")"
-            error at 11..12: expected infix operator, but found ‘@’"#]],
+            error at 11..12: unexpected token
+            | error for 11..12: expected infix operator, but found ‘@’"#]],
     );
 }
 
@@ -3485,7 +3515,8 @@ fn recover_just_indirect_ty() {
                 Error@0..4
                   PrimType@0..4
                     KwChar@0..4 "char"
-            error at 0..4: expected ‘(’ or ‘@’ after here"#]],
+            error at 0..4: unexpected end of file
+            | error for 0..4: expected ‘(’ or ‘@’ after here"#]],
     );
 }
 
@@ -3662,7 +3693,8 @@ fn recover_just_bits() {
                 CallStmt@0..4
                   BitsExpr@0..4
                     KwBits@0..4 "bits"
-            error at 0..4: expected ‘(’ after here"#]],
+            error at 0..4: unexpected end of file
+            | error for 0..4: expected ‘(’ after here"#]],
     );
 }
 
@@ -3767,7 +3799,8 @@ fn recover_just_objclass() {
                 CallStmt@0..11
                   ObjClassExpr@0..11
                     KwObjectClass@0..11 "objectclass"
-            error at 0..11: expected ‘(’ after here"#]],
+            error at 0..11: unexpected end of file
+            | error for 0..11: expected ‘(’ after here"#]],
     );
 }
 
@@ -3889,7 +3922,8 @@ fn recover_cheat_expr_missing_size_spec_expr() {
                       Colon@16..17 ":"
                     Whitespace@17..18 " "
                     RightParen@18..19 ")"
-            error at 18..19: expected expression, but found ‘)’"#]],
+            error at 18..19: unexpected token
+            | error for 18..19: expected expression, but found ‘)’"#]],
     );
 }
 
@@ -3914,7 +3948,8 @@ fn recover_cheat_expr_missing_expr() {
                     Comma@12..13 ","
                     Whitespace@13..14 " "
                     RightParen@14..15 ")"
-            error at 14..15: expected expression, but found ‘)’"#]],
+            error at 14..15: unexpected token
+            | error for 14..15: expected expression, but found ‘)’"#]],
     );
 }
 
@@ -3937,7 +3972,8 @@ fn recover_cheat_expr_missing_comma() {
                     PrimType@9..12
                       KwInt@9..12 "int"
                     RightParen@12..13 ")"
-            error at 12..13: expected ‘,’, but found ‘)’"#]],
+            error at 12..13: unexpected token
+            | error for 12..13: expected ‘,’, but found ‘)’"#]],
     );
 }
 
@@ -3958,7 +3994,8 @@ fn recover_cheat_expr_empty() {
                     KwCheat@3..8 "cheat"
                     LeftParen@8..9 "("
                     RightParen@9..10 ")"
-            error at 9..10: expected type specifier, but found ‘)’"#]],
+            error at 9..10: unexpected token
+            | error for 9..10: expected type specifier, but found ‘)’"#]],
     );
 }
 
@@ -3977,7 +4014,8 @@ fn recover_just_cheat() {
                     Assign@1..3 ":="
                   CheatExpr@3..8
                     KwCheat@3..8 "cheat"
-            error at 3..8: expected ‘(’ after here"#]],
+            error at 3..8: unexpected end of file
+            | error for 3..8: expected ‘(’ after here"#]],
     );
 }
 
@@ -4216,7 +4254,8 @@ fn recover_call_expr_range_item_missing_expr() {
                           Range@7..9 ".."
                       Whitespace@9..10 " "
                       RightParen@10..11 ")"
-            error at 10..11: expected expression, but found ‘)’"#]],
+            error at 10..11: unexpected token
+            | error for 10..11: expected expression, but found ‘)’"#]],
     );
 }
 
@@ -4246,7 +4285,8 @@ fn recover_call_expr_relative_bound_missing_expr() {
                           Minus@7..8 "-"
                       Whitespace@8..9 " "
                       RightParen@9..10 ")"
-            error at 9..10: expected expression, but found ‘)’"#]],
+            error at 9..10: unexpected token
+            | error for 9..10: expected expression, but found ‘)’"#]],
     );
 }
 
@@ -4278,8 +4318,10 @@ fn recover_call_expr_relative_bound_missing_minus() {
                     IntLiteral@7..8 "1"
                 Error@8..9
                   RightParen@8..9 ")"
-            error at 7..8: expected ‘-’, ‘..’, ‘,’ or ‘)’, but found int literal
-            error at 8..9: expected statement, but found ‘)’"#]],
+            error at 7..8: unexpected token
+            | error for 7..8: expected ‘-’, ‘..’, ‘,’ or ‘)’, but found int literal
+            error at 8..9: unexpected token
+            | error for 8..9: expected statement, but found ‘)’"#]],
     );
 }
 
@@ -4381,8 +4423,10 @@ fn recover_all_not_primary() {
                       IntLiteral@18..19 "1"
                 Error@19..20
                   RightParen@19..20 ")"
-            error at 16..17: expected ‘,’ or ‘)’, but found ‘+’
-            error at 19..20: expected statement, but found ‘)’"#]],
+            error at 16..17: unexpected token
+            | error for 16..17: expected ‘,’ or ‘)’, but found ‘+’
+            error at 19..20: unexpected token
+            | error for 19..20: expected statement, but found ‘)’"#]],
     );
 }
 
@@ -4544,7 +4588,8 @@ fn recover_nil_expr_missing_spec() {
                     Whitespace@6..7 " "
                     LeftParen@7..8 "("
                     RightParen@8..9 ")"
-            error at 8..9: expected expression, but found ‘)’"#]],
+            error at 8..9: unexpected token
+            | error for 8..9: expected expression, but found ‘)’"#]],
     );
 }
 
@@ -4568,7 +4613,8 @@ fn recover_nil_expr_missing_right_paren() {
                     NameExpr@8..9
                       Name@8..9
                         Identifier@8..9 "a"
-            error at 8..9: expected ‘)’ after here"#]],
+            error at 8..9: unexpected end of file
+            | error for 8..9: expected ‘)’ after here"#]],
     );
 }
 
@@ -4599,8 +4645,10 @@ fn recover_include_glob_expr() {
                 CallStmt@20..21
                   LiteralExpr@20..21
                     IntLiteral@20..21 "1"
-            error at 3..10: expected expression, but found ‘include’
-            error at 18..19: expected statement, but found ‘+’"#]],
+            error at 3..10: unexpected token
+            | error for 3..10: expected expression, but found ‘include’
+            error at 18..19: unexpected token
+            | error for 18..19: expected statement, but found ‘+’"#]],
     );
 }
 
@@ -4626,7 +4674,8 @@ fn recover_include_glob_ref() {
                   NameExpr@18..27
                     Name@18..27
                       Identifier@18..27 "and_there"
-            error at 15..17: expected statement, but found ‘->’"#]],
+            error at 15..17: unexpected token
+            | error for 15..17: expected statement, but found ‘->’"#]],
     );
 }
 
@@ -4874,7 +4923,8 @@ fn recover_sizeof_expr_missing_right_paren() {
                     NameExpr@10..11
                       Name@10..11
                         Identifier@10..11 "a"
-            error at 10..11: expected ‘)’ after here"#]],
+            error at 10..11: unexpected end of file
+            | error for 10..11: expected ‘)’ after here"#]],
     );
 }
 
@@ -4898,7 +4948,8 @@ fn recover_sizeof_expr_missing_left_paren() {
                       Name@10..11
                         Identifier@10..11 "a"
                     RightParen@11..12 ")"
-            error at 10..11: expected ‘(’, but found identifier"#]],
+            error at 10..11: unexpected token
+            | error for 10..11: expected ‘(’, but found identifier"#]],
     );
 }
 
@@ -4921,7 +4972,8 @@ fn recover_sizeof_expr_missing_parens() {
                     NameExpr@10..11
                       Name@10..11
                         Identifier@10..11 "a"
-            error at 10..11: expected ‘(’, but found identifier"#]],
+            error at 10..11: unexpected token
+            | error for 10..11: expected ‘(’, but found identifier"#]],
     );
 }
 
@@ -4942,7 +4994,8 @@ fn recover_sizeof_expr_missing_arg() {
                     KwSizeOf@3..9 "sizeof"
                     LeftParen@9..10 "("
                     RightParen@10..11 ")"
-            error at 10..11: expected expression, but found ‘)’"#]],
+            error at 10..11: unexpected token
+            | error for 10..11: expected expression, but found ‘)’"#]],
     );
 }
 
@@ -4985,28 +5038,29 @@ fn parse_invalid_tilde_before_indirect() {
     check(
         "_:=A~B@()",
         expect![[r#"
-        Source@0..9
-          StmtList@0..9
-            AssignStmt@0..9
-              NameExpr@0..1
-                Name@0..1
-                  Identifier@0..1 "_"
-              AsnOp@1..3
-                Assign@1..3 ":="
-              BinaryExpr@3..9
-                NameExpr@3..4
-                  Name@3..4
-                    Identifier@3..4 "A"
-                Error@4..5
-                  Tilde@4..5 "~"
-                IndirectExpr@5..9
-                  NameExpr@5..6
-                    Name@5..6
-                      Identifier@5..6 "B"
-                  At@6..7 "@"
-                  LeftParen@7..8 "("
-                  RightParen@8..9 ")"
-        error at 5..6: expected ‘in’ or ‘=’, but found identifier"#]],
+            Source@0..9
+              StmtList@0..9
+                AssignStmt@0..9
+                  NameExpr@0..1
+                    Name@0..1
+                      Identifier@0..1 "_"
+                  AsnOp@1..3
+                    Assign@1..3 ":="
+                  BinaryExpr@3..9
+                    NameExpr@3..4
+                      Name@3..4
+                        Identifier@3..4 "A"
+                    Error@4..5
+                      Tilde@4..5 "~"
+                    IndirectExpr@5..9
+                      NameExpr@5..6
+                        Name@5..6
+                          Identifier@5..6 "B"
+                      At@6..7 "@"
+                      LeftParen@7..8 "("
+                      RightParen@8..9 ")"
+            error at 5..6: unexpected token
+            | error for 5..6: expected ‘in’ or ‘=’, but found identifier"#]],
     );
 }
 
@@ -5015,29 +5069,30 @@ fn parse_invalid_not_before_indirect() {
     check(
         "_:=A not B@()",
         expect![[r#"
-        Source@0..13
-          StmtList@0..13
-            AssignStmt@0..13
-              NameExpr@0..1
-                Name@0..1
-                  Identifier@0..1 "_"
-              AsnOp@1..3
-                Assign@1..3 ":="
-              BinaryExpr@3..13
-                NameExpr@3..4
-                  Name@3..4
-                    Identifier@3..4 "A"
-                Whitespace@4..5 " "
-                Error@5..8
-                  KwNot@5..8 "not"
-                Whitespace@8..9 " "
-                IndirectExpr@9..13
-                  NameExpr@9..10
-                    Name@9..10
-                      Identifier@9..10 "B"
-                  At@10..11 "@"
-                  LeftParen@11..12 "("
-                  RightParen@12..13 ")"
-        error at 9..10: expected ‘in’ or ‘=’, but found identifier"#]],
+            Source@0..13
+              StmtList@0..13
+                AssignStmt@0..13
+                  NameExpr@0..1
+                    Name@0..1
+                      Identifier@0..1 "_"
+                  AsnOp@1..3
+                    Assign@1..3 ":="
+                  BinaryExpr@3..13
+                    NameExpr@3..4
+                      Name@3..4
+                        Identifier@3..4 "A"
+                    Whitespace@4..5 " "
+                    Error@5..8
+                      KwNot@5..8 "not"
+                    Whitespace@8..9 " "
+                    IndirectExpr@9..13
+                      NameExpr@9..10
+                        Name@9..10
+                          Identifier@9..10 "B"
+                      At@10..11 "@"
+                      LeftParen@11..12 "("
+                      RightParen@12..13 ")"
+            error at 9..10: unexpected token
+            | error for 9..10: expected ‘in’ or ‘=’, but found identifier"#]],
     );
 }

--- a/compiler/toc_parser/src/grammar/mod.rs
+++ b/compiler/toc_parser/src/grammar/mod.rs
@@ -361,8 +361,11 @@ mod test {
                   Whitespace@28..29 " "
                   Comment@29..42 "% skipped too"
                 error at 9..10: invalid character
+                | error for 9..10: here
                 error at 10..11: invalid character
-                error at 11..12: invalid character"#]],
+                | error for 10..11: here
+                error at 11..12: invalid character
+                | error for 11..12: here"#]],
         );
     }
 
@@ -385,7 +388,8 @@ mod test {
                   Comment@9..26 "/* some trivia */"
                   Whitespace@26..31 "     "
                   Comment@31..48 "% and more trivia"
-                error at 6..8: expected expression after here"#]],
+                error at 6..8: unexpected end of file
+                | error for 6..8: expected expression after here"#]],
         );
     }
 }

--- a/compiler/toc_parser/src/grammar/mod.rs
+++ b/compiler/toc_parser/src/grammar/mod.rs
@@ -365,4 +365,27 @@ mod test {
                 error at 11..12: invalid character"#]],
         );
     }
+
+    #[test]
+    fn last_non_trivia_token() {
+        check(
+            "var i := /* some trivia */     % and more trivia",
+            expect![[r#"
+                Source@0..48
+                  StmtList@0..8
+                    ConstVarDecl@0..8
+                      KwVar@0..3 "var"
+                      Whitespace@3..4 " "
+                      NameList@4..5
+                        Name@4..5
+                          Identifier@4..5 "i"
+                      Whitespace@5..6 " "
+                      Assign@6..8 ":="
+                  Whitespace@8..9 " "
+                  Comment@9..26 "/* some trivia */"
+                  Whitespace@26..31 "     "
+                  Comment@31..48 "% and more trivia"
+                error at 6..8: expected expression after here"#]],
+        );
+    }
 }

--- a/compiler/toc_parser/src/grammar/preproc/test.rs
+++ b/compiler/toc_parser/src/grammar/preproc/test.rs
@@ -89,7 +89,8 @@ mod cond {
                           Whitespace@52..53 " "
                           KwIf@53..55 "if"
                   Whitespace@55..60 "\n    "
-                error at 9..13: expected preprocessor condition, but found ‘then’"##]],
+                error at 9..13: unexpected token
+                | error for 9..13: expected preprocessor condition, but found ‘then’"##]],
         );
     }
 
@@ -133,7 +134,8 @@ mod cond {
                           Whitespace@49..50 " "
                           KwIf@50..52 "if"
                   Whitespace@52..57 "\n    "
-                error at 15..21: expected ‘then’, but found ‘assert’"##]],
+                error at 15..21: unexpected token
+                | error for 15..21: expected ‘then’, but found ‘assert’"##]],
         );
     }
 
@@ -173,7 +175,8 @@ mod cond {
                             EndGroup@42..45
                               KwEnd@42..45 "end"
                   Whitespace@45..50 "\n    "
-                error at 42..45: expected ‘#elseif’, ‘#elsif’, ‘#else’, ‘#end’ or ‘#endif’ after here"##]],
+                error at 42..45: unexpected end of file
+                | error for 42..45: expected ‘#elseif’, ‘#elsif’, ‘#else’, ‘#end’ or ‘#endif’ after here"##]],
         );
     }
 
@@ -319,7 +322,8 @@ mod cond {
                           Whitespace@124..125 " "
                           KwIf@125..127 "if"
                   Whitespace@127..132 "\n    "
-                warn at 85..92: ‘#elseif’ found, assuming it to be ‘#elsif’"##]],
+                warn at 85..92: ‘#elseif’ found
+                | warn for 85..92: assuming it to be ‘#elsif’"##]],
         );
     }
 
@@ -416,7 +420,8 @@ mod cond {
                           Whitespace@162..163 " "
                           KwIf@163..165 "if"
                   Whitespace@165..170 "\n    "
-                warn at 85..92: ‘#elseif’ found, assuming it to be ‘#elsif’"##]],
+                warn at 85..92: ‘#elseif’ found
+                | warn for 85..92: assuming it to be ‘#elsif’"##]],
         );
     }
 
@@ -495,7 +500,8 @@ mod cond {
                           Whitespace@40..41 " "
                           KwIf@41..43 "if"
                   Whitespace@43..48 "\n    "
-                warn at 5..12: ‘#elseif’ found, assuming it to be ‘#elsif’"##]],
+                warn at 5..12: ‘#elseif’ found
+                | warn for 5..12: assuming it to be ‘#elsif’"##]],
         );
     }
 
@@ -562,7 +568,8 @@ mod cond {
                     PreprocGlob@0..6
                       PPEndIf@0..6
                         PPKwEndIf@0..6 "#endif"
-                warn at 0..6: ‘#endif’ found, assuming it to be ‘#end if’"##]],
+                warn at 0..6: ‘#endif’ found
+                | warn for 0..6: assuming it to be ‘#end if’"##]],
         );
     }
 
@@ -577,7 +584,8 @@ mod cond {
                       PPIf@0..3
                         PPKwIf@0..3 "#if"
                         PPTokenBody@3..3
-                error at 0..3: expected preprocessor condition after here"##]],
+                error at 0..3: unexpected end of file
+                | error for 0..3: expected preprocessor condition after here"##]],
         );
     }
 
@@ -592,7 +600,8 @@ mod cond {
                       PPElseif@0..6
                         PPKwElsif@0..6 "#elsif"
                         PPTokenBody@6..6
-                error at 0..6: expected preprocessor condition after here"##]],
+                error at 0..6: unexpected end of file
+                | error for 0..6: expected preprocessor condition after here"##]],
         );
     }
 
@@ -607,8 +616,10 @@ mod cond {
                       PPElseif@0..7
                         PPKwElseif@0..7 "#elseif"
                         PPTokenBody@7..7
-                warn at 0..7: ‘#elseif’ found, assuming it to be ‘#elsif’
-                error at 0..7: expected preprocessor condition after here"##]],
+                warn at 0..7: ‘#elseif’ found
+                | warn for 0..7: assuming it to be ‘#elsif’
+                error at 0..7: unexpected end of file
+                | error for 0..7: expected preprocessor condition after here"##]],
         );
     }
 
@@ -623,7 +634,8 @@ mod cond {
                       PPElse@0..5
                         PPKwElse@0..5 "#else"
                         PPTokenBody@5..5
-                error at 0..5: expected ‘#end’ or ‘#endif’ after here"##]],
+                error at 0..5: unexpected end of file
+                | error for 0..5: expected ‘#end’ or ‘#endif’ after here"##]],
         );
     }
 
@@ -637,7 +649,8 @@ mod cond {
                     PreprocGlob@0..4
                       PPEndIf@0..4
                         PPKwEnd@0..4 "#end"
-                error at 0..4: expected ‘if’ after here"##]],
+                error at 0..4: unexpected end of file
+                | error for 0..4: expected ‘if’ after here"##]],
         );
     }
 
@@ -651,7 +664,8 @@ mod cond {
                     PreprocGlob@0..6
                       PPEndIf@0..6
                         PPKwEndIf@0..6 "#endif"
-                warn at 0..6: ‘#endif’ found, assuming it to be ‘#end if’"##]],
+                warn at 0..6: ‘#endif’ found
+                | warn for 0..6: assuming it to be ‘#end if’"##]],
         );
     }
 
@@ -701,7 +715,8 @@ mod cond {
                           Whitespace@49..50 " "
                           KwIf@50..52 "if"
                   Whitespace@52..57 "\n    "
-                error at 18..21: expected expression, but found ‘#if’"##]],
+                error at 18..21: unexpected token
+                | error for 18..21: expected expression, but found ‘#if’"##]],
         );
     }
 
@@ -751,7 +766,8 @@ mod cond {
                           Whitespace@52..53 " "
                           KwIf@53..55 "if"
                   Whitespace@55..60 "\n    "
-                error at 18..24: expected expression, but found ‘#elsif’"##]],
+                error at 18..24: unexpected token
+                | error for 18..24: expected expression, but found ‘#elsif’"##]],
         );
     }
 
@@ -801,8 +817,10 @@ mod cond {
                           Whitespace@53..54 " "
                           KwIf@54..56 "if"
                   Whitespace@56..61 "\n    "
-                error at 18..25: expected expression, but found ‘#elseif’
-                warn at 18..25: ‘#elseif’ found, assuming it to be ‘#elsif’"##]],
+                error at 18..25: unexpected token
+                | error for 18..25: expected expression, but found ‘#elseif’
+                warn at 18..25: ‘#elseif’ found
+                | warn for 18..25: assuming it to be ‘#elsif’"##]],
         );
     }
 
@@ -846,7 +864,8 @@ mod cond {
                           Whitespace@44..45 " "
                           KwIf@45..47 "if"
                   Whitespace@47..52 "\n    "
-                error at 18..23: expected expression, but found ‘#else’"##]],
+                error at 18..23: unexpected token
+                | error for 18..23: expected expression, but found ‘#else’"##]],
         );
     }
 
@@ -877,7 +896,8 @@ mod cond {
                         Whitespace@22..23 " "
                         KwIf@23..25 "if"
                   Whitespace@25..30 "\n    "
-                error at 18..22: expected expression, but found ‘#end’"##]],
+                error at 18..22: unexpected token
+                | error for 18..22: expected expression, but found ‘#end’"##]],
         );
     }
 
@@ -903,8 +923,10 @@ mod cond {
                     PreprocGlob@18..24
                       PPEndIf@18..24
                         PPKwEndIf@18..24 "#endif"
-                error at 18..24: expected expression, but found ‘#endif’
-                warn at 18..24: ‘#endif’ found, assuming it to be ‘#end if’"##]],
+                error at 18..24: unexpected token
+                | error for 18..24: expected expression, but found ‘#endif’
+                warn at 18..24: ‘#endif’ found
+                | warn for 18..24: assuming it to be ‘#end if’"##]],
         );
     }
 }
@@ -1201,7 +1223,8 @@ mod expr {
                           PPKwEnd@13..17 "#end"
                           Whitespace@17..18 " "
                           KwIf@18..20 "if"
-                error at 8..12: expected preprocessor condition, but found ‘then’"##]],
+                error at 8..12: unexpected token
+                | error for 8..12: expected preprocessor condition, but found ‘then’"##]],
         )
     }
 
@@ -1230,7 +1253,8 @@ mod expr {
                           PPKwEnd@15..19 "#end"
                           Whitespace@19..20 " "
                           KwIf@20..22 "if"
-                error at 10..14: expected preprocessor condition, but found ‘then’"##]],
+                error at 10..14: unexpected token
+                | error for 10..14: expected preprocessor condition, but found ‘then’"##]],
         )
     }
 
@@ -1265,8 +1289,10 @@ mod expr {
                           PPKwEnd@17..21 "#end"
                           Whitespace@21..22 " "
                           KwIf@22..24 "if"
-                error at 6..9: expected ‘then’, but found ‘not’
-                error at 12..16: expected statement, but found ‘then’"##]],
+                error at 6..9: unexpected token
+                | error for 6..9: expected ‘then’, but found ‘not’
+                error at 12..16: unexpected token
+                | error for 12..16: expected statement, but found ‘then’"##]],
         )
     }
 
@@ -1297,9 +1323,12 @@ mod expr {
                           PPKwEnd@15..19 "#end"
                           Whitespace@19..20 " "
                           KwIf@20..22 "if"
-                error at 4..7: expected preprocessor condition, but found ‘and’
-                error at 8..9: expected ‘then’, but found identifier
-                error at 10..14: expected statement, but found ‘then’"##]],
+                error at 4..7: unexpected token
+                | error for 4..7: expected preprocessor condition, but found ‘and’
+                error at 8..9: unexpected token
+                | error for 8..9: expected ‘then’, but found identifier
+                error at 10..14: unexpected token
+                | error for 10..14: expected statement, but found ‘then’"##]],
         )
     }
 
@@ -1421,7 +1450,8 @@ mod expr {
                           PPKwEnd@12..16 "#end"
                           Whitespace@16..17 " "
                           KwIf@17..19 "if"
-                error at 7..11: expected ‘)’, but found ‘then’"##]],
+                error at 7..11: unexpected token
+                | error for 7..11: expected ‘)’, but found ‘then’"##]],
         )
     }
 
@@ -1447,7 +1477,8 @@ mod expr {
                           PPKwEnd@12..16 "#end"
                           Whitespace@16..17 " "
                           KwIf@17..19 "if"
-                error at 5..6: expected preprocessor condition, but found ‘)’"##]],
+                error at 5..6: unexpected token
+                | error for 5..6: expected preprocessor condition, but found ‘)’"##]],
         )
     }
 }

--- a/compiler/toc_parser/src/grammar/preproc/test.rs
+++ b/compiler/toc_parser/src/grammar/preproc/test.rs
@@ -173,7 +173,7 @@ mod cond {
                             EndGroup@42..45
                               KwEnd@42..45 "end"
                   Whitespace@45..50 "\n    "
-                error at 45..50: expected ‘#elseif’, ‘#elsif’, ‘#else’, ‘#end’ or ‘#endif’ after here"##]],
+                error at 42..45: expected ‘#elseif’, ‘#elsif’, ‘#else’, ‘#end’ or ‘#endif’ after here"##]],
         );
     }
 

--- a/compiler/toc_parser/src/grammar/stmt/test.rs
+++ b/compiler/toc_parser/src/grammar/stmt/test.rs
@@ -1450,7 +1450,7 @@ fn recover_type_decl_missing_type() {
                   Whitespace@6..7 " "
                   Colon@7..8 ":"
               Whitespace@8..9 " "
-            error at 8..9: expected type specifier after here"#]],
+            error at 7..8: expected type specifier after here"#]],
     );
 }
 
@@ -5353,7 +5353,7 @@ fn recover_quit_stmt_missing_code_expr() {
                   Whitespace@4..5 " "
                   Colon@5..6 ":"
               Whitespace@6..7 " "
-            error at 6..7: expected expression after here"#]],
+            error at 5..6: expected expression after here"#]],
     );
 }
 
@@ -5420,7 +5420,7 @@ fn recover_tag_stmt_missing_tag_val() {
                       Identifier@4..5 "a"
                   Comma@5..6 ","
               Whitespace@6..7 " "
-            error at 6..7: expected expression after here"#]],
+            error at 5..6: expected expression after here"#]],
     );
 }
 
@@ -5684,7 +5684,7 @@ fn recover_fork_stmt_process_ref_missing_ref() {
                   Comma@17..18 ","
                   Whitespace@18..19 " "
                   ProcessDesc@19..19
-            error at 18..19: expected expression after here"#]],
+            error at 17..18: expected expression after here"#]],
     );
 }
 
@@ -9244,7 +9244,7 @@ fn recover_tell_stmt_missing_tell_dest() {
                         Identifier@7..8 "a"
                   Comma@8..9 ","
               Whitespace@9..10 " "
-            error at 9..10: expected expression after here"#]],
+            error at 8..9: expected expression after here"#]],
     );
 }
 
@@ -9387,7 +9387,7 @@ fn recover_seek_stmt_missing_to_expr() {
                         Identifier@7..8 "a"
                   Comma@8..9 ","
               Whitespace@9..10 " "
-            error at 9..10: expected expression after here"#]],
+            error at 8..9: expected expression after here"#]],
     );
 }
 
@@ -10560,7 +10560,7 @@ fn recover_new_open_missing_mode() {
                           Identifier@13..19 "a_path"
                     Comma@19..20 ","
               Whitespace@20..21 " "
-            error at 20..21: expected ‘get’, ‘put’, ‘read’, ‘write’, ‘seek’ or ‘mod’ after here"#]],
+            error at 19..20: expected ‘get’, ‘put’, ‘read’, ‘write’, ‘seek’ or ‘mod’ after here"#]],
     );
 }
 
@@ -10775,7 +10775,7 @@ fn recover_old_close_missing_right_paren() {
                       Name@8..16
                         Identifier@8..16 "some_ref"
               Whitespace@16..17 " "
-            error at 16..17: expected ‘)’ after here"#]],
+            error at 8..16: expected ‘)’ after here"#]],
     );
 }
 
@@ -10851,7 +10851,7 @@ fn recover_new_close_missing_file_ref() {
                   NewClose@6..7
                     Colon@6..7 ":"
               Whitespace@7..8 " "
-            error at 7..8: expected expression after here"#]],
+            error at 6..7: expected expression after here"#]],
     );
 }
 
@@ -11418,7 +11418,7 @@ fn recover_get_stmt_missing_width_expr() {
                     GetWidth@14..15
                       Colon@14..15 ":"
               Whitespace@15..16 " "
-            error at 15..16: expected expression after here"#]],
+            error at 14..15: expected expression after here"#]],
     );
 }
 
@@ -11707,7 +11707,7 @@ fn recover_wait_stmt_missing_opt_arg_expr() {
                       Identifier@5..6 "a"
                   Comma@6..7 ","
               Whitespace@7..8 " "
-            error at 7..8: expected expression after here"#]],
+            error at 6..7: expected expression after here"#]],
     );
 }
 

--- a/compiler/toc_parser/src/grammar/stmt/test.rs
+++ b/compiler/toc_parser/src/grammar/stmt/test.rs
@@ -84,7 +84,8 @@ fn report_not_a_stmt() {
               StmtList@0..9
                 Error@0..9
                   KwPervasive@0..9 "pervasive"
-            error at 0..9: expected statement, but found ‘pervasive’"#]],
+            error at 0..9: unexpected token
+            | error for 0..9: expected statement, but found ‘pervasive’"#]],
     );
 }
 
@@ -97,7 +98,8 @@ fn recover_just_assign() {
               StmtList@0..2
                 Error@0..2
                   Assign@0..2 ":="
-            error at 0..2: expected statement, but found ‘:=’"#]],
+            error at 0..2: unexpected token
+            | error for 0..2: expected statement, but found ‘:=’"#]],
     )
 }
 
@@ -111,7 +113,8 @@ fn recover_just_var() {
                 ConstVarDecl@0..3
                   KwVar@0..3 "var"
                   NameList@3..3
-            error at 0..3: expected identifier after here"#]],
+            error at 0..3: unexpected end of file
+            | error for 0..3: expected identifier after here"#]],
     )
 }
 
@@ -190,7 +193,8 @@ fn parse_var_decl_with_alt_eq() {
                   Whitespace@13..14 " "
                   LiteralExpr@14..15
                     IntLiteral@14..15 "1"
-            warn at 12..13: ‘=’ found, assuming it to be ‘:=’"#]],
+            warn at 12..13: ‘=’ found
+            | warn for 12..13: assuming it to be ‘:=’"#]],
     )
 }
 
@@ -217,7 +221,8 @@ fn parse_const_decl_with_alt_eq() {
                   Whitespace@15..16 " "
                   LiteralExpr@16..17
                     IntLiteral@16..17 "1"
-            warn at 14..15: ‘=’ found, assuming it to be ‘:=’"#]],
+            warn at 14..15: ‘=’ found
+            | warn for 14..15: assuming it to be ‘:=’"#]],
     )
 }
 
@@ -359,7 +364,8 @@ fn recover_const_decl_no_init() {
                   Whitespace@9..10 " "
                   PrimType@10..13
                     KwInt@10..13 "int"
-            error at 10..13: expected ‘:=’ after here"#]],
+            error at 10..13: unexpected end of file
+            | error for 10..13: expected ‘:=’ after here"#]],
     )
 }
 
@@ -418,7 +424,8 @@ fn recover_not_name_in_var_decl_multiple_names() {
                   Whitespace@15..16 " "
                   LiteralExpr@16..17
                     IntLiteral@16..17 "1"
-            error at 7..9: expected identifier, but found ‘to’"#]],
+            error at 7..9: unexpected token
+            | error for 7..9: expected identifier, but found ‘to’"#]],
     );
 }
 
@@ -440,7 +447,8 @@ fn recover_not_name_in_var_decl() {
                   Whitespace@9..10 " "
                   LiteralExpr@10..11
                     IntLiteral@10..11 "1"
-            error at 4..6: expected identifier, but found ‘to’"#]],
+            error at 4..6: unexpected token
+            | error for 4..6: expected identifier, but found ‘to’"#]],
     );
 }
 
@@ -457,7 +465,8 @@ fn recover_bare_var_decl() {
                   NameList@4..5
                     Name@4..5
                       Identifier@4..5 "a"
-            error at 4..5: expected ‘,’, ‘:’ or ‘:=’ after here"#]],
+            error at 4..5: unexpected end of file
+            | error for 4..5: expected ‘,’, ‘:’ or ‘:=’ after here"#]],
     )
 }
 
@@ -474,7 +483,8 @@ fn recover_bare_const_decl() {
                   NameList@6..7
                     Name@6..7
                       Identifier@6..7 "a"
-            error at 6..7: expected ‘,’, ‘:’ or ‘:=’ after here"#]],
+            error at 6..7: unexpected end of file
+            | error for 6..7: expected ‘,’, ‘:’ or ‘:=’ after here"#]],
     )
 }
 
@@ -498,7 +508,8 @@ fn recover_var_decl_missing_ty() {
                   Whitespace@10..11 " "
                   LiteralExpr@11..12
                     IntLiteral@11..12 "1"
-            error at 8..10: expected type specifier, but found ‘:=’"#]],
+            error at 8..10: unexpected token
+            | error for 8..10: expected type specifier, but found ‘:=’"#]],
     )
 }
 
@@ -525,7 +536,8 @@ fn recover_var_decl_not_a_ty() {
                   Whitespace@13..14 " "
                   LiteralExpr@14..15
                     IntLiteral@14..15 "1"
-            error at 8..10: expected type specifier, but found ‘to’"#]],
+            error at 8..10: unexpected token
+            | error for 8..10: expected type specifier, but found ‘to’"#]],
     )
 }
 
@@ -544,7 +556,8 @@ fn recover_var_decl_missing_name() {
                   Whitespace@5..6 " "
                   PrimType@6..9
                     KwInt@6..9 "int"
-            error at 4..5: expected identifier, but found ‘:’"#]],
+            error at 4..5: unexpected token
+            | error for 4..5: expected identifier, but found ‘:’"#]],
     );
 }
 
@@ -567,7 +580,8 @@ fn recover_var_decl_missing_final_name() {
                   Whitespace@8..9 " "
                   PrimType@9..12
                     KwInt@9..12 "int"
-            error at 7..8: expected identifier, but found ‘:’"#]],
+            error at 7..8: unexpected token
+            | error for 7..8: expected identifier, but found ‘:’"#]],
     );
 }
 
@@ -666,7 +680,8 @@ fn recover_on_var() {
                   Whitespace@20..21 " "
                   LiteralExpr@21..22
                     IntLiteral@21..22 "1"
-            error at 12..15: expected expression, but found ‘var’"#]],
+            error at 12..15: unexpected token
+            | error for 12..15: expected expression, but found ‘var’"#]],
     );
 }
 
@@ -697,7 +712,8 @@ fn recover_on_const() {
                   Whitespace@20..21 " "
                   LiteralExpr@21..22
                     IntLiteral@21..22 "1"
-            error at 10..15: expected expression, but found ‘const’"#]],
+            error at 10..15: unexpected token
+            | error for 10..15: expected expression, but found ‘const’"#]],
     );
 }
 
@@ -1045,10 +1061,14 @@ fn recover_not_weird_asn_op() {
                 CallStmt@11..12
                   LiteralExpr@11..12
                     IntLiteral@11..12 "1"
-            error at 2..5: expected statement, but found ‘not’
-            error at 5..6: expected statement, but found ‘=’
-            error at 6..7: expected statement, but found ‘=’
-            error at 7..10: expected statement, but found ‘not’"#]],
+            error at 2..5: unexpected token
+            | error for 2..5: expected statement, but found ‘not’
+            error at 5..6: unexpected token
+            | error for 5..6: expected statement, but found ‘=’
+            error at 6..7: unexpected token
+            | error for 6..7: expected statement, but found ‘=’
+            error at 7..10: unexpected token
+            | error for 7..10: expected statement, but found ‘not’"#]],
     );
     check(
         "a ~==~ 1",
@@ -1072,10 +1092,14 @@ fn recover_not_weird_asn_op() {
                 CallStmt@7..8
                   LiteralExpr@7..8
                     IntLiteral@7..8 "1"
-            error at 2..3: expected statement, but found ‘~’
-            error at 3..4: expected statement, but found ‘=’
-            error at 4..5: expected statement, but found ‘=’
-            error at 5..6: expected statement, but found ‘~’"#]],
+            error at 2..3: unexpected token
+            | error for 2..3: expected statement, but found ‘~’
+            error at 3..4: unexpected token
+            | error for 3..4: expected statement, but found ‘=’
+            error at 4..5: unexpected token
+            | error for 4..5: expected statement, but found ‘=’
+            error at 5..6: unexpected token
+            | error for 5..6: expected statement, but found ‘~’"#]],
     );
 }
 
@@ -1098,7 +1122,8 @@ fn recover_not_a_compound_asn_op() {
                 CallStmt@5..6
                   LiteralExpr@5..6
                     IntLiteral@5..6 "1"
-            error at 2..4: expected statement, but found ‘<=’"#]],
+            error at 2..4: unexpected token
+            | error for 2..4: expected statement, but found ‘<=’"#]],
     );
     check(
         "a <== 1",
@@ -1118,8 +1143,10 @@ fn recover_not_a_compound_asn_op() {
                 CallStmt@6..7
                   LiteralExpr@6..7
                     IntLiteral@6..7 "1"
-            error at 2..4: expected statement, but found ‘<=’
-            error at 4..5: expected statement, but found ‘=’"#]],
+            error at 2..4: unexpected token
+            | error for 2..4: expected statement, but found ‘<=’
+            error at 4..5: unexpected token
+            | error for 4..5: expected statement, but found ‘=’"#]],
     );
     check(
         "a >= 1",
@@ -1137,7 +1164,8 @@ fn recover_not_a_compound_asn_op() {
                 CallStmt@5..6
                   LiteralExpr@5..6
                     IntLiteral@5..6 "1"
-            error at 2..4: expected statement, but found ‘>=’"#]],
+            error at 2..4: unexpected token
+            | error for 2..4: expected statement, but found ‘>=’"#]],
     );
     check(
         "a >== 1",
@@ -1157,8 +1185,10 @@ fn recover_not_a_compound_asn_op() {
                 CallStmt@6..7
                   LiteralExpr@6..7
                     IntLiteral@6..7 "1"
-            error at 2..4: expected statement, but found ‘>=’
-            error at 4..5: expected statement, but found ‘=’"#]],
+            error at 2..4: unexpected token
+            | error for 2..4: expected statement, but found ‘>=’
+            error at 4..5: unexpected token
+            | error for 4..5: expected statement, but found ‘=’"#]],
     );
 
     // these are not compound ops in `toc`
@@ -1182,9 +1212,12 @@ fn recover_not_a_compound_asn_op() {
                 CallStmt@6..7
                   LiteralExpr@6..7
                     IntLiteral@6..7 "1"
-            error at 2..3: expected statement, but found ‘~’
-            error at 3..4: expected statement, but found ‘=’
-            error at 4..5: expected statement, but found ‘=’"#]],
+            error at 2..3: unexpected token
+            | error for 2..3: expected statement, but found ‘~’
+            error at 3..4: unexpected token
+            | error for 3..4: expected statement, but found ‘=’
+            error at 4..5: unexpected token
+            | error for 4..5: expected statement, but found ‘=’"#]],
     );
     check(
         "a not== 1",
@@ -1206,9 +1239,12 @@ fn recover_not_a_compound_asn_op() {
                 CallStmt@8..9
                   LiteralExpr@8..9
                     IntLiteral@8..9 "1"
-            error at 2..5: expected statement, but found ‘not’
-            error at 5..6: expected statement, but found ‘=’
-            error at 6..7: expected statement, but found ‘=’"#]],
+            error at 2..5: unexpected token
+            | error for 2..5: expected statement, but found ‘not’
+            error at 5..6: unexpected token
+            | error for 5..6: expected statement, but found ‘=’
+            error at 6..7: unexpected token
+            | error for 6..7: expected statement, but found ‘=’"#]],
     );
     check(
         "a not in= 1",
@@ -1231,9 +1267,12 @@ fn recover_not_a_compound_asn_op() {
                 CallStmt@10..11
                   LiteralExpr@10..11
                     IntLiteral@10..11 "1"
-            error at 2..5: expected statement, but found ‘not’
-            error at 6..8: expected statement, but found ‘in’
-            error at 8..9: expected statement, but found ‘=’"#]],
+            error at 2..5: unexpected token
+            | error for 2..5: expected statement, but found ‘not’
+            error at 6..8: unexpected token
+            | error for 6..8: expected statement, but found ‘in’
+            error at 8..9: unexpected token
+            | error for 8..9: expected statement, but found ‘=’"#]],
     );
     check(
         "a ~in= 1",
@@ -1255,9 +1294,12 @@ fn recover_not_a_compound_asn_op() {
                 CallStmt@7..8
                   LiteralExpr@7..8
                     IntLiteral@7..8 "1"
-            error at 2..3: expected statement, but found ‘~’
-            error at 3..5: expected statement, but found ‘in’
-            error at 5..6: expected statement, but found ‘=’"#]],
+            error at 2..3: unexpected token
+            | error for 2..3: expected statement, but found ‘~’
+            error at 3..5: unexpected token
+            | error for 3..5: expected statement, but found ‘in’
+            error at 5..6: unexpected token
+            | error for 5..6: expected statement, but found ‘=’"#]],
     );
     check(
         "a in= 1",
@@ -1277,8 +1319,10 @@ fn recover_not_a_compound_asn_op() {
                 CallStmt@6..7
                   LiteralExpr@6..7
                     IntLiteral@6..7 "1"
-            error at 2..4: expected statement, but found ‘in’
-            error at 4..5: expected statement, but found ‘=’"#]],
+            error at 2..4: unexpected token
+            | error for 2..4: expected statement, but found ‘in’
+            error at 4..5: unexpected token
+            | error for 4..5: expected statement, but found ‘=’"#]],
     );
     check(
         "a == 1",
@@ -1298,8 +1342,10 @@ fn recover_not_a_compound_asn_op() {
                 CallStmt@5..6
                   LiteralExpr@5..6
                     IntLiteral@5..6 "1"
-            warn at 2..3: ‘=’ found, assuming it to be ‘:=’
-            error at 3..4: expected expression, but found ‘=’"#]],
+            warn at 2..3: ‘=’ found
+            | warn for 2..3: assuming it to be ‘:=’
+            error at 3..4: unexpected token
+            | error for 3..4: expected expression, but found ‘=’"#]],
     );
 }
 
@@ -1325,7 +1371,8 @@ fn recover_missing_eq_in_asn_op() {
                   NameExpr@6..7
                     Name@6..7
                       Identifier@6..7 "a"
-            error at 4..5: expected ‘=’, but found int literal"#]],
+            error at 4..5: unexpected token
+            | error for 4..5: expected ‘=’, but found int literal"#]],
     );
 }
 
@@ -1346,7 +1393,8 @@ fn recover_eq_instead_of_asn() {
                   Whitespace@3..4 " "
                   LiteralExpr@4..5
                     IntLiteral@4..5 "1"
-            warn at 2..3: ‘=’ found, assuming it to be ‘:=’"#]],
+            warn at 2..3: ‘=’ found
+            | warn for 2..3: assuming it to be ‘:=’"#]],
     );
 }
 
@@ -1450,7 +1498,8 @@ fn recover_type_decl_missing_type() {
                   Whitespace@6..7 " "
                   Colon@7..8 ":"
               Whitespace@8..9 " "
-            error at 7..8: expected type specifier after here"#]],
+            error at 7..8: unexpected end of file
+            | error for 7..8: expected type specifier after here"#]],
     );
 }
 
@@ -1468,7 +1517,8 @@ fn recover_type_decl_missing_name() {
                   Whitespace@6..7 " "
                   PrimType@7..10
                     KwInt@7..10 "int"
-            error at 5..6: expected identifier, but found ‘:’"#]],
+            error at 5..6: unexpected token
+            | error for 5..6: expected identifier, but found ‘:’"#]],
     );
 }
 
@@ -1486,7 +1536,8 @@ fn recover_type_decl_missing_colon() {
                     Identifier@5..6 "a"
                   Whitespace@6..7 " "
                   KwForward@7..14 "forward"
-            error at 7..14: expected ‘:’, but found ‘forward’"#]],
+            error at 7..14: unexpected token
+            | error for 7..14: expected ‘:’, but found ‘forward’"#]],
     );
 }
 
@@ -1502,7 +1553,8 @@ fn recover_type_decl_missing_colon_and_type() {
                   Whitespace@4..5 " "
                   Name@5..6
                     Identifier@5..6 "a"
-            error at 5..6: expected ‘:’ after here"#]],
+            error at 5..6: unexpected end of file
+            | error for 5..6: expected ‘:’ after here"#]],
     );
 }
 
@@ -1515,7 +1567,8 @@ fn recover_just_type() {
               StmtList@0..4
                 TypeDecl@0..4
                   KwType@0..4 "type"
-            error at 0..4: expected identifier after here"#]],
+            error at 0..4: unexpected end of file
+            | error for 0..4: expected identifier after here"#]],
     );
 }
 
@@ -1545,7 +1598,8 @@ fn recover_on_type() {
                   Whitespace@18..19 " "
                   PrimType@19..22
                     KwInt@19..22 "int"
-            error at 10..14: expected expression, but found ‘type’"#]],
+            error at 10..14: unexpected token
+            | error for 10..14: expected expression, but found ‘type’"#]],
     );
 }
 
@@ -1615,7 +1669,8 @@ fn recover_on_block_stmt() {
                   StmtList@15..15
                   EndGroup@15..18
                     KwEnd@15..18 "end"
-            error at 9..14: expected expression, but found ‘begin’"#]],
+            error at 9..14: unexpected token
+            | error for 9..14: expected expression, but found ‘begin’"#]],
     );
 }
 
@@ -1762,8 +1817,10 @@ fn parse_if_chained_alternates() {
                     KwEnd@45..48 "end"
                     Whitespace@48..49 " "
                     KwIf@49..51 "if"
-            warn at 13..19: ‘elseif’ found, assuming it to be ‘elsif’
-            warn at 30..34: ‘elif’ found, assuming it to be ‘elsif’"#]],
+            warn at 13..19: ‘elseif’ found
+            | warn for 13..19: assuming it to be ‘elsif’
+            warn at 30..34: ‘elif’ found
+            | warn for 30..34: assuming it to be ‘elsif’"#]],
     );
 }
 
@@ -1785,7 +1842,8 @@ fn recover_if_stmt_missing_condition() {
                     KwEnd@8..11 "end"
                     Whitespace@11..12 " "
                     KwIf@12..14 "if"
-            error at 3..7: expected expression, but found ‘then’"#]],
+            error at 3..7: unexpected token
+            | error for 3..7: expected expression, but found ‘then’"#]],
     );
 }
 
@@ -1808,7 +1866,8 @@ fn recover_if_stmt_missing_then() {
                     KwEnd@8..11 "end"
                     Whitespace@11..12 " "
                     KwIf@12..14 "if"
-            error at 8..11: expected ‘then’, but found ‘end’"#]],
+            error at 8..11: unexpected token
+            | error for 8..11: expected ‘then’, but found ‘end’"#]],
     );
 }
 
@@ -1829,7 +1888,8 @@ fn recover_if_stmt_missing_end() {
                     KwThen@8..12 "then"
                     StmtList@12..12
                   EndGroup@12..12
-            error at 8..12: expected ‘else’, ‘elsif’ or ‘end’ after here"#]],
+            error at 8..12: unexpected end of file
+            | error for 8..12: expected ‘else’, ‘elsif’ or ‘end’ after here"#]],
     );
 }
 
@@ -1852,7 +1912,8 @@ fn parse_if_alternate_end() {
                     StmtList@13..13
                   EndGroup@13..18
                     KwEndIf@13..18 "endif"
-            warn at 13..18: ‘endif’ found, assuming it to be ’end if’"#]],
+            warn at 13..18: ‘endif’ found
+            | warn for 13..18: assuming it to be ’end if’"#]],
     );
 }
 
@@ -1901,7 +1962,8 @@ fn parse_elseif_alternates_stmt() {
                     KwEnd@17..20 "end"
                     Whitespace@20..21 " "
                     KwIf@21..23 "if"
-            warn at 0..6: ‘elseif’ found, assuming it to be ‘elsif’"#]],
+            warn at 0..6: ‘elseif’ found
+            | warn for 0..6: assuming it to be ‘elsif’"#]],
     );
     check(
         "elif true then end if",
@@ -1922,7 +1984,8 @@ fn parse_elseif_alternates_stmt() {
                     KwEnd@15..18 "end"
                     Whitespace@18..19 " "
                     KwIf@19..21 "if"
-            warn at 0..4: ‘elif’ found, assuming it to be ‘elsif’"#]],
+            warn at 0..4: ‘elif’ found
+            | warn for 0..4: assuming it to be ‘elsif’"#]],
     );
 }
 
@@ -1945,7 +2008,8 @@ fn parse_elseif_alternate_end() {
                     StmtList@16..16
                   EndGroup@16..21
                     KwEndIf@16..21 "endif"
-            warn at 16..21: ‘endif’ found, assuming it to be ’end if’"#]],
+            warn at 16..21: ‘endif’ found
+            | warn for 16..21: assuming it to be ’end if’"#]],
     );
 }
 
@@ -2040,7 +2104,8 @@ fn recover_if_stmt_multiple_elses() {
                             Whitespace@26..27 " "
                             KwIf@27..29 "if"
                   EndGroup@29..29
-            error at 27..29: expected ‘end’ after here"#]],
+            error at 27..29: unexpected end of file
+            | error for 27..29: expected ‘end’ after here"#]],
     );
 }
 
@@ -2074,7 +2139,8 @@ fn recover_on_if() {
                     KwEnd@23..26 "end"
                     Whitespace@26..27 " "
                     KwIf@27..29 "if"
-            error at 10..12: expected expression, but found ‘if’"#]],
+            error at 10..12: unexpected token
+            | error for 10..12: expected expression, but found ‘if’"#]],
     );
 }
 
@@ -2102,7 +2168,8 @@ fn recover_on_else() {
                     KwEnd@15..18 "end"
                     Whitespace@18..19 " "
                     KwIf@19..21 "if"
-            error at 10..14: expected expression, but found ‘else’"#]],
+            error at 10..14: unexpected token
+            | error for 10..14: expected expression, but found ‘else’"#]],
     );
 }
 
@@ -2136,8 +2203,10 @@ fn recover_on_elseif() {
                     KwEnd@27..30 "end"
                     Whitespace@30..31 " "
                     KwIf@31..33 "if"
-            error at 10..16: expected expression, but found ‘elseif’
-            warn at 10..16: ‘elseif’ found, assuming it to be ‘elsif’"#]],
+            error at 10..16: unexpected token
+            | error for 10..16: expected expression, but found ‘elseif’
+            warn at 10..16: ‘elseif’ found
+            | warn for 10..16: assuming it to be ‘elsif’"#]],
     );
 }
 
@@ -2171,7 +2240,8 @@ fn recover_on_elsif() {
                     KwEnd@26..29 "end"
                     Whitespace@29..30 " "
                     KwIf@30..32 "if"
-            error at 10..15: expected expression, but found ‘elsif’"#]],
+            error at 10..15: unexpected token
+            | error for 10..15: expected expression, but found ‘elsif’"#]],
     );
 }
 
@@ -2205,8 +2275,10 @@ fn recover_on_elif() {
                     KwEnd@25..28 "end"
                     Whitespace@28..29 " "
                     KwIf@29..31 "if"
-            error at 10..14: expected expression, but found ‘elif’
-            warn at 10..14: ‘elif’ found, assuming it to be ‘elsif’"#]],
+            error at 10..14: unexpected token
+            | error for 10..14: expected expression, but found ‘elif’
+            warn at 10..14: ‘elif’ found
+            | warn for 10..14: assuming it to be ‘elsif’"#]],
     );
 }
 
@@ -2234,8 +2306,10 @@ fn recover_begin_missing_end_in_if() {
                         EndGroup@16..16
                   EndGroup@16..21
                     KwEndIf@16..21 "endif"
-            error at 16..21: expected ‘end’, but found ‘endif’
-            warn at 16..21: ‘endif’ found, assuming it to be ’end if’"#]],
+            error at 16..21: unexpected token
+            | error for 16..21: expected ‘end’, but found ‘endif’
+            warn at 16..21: ‘endif’ found
+            | warn for 16..21: assuming it to be ’end if’"#]],
     );
 }
 
@@ -2253,7 +2327,8 @@ fn recover_begin_with_endloop() {
                   EndGroup@6..6
                 Error@6..13
                   KwEndLoop@6..13 "endloop"
-            error at 6..13: expected ‘end’, but found ‘endloop’"#]],
+            error at 6..13: unexpected token
+            | error for 6..13: expected ‘end’, but found ‘endloop’"#]],
     );
 }
 
@@ -2271,7 +2346,8 @@ fn recover_begin_with_endfor() {
                   EndGroup@6..6
                 Error@6..12
                   KwEndFor@6..12 "endfor"
-            error at 6..12: expected ‘end’, but found ‘endfor’"#]],
+            error at 6..12: unexpected token
+            | error for 6..12: expected ‘end’, but found ‘endfor’"#]],
     );
 }
 
@@ -2289,7 +2365,8 @@ fn recover_begin_with_endcase() {
                   EndGroup@6..6
                 Error@6..13
                   KwEndCase@6..13 "endcase"
-            error at 6..13: expected ‘end’, but found ‘endcase’"#]],
+            error at 6..13: unexpected token
+            | error for 6..13: expected ‘end’, but found ‘endcase’"#]],
     );
 }
 
@@ -2329,7 +2406,8 @@ fn recover_just_invariant() {
               StmtList@0..9
                 InvariantStmt@0..9
                   KwInvariant@0..9 "invariant"
-            error at 0..9: expected expression after here"#]],
+            error at 0..9: unexpected end of file
+            | error for 0..9: expected expression after here"#]],
     );
 }
 
@@ -2351,7 +2429,8 @@ fn recover_on_invariant() {
                 Whitespace@8..10 " \n"
                 InvariantStmt@10..19
                   KwInvariant@10..19 "invariant"
-            error at 10..19: expected expression, but found ‘invariant’"#]],
+            error at 10..19: unexpected token
+            | error for 10..19: expected expression, but found ‘invariant’"#]],
     );
 }
 
@@ -2391,7 +2470,8 @@ fn recover_just_assert() {
               StmtList@0..6
                 AssertStmt@0..6
                   KwAssert@0..6 "assert"
-            error at 0..6: expected expression after here"#]],
+            error at 0..6: unexpected end of file
+            | error for 0..6: expected expression after here"#]],
     );
 }
 
@@ -2416,7 +2496,8 @@ fn recover_on_assert() {
                   Whitespace@16..17 " "
                   LiteralExpr@17..21
                     KwTrue@17..21 "true"
-            error at 10..16: expected expression, but found ‘assert’"#]],
+            error at 10..16: unexpected token
+            | error for 10..16: expected expression, but found ‘assert’"#]],
     );
 }
 
@@ -2461,7 +2542,8 @@ fn recover_just_signal() {
               StmtList@0..6
                 SignalStmt@0..6
                   KwSignal@0..6 "signal"
-            error at 0..6: expected expression after here"#]],
+            error at 0..6: unexpected end of file
+            | error for 0..6: expected expression after here"#]],
     );
 }
 
@@ -2487,7 +2569,8 @@ fn recover_on_signal() {
                   NameExpr@17..18
                     Name@17..18
                       Identifier@17..18 "a"
-            error at 10..16: expected expression, but found ‘signal’"#]],
+            error at 10..16: unexpected token
+            | error for 10..16: expected expression, but found ‘signal’"#]],
     );
 }
 
@@ -2527,7 +2610,8 @@ fn recover_just_pause() {
               StmtList@0..5
                 PauseStmt@0..5
                   KwPause@0..5 "pause"
-            error at 0..5: expected expression after here"#]],
+            error at 0..5: unexpected end of file
+            | error for 0..5: expected expression after here"#]],
     );
 }
 
@@ -2552,7 +2636,8 @@ fn recover_on_pause() {
                   Whitespace@15..16 " "
                   LiteralExpr@16..17
                     IntLiteral@16..17 "3"
-            error at 10..15: expected expression, but found ‘pause’"#]],
+            error at 10..15: unexpected token
+            | error for 10..15: expected expression, but found ‘pause’"#]],
     );
 }
 
@@ -2580,7 +2665,8 @@ fn recover_just_result() {
               StmtList@0..6
                 ResultStmt@0..6
                   KwResult@0..6 "result"
-            error at 0..6: expected expression after here"#]],
+            error at 0..6: unexpected end of file
+            | error for 0..6: expected expression after here"#]],
     );
 }
 
@@ -2605,7 +2691,8 @@ fn recover_on_result() {
                   Whitespace@16..17 " "
                   LiteralExpr@17..18
                     IntLiteral@17..18 "2"
-            error at 10..16: expected expression, but found ‘result’"#]],
+            error at 10..16: unexpected token
+            | error for 10..16: expected expression, but found ‘result’"#]],
     );
 }
 
@@ -2639,7 +2726,8 @@ fn recover_on_return() {
                 Whitespace@8..10 " \n"
                 ReturnStmt@10..16
                   KwReturn@10..16 "return"
-            error at 10..16: expected expression, but found ‘return’"#]],
+            error at 10..16: unexpected token
+            | error for 10..16: expected expression, but found ‘return’"#]],
     );
 }
 
@@ -2673,7 +2761,8 @@ fn recover_on_checked() {
                 Whitespace@8..10 " \n"
                 CheckednessStmt@10..17
                   KwChecked@10..17 "checked"
-            error at 10..17: expected expression, but found ‘checked’"#]],
+            error at 10..17: unexpected token
+            | error for 10..17: expected expression, but found ‘checked’"#]],
     );
 }
 
@@ -2707,7 +2796,8 @@ fn recover_on_unchecked() {
                 Whitespace@8..10 " \n"
                 CheckednessStmt@10..19
                   KwUnchecked@10..19 "unchecked"
-            error at 10..19: expected expression, but found ‘unchecked’"#]],
+            error at 10..19: unexpected token
+            | error for 10..19: expected expression, but found ‘unchecked’"#]],
     );
 }
 
@@ -2792,7 +2882,8 @@ fn parse_loop_stmt_alt_end() {
                   StmtList@5..5
                   EndGroup@5..12
                     KwEndLoop@5..12 "endloop"
-            warn at 5..12: ‘endloop’ found, assuming it to be ’end loop’"#]],
+            warn at 5..12: ‘endloop’ found
+            | warn for 5..12: assuming it to be ’end loop’"#]],
     );
 }
 
@@ -2816,7 +2907,8 @@ fn recover_loop_stmt_missing_tail_loop() {
                   StmtList@15..15
                   EndGroup@15..18
                     KwEnd@15..18 "end"
-            error at 9..14: expected ‘loop’, but found ‘begin’"#]],
+            error at 9..14: unexpected token
+            | error for 9..14: expected ‘loop’, but found ‘begin’"#]],
     );
 }
 
@@ -2838,7 +2930,8 @@ fn recover_just_loop() {
                       EndGroup@11..14
                         KwEnd@11..14 "end"
                   EndGroup@14..14
-            error at 11..14: expected ‘end’ after here"#]],
+            error at 11..14: unexpected end of file
+            | error for 11..14: expected ‘end’ after here"#]],
     );
 }
 
@@ -2866,7 +2959,8 @@ fn recover_on_loop() {
                     KwEnd@15..18 "end"
                     Whitespace@18..19 " "
                     KwLoop@19..23 "loop"
-            error at 10..14: expected expression, but found ‘loop’"#]],
+            error at 10..14: unexpected token
+            | error for 10..14: expected expression, but found ‘loop’"#]],
     );
 }
 
@@ -2910,7 +3004,8 @@ fn recover_exit_stmt_with_when_missing_expr() {
                   KwExit@0..4 "exit"
                   Whitespace@4..5 " "
                   KwWhen@5..9 "when"
-            error at 5..9: expected expression after here"#]],
+            error at 5..9: unexpected end of file
+            | error for 5..9: expected expression after here"#]],
     );
 }
 
@@ -2932,7 +3027,8 @@ fn recover_on_exit() {
                 Whitespace@8..10 " \n"
                 ExitStmt@10..14
                   KwExit@10..14 "exit"
-            error at 10..14: expected expression, but found ‘exit’"#]],
+            error at 10..14: unexpected token
+            | error for 10..14: expected expression, but found ‘exit’"#]],
     );
 }
 
@@ -3019,7 +3115,8 @@ fn parse_for_loop_alt_end() {
                   EndGroup@47..53
                     KwEndFor@47..53 "endfor"
               Whitespace@53..58 "\n    "
-            warn at 47..53: ‘endfor’ found, assuming it to be ’end for’"#]],
+            warn at 47..53: ‘endfor’ found
+            | warn for 47..53: assuming it to be ’end for’"#]],
     );
 }
 
@@ -3238,7 +3335,8 @@ fn recover_for_loop_missing_left_bound() {
                     Whitespace@48..49 " "
                     KwFor@49..52 "for"
               Whitespace@52..57 "\n    "
-            error at 13..15: expected expression, but found ‘..’"#]],
+            error at 13..15: unexpected token
+            | error for 13..15: expected expression, but found ‘..’"#]],
     );
 }
 
@@ -3326,7 +3424,8 @@ fn recover_for_loop_missing_right_bound() {
                     Whitespace@48..49 " "
                     KwFor@49..52 "for"
               Whitespace@52..57 "\n    "
-            error at 26..35: expected expression, but found ‘invariant’"#]],
+            error at 26..35: unexpected token
+            | error for 26..35: expected expression, but found ‘invariant’"#]],
     );
 }
 
@@ -3335,20 +3434,21 @@ fn recover_for_loop_no_bounds() {
     check(
         "for : end for",
         expect![[r#"
-        Source@0..13
-          StmtList@0..13
-            ForStmt@0..13
-              KwFor@0..3 "for"
-              Whitespace@3..4 " "
-              Colon@4..5 ":"
-              Whitespace@5..6 " "
-              ForBounds@6..6
-              StmtList@6..6
-              EndGroup@6..13
-                KwEnd@6..9 "end"
-                Whitespace@9..10 " "
-                KwFor@10..13 "for"
-        error at 6..9: expected expression, but found ‘end’"#]],
+            Source@0..13
+              StmtList@0..13
+                ForStmt@0..13
+                  KwFor@0..3 "for"
+                  Whitespace@3..4 " "
+                  Colon@4..5 ":"
+                  Whitespace@5..6 " "
+                  ForBounds@6..6
+                  StmtList@6..6
+                  EndGroup@6..13
+                    KwEnd@6..9 "end"
+                    Whitespace@9..10 " "
+                    KwFor@10..13 "for"
+            error at 6..9: unexpected token
+            | error for 6..9: expected expression, but found ‘end’"#]],
     );
 }
 
@@ -3357,19 +3457,21 @@ fn recover_for_loop_no_bounds_and_alt_end() {
     check(
         "for : endfor",
         expect![[r#"
-        Source@0..12
-          StmtList@0..12
-            ForStmt@0..12
-              KwFor@0..3 "for"
-              Whitespace@3..4 " "
-              Colon@4..5 ":"
-              Whitespace@5..6 " "
-              ForBounds@6..6
-              StmtList@6..6
-              EndGroup@6..12
-                KwEndFor@6..12 "endfor"
-        error at 6..12: expected expression, but found ‘endfor’
-        warn at 6..12: ‘endfor’ found, assuming it to be ’end for’"#]],
+            Source@0..12
+              StmtList@0..12
+                ForStmt@0..12
+                  KwFor@0..3 "for"
+                  Whitespace@3..4 " "
+                  Colon@4..5 ":"
+                  Whitespace@5..6 " "
+                  ForBounds@6..6
+                  StmtList@6..6
+                  EndGroup@6..12
+                    KwEndFor@6..12 "endfor"
+            error at 6..12: unexpected token
+            | error for 6..12: expected expression, but found ‘endfor’
+            warn at 6..12: ‘endfor’ found
+            | warn for 6..12: assuming it to be ’end for’"#]],
     );
 }
 
@@ -3424,7 +3526,8 @@ fn recover_on_for_loop() {
                     Whitespace@63..64 " "
                     KwFor@64..67 "for"
               Whitespace@67..72 "\n    "
-            error at 18..21: expected expression, but found ‘for’"#]],
+            error at 18..21: unexpected token
+            | error for 18..21: expected expression, but found ‘for’"#]],
     );
 }
 
@@ -3528,7 +3631,8 @@ fn parse_case_stmt_alt_end() {
                     StmtList@35..35
                   EndGroup@35..42
                     KwEndCase@35..42 "endcase"
-            warn at 35..42: ‘endcase’ found, assuming it to be ’end case’"#]],
+            warn at 35..42: ‘endcase’ found
+            | warn for 35..42: assuming it to be ’end case’"#]],
     );
 }
 
@@ -3584,7 +3688,8 @@ fn recover_case_stmt_missing_of() {
                     KwEnd@32..35 "end"
                     Whitespace@35..36 " "
                     KwCase@36..40 "case"
-            error at 20..25: expected ‘of’, but found ‘label’"#]],
+            error at 20..25: unexpected token
+            | error for 20..25: expected ‘of’, but found ‘label’"#]],
     );
 }
 
@@ -3614,7 +3719,8 @@ fn recover_case_stmt_missing_expr() {
                     KwEnd@33..36 "end"
                     Whitespace@36..37 " "
                     KwCase@37..41 "case"
-            error at 10..12: expected expression, but found ‘of’"#]],
+            error at 10..12: unexpected token
+            | error for 10..12: expected expression, but found ‘of’"#]],
     );
 }
 
@@ -3657,7 +3763,8 @@ fn recover_on_case_stmt() {
                     KwEnd@48..51 "end"
                     Whitespace@51..52 " "
                     KwCase@52..56 "case"
-            error at 18..22: expected expression, but found ‘case’"#]],
+            error at 18..22: unexpected token
+            | error for 18..22: expected expression, but found ‘case’"#]],
     );
 }
 
@@ -3852,7 +3959,8 @@ fn recover_bind_decl_missing_name() {
                     NameExpr@8..9
                       Name@8..9
                         Identifier@8..9 "b"
-            error at 5..7: expected identifier, but found ‘to’"#]],
+            error at 5..7: unexpected token
+            | error for 5..7: expected identifier, but found ‘to’"#]],
     );
 }
 
@@ -3874,7 +3982,8 @@ fn recover_bind_decl_missing_to() {
                     NameExpr@7..8
                       Name@7..8
                         Identifier@7..8 "b"
-            error at 7..8: expected ‘to’, but found identifier"#]],
+            error at 7..8: unexpected token
+            | error for 7..8: expected ‘to’, but found identifier"#]],
     );
 }
 
@@ -3894,7 +4003,8 @@ fn recover_bind_decl_missing_binding() {
                       Identifier@5..6 "a"
                     Whitespace@6..7 " "
                     KwTo@7..9 "to"
-            error at 7..9: expected expression after here"#]],
+            error at 7..9: unexpected end of file
+            | error for 7..9: expected expression after here"#]],
     );
 }
 
@@ -3909,7 +4019,8 @@ fn recover_just_bind() {
                 BindDecl@0..4
                   KwBind@0..4 "bind"
                   BindItem@4..4
-            error at 0..4: expected identifier after here"#]],
+            error at 0..4: unexpected end of file
+            | error for 0..4: expected identifier after here"#]],
     );
 }
 
@@ -3942,7 +4053,8 @@ fn recover_on_bind() {
                     NameExpr@20..21
                       Name@20..21
                         Identifier@20..21 "i"
-            error at 10..14: expected expression, but found ‘bind’"#]],
+            error at 10..14: unexpected token
+            | error for 10..14: expected expression, but found ‘bind’"#]],
     );
 }
 
@@ -4134,7 +4246,8 @@ fn recover_proc_decl_missing_name() {
                     KwEnd@40..43 "end"
                     Whitespace@43..44 " "
                     Identifier@44..45 "a"
-            error at 23..29: expected identifier, but found ‘assert’"#]],
+            error at 23..29: unexpected token
+            | error for 23..29: expected identifier, but found ‘assert’"#]],
     );
 }
 
@@ -4165,7 +4278,8 @@ fn recover_proc_decl_missing_tail_name() {
                   Whitespace@37..42 "\n    "
                   EndGroup@42..45
                     KwEnd@42..45 "end"
-            error at 42..45: expected identifier after here"#]],
+            error at 42..45: unexpected end of file
+            | error for 42..45: expected identifier after here"#]],
     );
 }
 
@@ -4208,7 +4322,8 @@ fn recover_on_proc() {
                     KwEnd@55..58 "end"
                     Whitespace@58..59 " "
                     Identifier@59..60 "a"
-            error at 18..27: expected expression, but found ‘procedure’"#]],
+            error at 18..27: unexpected token
+            | error for 18..27: expected expression, but found ‘procedure’"#]],
     );
 }
 
@@ -4574,7 +4689,8 @@ fn recover_fcn_decl_missing_name() {
                     KwEnd@40..43 "end"
                     Whitespace@43..44 " "
                     Identifier@44..45 "a"
-            error at 9..10: expected identifier, but found ‘:’"#]],
+            error at 9..10: unexpected token
+            | error for 9..10: expected identifier, but found ‘:’"#]],
     );
 }
 
@@ -4611,7 +4727,8 @@ fn recover_fcn_decl_missing_tail_name() {
                   Whitespace@37..42 "\n    "
                   EndGroup@42..45
                     KwEnd@42..45 "end"
-            error at 42..45: expected identifier after here"#]],
+            error at 42..45: unexpected end of file
+            | error for 42..45: expected identifier after here"#]],
     );
 }
 
@@ -4647,7 +4764,8 @@ fn recover_fcn_decl_missing_ret_ty() {
                     KwEnd@38..41 "end"
                     Whitespace@41..42 " "
                     Identifier@42..43 "a"
-            error at 21..27: expected type specifier, but found ‘assert’"#]],
+            error at 21..27: unexpected token
+            | error for 21..27: expected type specifier, but found ‘assert’"#]],
     );
 }
 
@@ -4683,7 +4801,8 @@ fn recover_fcn_decl_missing_colon() {
                     KwEnd@40..43 "end"
                     Whitespace@43..44 " "
                     Identifier@44..45 "a"
-            error at 11..14: expected ‘(’, identifier or ‘:’, but found ‘int’"#]],
+            error at 11..14: unexpected token
+            | error for 11..14: expected ‘(’, identifier or ‘:’, but found ‘int’"#]],
     );
 }
 
@@ -4732,7 +4851,8 @@ fn recover_on_fcn() {
                     KwEnd@55..58 "end"
                     Whitespace@58..59 " "
                     Identifier@59..60 "a"
-            error at 18..21: expected expression, but found ‘function’"#]],
+            error at 18..21: unexpected token
+            | error for 18..21: expected expression, but found ‘function’"#]],
     );
 }
 
@@ -4772,7 +4892,8 @@ fn recover_just_pre() {
               StmtList@0..3
                 PreStmt@0..3
                   KwPre@0..3 "pre"
-            error at 0..3: expected expression after here"#]],
+            error at 0..3: unexpected end of file
+            | error for 0..3: expected expression after here"#]],
     );
 }
 
@@ -4797,7 +4918,8 @@ fn recover_on_pre() {
                   Whitespace@13..14 " "
                   LiteralExpr@14..18
                     KwTrue@14..18 "true"
-            error at 10..13: expected expression, but found ‘pre’"#]],
+            error at 10..13: unexpected token
+            | error for 10..13: expected expression, but found ‘pre’"#]],
     );
 }
 
@@ -4837,7 +4959,8 @@ fn recover_just_post() {
               StmtList@0..4
                 PostStmt@0..4
                   KwPost@0..4 "post"
-            error at 0..4: expected expression after here"#]],
+            error at 0..4: unexpected end of file
+            | error for 0..4: expected expression after here"#]],
     );
 }
 
@@ -4862,7 +4985,8 @@ fn recover_on_post() {
                   Whitespace@14..15 " "
                   LiteralExpr@15..19
                     KwTrue@15..19 "true"
-            error at 10..14: expected expression, but found ‘post’"#]],
+            error at 10..14: unexpected token
+            | error for 10..14: expected expression, but found ‘post’"#]],
     );
 }
 
@@ -4905,7 +5029,8 @@ fn parse_init_stmt_alt_asn() {
                     Whitespace@8..9 " "
                     LiteralExpr@9..10
                       IntLiteral@9..10 "1"
-            warn at 7..8: ‘=’ found, assuming it to be ‘:=’"#]],
+            warn at 7..8: ‘=’ found
+            | warn for 7..8: assuming it to be ‘:=’"#]],
     );
 }
 
@@ -4967,7 +5092,8 @@ fn recover_init_stmt_missing_asn() {
                     Whitespace@6..7 " "
                     LiteralExpr@7..8
                       IntLiteral@7..8 "1"
-            error at 7..8: expected ‘:=’, but found int literal"#]],
+            error at 7..8: unexpected token
+            | error for 7..8: expected ‘:=’, but found int literal"#]],
     );
 }
 
@@ -4986,7 +5112,8 @@ fn recover_init_stmt_missing_expr() {
                       Identifier@5..6 "a"
                     Whitespace@6..7 " "
                     Assign@7..9 ":="
-            error at 7..9: expected expression after here"#]],
+            error at 7..9: unexpected end of file
+            | error for 7..9: expected expression after here"#]],
     );
 }
 
@@ -5005,7 +5132,8 @@ fn recover_init_stmt_missing_name() {
                     Whitespace@7..8 " "
                     LiteralExpr@8..9
                       IntLiteral@8..9 "1"
-            error at 5..7: expected identifier, but found ‘:=’"#]],
+            error at 5..7: unexpected token
+            | error for 5..7: expected identifier, but found ‘:=’"#]],
     );
 }
 
@@ -5019,7 +5147,8 @@ fn recover_just_init() {
                 InitStmt@0..4
                   KwInit@0..4 "init"
                   InitVar@4..4
-            error at 0..4: expected identifier after here"#]],
+            error at 0..4: unexpected end of file
+            | error for 0..4: expected identifier after here"#]],
     );
 }
 
@@ -5048,7 +5177,8 @@ fn recover_on_init() {
                     Whitespace@18..19 " "
                     LiteralExpr@19..20
                       IntLiteral@19..20 "1"
-            error at 9..13: expected ‘loop’, but found ‘init’"#]],
+            error at 9..13: unexpected token
+            | error for 9..13: expected ‘loop’, but found ‘init’"#]],
     );
 }
 
@@ -5099,7 +5229,8 @@ fn recover_handler_stmt_missing_name() {
                     KwEnd@18..21 "end"
                     Whitespace@21..22 " "
                     KwHandler@22..29 "handler"
-            error at 9..10: expected identifier, but found ‘)’"#]],
+            error at 9..10: unexpected token
+            | error for 9..10: expected identifier, but found ‘)’"#]],
     );
 }
 
@@ -5125,7 +5256,8 @@ fn recover_handler_stmt_missing_left_paren() {
                     KwEnd@18..21 "end"
                     Whitespace@21..22 " "
                     KwHandler@22..29 "handler"
-            error at 8..9: expected ‘(’, but found identifier"#]],
+            error at 8..9: unexpected token
+            | error for 8..9: expected ‘(’, but found identifier"#]],
     );
 }
 
@@ -5151,7 +5283,8 @@ fn recover_handler_stmt_missing_right_paren() {
                     KwEnd@18..21 "end"
                     Whitespace@21..22 " "
                     KwHandler@22..29 "handler"
-            error at 11..17: expected ‘)’, but found ‘return’"#]],
+            error at 11..17: unexpected token
+            | error for 11..17: expected ‘)’, but found ‘return’"#]],
     );
 }
 
@@ -5173,7 +5306,8 @@ fn recover_handler_stmt_missing_name_portion() {
                     KwEnd@15..18 "end"
                     Whitespace@18..19 " "
                     KwHandler@19..26 "handler"
-            error at 8..14: expected ‘(’, but found ‘return’"#]],
+            error at 8..14: unexpected token
+            | error for 8..14: expected ‘(’, but found ‘return’"#]],
     );
 }
 
@@ -5198,7 +5332,8 @@ fn recover_handler_stmt_missing_tail() {
                   Whitespace@18..19 " "
                   EndGroup@19..22
                     KwEnd@19..22 "end"
-            error at 19..22: expected ‘handler’ after here"#]],
+            error at 19..22: unexpected end of file
+            | error for 19..22: expected ‘handler’ after here"#]],
     );
 }
 
@@ -5213,7 +5348,8 @@ fn recover_just_handler() {
                   KwHandler@0..7 "handler"
                   StmtList@7..7
                   EndGroup@7..7
-            error at 0..7: expected ‘(’ after here"#]],
+            error at 0..7: unexpected end of file
+            | error for 0..7: expected ‘(’ after here"#]],
     );
 }
 
@@ -5246,7 +5382,8 @@ fn recover_on_handler() {
                     KwEnd@22..25 "end"
                     Whitespace@25..26 " "
                     KwHandler@26..33 "handler"
-            error at 10..17: expected expression, but found ‘handler’"#]],
+            error at 10..17: unexpected token
+            | error for 10..17: expected expression, but found ‘handler’"#]],
     );
 }
 
@@ -5353,7 +5490,8 @@ fn recover_quit_stmt_missing_code_expr() {
                   Whitespace@4..5 " "
                   Colon@5..6 ":"
               Whitespace@6..7 " "
-            error at 5..6: expected expression after here"#]],
+            error at 5..6: unexpected end of file
+            | error for 5..6: expected expression after here"#]],
     );
 }
 
@@ -5375,7 +5513,8 @@ fn recover_on_quit() {
                 Whitespace@8..10 " \n"
                 QuitStmt@10..14
                   KwQuit@10..14 "quit"
-            error at 10..14: expected expression, but found ‘quit’"#]],
+            error at 10..14: unexpected token
+            | error for 10..14: expected expression, but found ‘quit’"#]],
     );
 }
 
@@ -5420,7 +5559,8 @@ fn recover_tag_stmt_missing_tag_val() {
                       Identifier@4..5 "a"
                   Comma@5..6 ","
               Whitespace@6..7 " "
-            error at 5..6: expected expression after here"#]],
+            error at 5..6: unexpected end of file
+            | error for 5..6: expected expression after here"#]],
     );
 }
 
@@ -5440,7 +5580,8 @@ fn recover_tag_stmt_missing_tag_comma() {
                   Whitespace@5..6 " "
                   LiteralExpr@6..7
                     IntLiteral@6..7 "1"
-            error at 6..7: expected ‘,’, but found int literal"#]],
+            error at 6..7: unexpected token
+            | error for 6..7: expected ‘,’, but found int literal"#]],
     );
 }
 
@@ -5458,7 +5599,8 @@ fn recover_tag_stmt_missing_ref() {
                   Whitespace@5..6 " "
                   LiteralExpr@6..7
                     IntLiteral@6..7 "1"
-            error at 4..5: expected expression, but found ‘,’"#]],
+            error at 4..5: unexpected token
+            | error for 4..5: expected expression, but found ‘,’"#]],
     );
 }
 
@@ -5471,7 +5613,8 @@ fn recover_just_tag() {
               StmtList@0..3
                 TagStmt@0..3
                   KwTag@0..3 "tag"
-            error at 0..3: expected expression after here"#]],
+            error at 0..3: unexpected end of file
+            | error for 0..3: expected expression after here"#]],
     );
 }
 
@@ -5501,7 +5644,8 @@ fn recover_on_tag() {
                   Whitespace@16..17 " "
                   LiteralExpr@17..18
                     IntLiteral@17..18 "1"
-            error at 10..13: expected expression, but found ‘tag’"#]],
+            error at 10..13: unexpected token
+            | error for 10..13: expected expression, but found ‘tag’"#]],
     );
 }
 
@@ -5684,7 +5828,8 @@ fn recover_fork_stmt_process_ref_missing_ref() {
                   Comma@17..18 ","
                   Whitespace@18..19 " "
                   ProcessDesc@19..19
-            error at 17..18: expected expression after here"#]],
+            error at 17..18: unexpected end of file
+            | error for 17..18: expected expression after here"#]],
     );
 }
 
@@ -5717,7 +5862,8 @@ fn recover_fork_stmt_process_ref_missing_stack_size_expr() {
                     NameExpr@17..18
                       Name@17..18
                         Identifier@17..18 "a"
-            error at 15..16: expected expression, but found ‘,’"#]],
+            error at 15..16: unexpected token
+            | error for 15..16: expected expression, but found ‘,’"#]],
     );
 }
 
@@ -5747,8 +5893,10 @@ fn recover_fork_stmt_process_ref_missing_stat_ref() {
                     NameExpr@13..14
                       Name@13..14
                         Identifier@13..14 "a"
-            error at 9..10: expected expression, but found ‘,’
-            error at 11..12: expected expression, but found ‘,’"#]],
+            error at 9..10: unexpected token
+            | error for 9..10: expected expression, but found ‘,’
+            error at 11..12: unexpected token
+            | error for 11..12: expected expression, but found ‘,’"#]],
     );
 }
 
@@ -5761,7 +5909,8 @@ fn recover_just_fork() {
               StmtList@0..4
                 ForkStmt@0..4
                   KwFork@0..4 "fork"
-            error at 0..4: expected expression after here"#]],
+            error at 0..4: unexpected end of file
+            | error for 0..4: expected expression after here"#]],
     );
 }
 
@@ -5787,7 +5936,8 @@ fn recover_on_fork() {
                   NameExpr@15..16
                     Name@15..16
                       Identifier@15..16 "a"
-            error at 10..14: expected expression, but found ‘fork’"#]],
+            error at 10..14: unexpected token
+            | error for 10..14: expected expression, but found ‘fork’"#]],
     );
 }
 
@@ -5873,7 +6023,8 @@ fn recover_just_new() {
                 NewStmt@0..3
                   KwNew@0..3 "new"
                   ExprList@3..3
-            error at 0..3: expected expression after here"#]],
+            error at 0..3: unexpected end of file
+            | error for 0..3: expected expression after here"#]],
     );
 }
 
@@ -5900,7 +6051,8 @@ fn recover_on_new() {
                     NameExpr@14..15
                       Name@14..15
                         Identifier@14..15 "a"
-            error at 10..13: expected expression, but found ‘new’"#]],
+            error at 10..13: unexpected token
+            | error for 10..13: expected expression, but found ‘new’"#]],
     );
 }
 
@@ -5987,7 +6139,8 @@ fn recover_just_free() {
                 FreeStmt@0..4
                   KwFree@0..4 "free"
                   ExprList@4..4
-            error at 0..4: expected expression after here"#]],
+            error at 0..4: unexpected end of file
+            | error for 0..4: expected expression after here"#]],
     );
 }
 
@@ -6014,7 +6167,8 @@ fn recover_on_free() {
                     NameExpr@15..16
                       Name@15..16
                         Identifier@15..16 "a"
-            error at 10..14: expected expression, but found ‘free’"#]],
+            error at 10..14: unexpected token
+            | error for 10..14: expected expression, but found ‘free’"#]],
     );
 }
 
@@ -6075,7 +6229,8 @@ fn recover_just_deferred() {
               StmtList@0..8
                 Error@0..8
                   KwDeferred@0..8 "deferred"
-            error at 0..8: expected ‘function’ or ‘procedure’ after here"#]],
+            error at 0..8: unexpected end of file
+            | error for 0..8: expected ‘function’ or ‘procedure’ after here"#]],
     );
 }
 
@@ -6106,7 +6261,8 @@ fn recover_on_deferred() {
                     Whitespace@32..33 " "
                     Name@33..34
                       Identifier@33..34 "a"
-            error at 19..27: expected expression, but found ‘deferred’"#]],
+            error at 19..27: unexpected token
+            | error for 19..27: expected expression, but found ‘deferred’"#]],
     );
 }
 
@@ -6231,7 +6387,8 @@ fn recover_forward_decl_missing_import_name() {
                   ImportList@21..21
                     ImportItem@21..21
                       ExternalItem@21..21
-            error at 15..21: expected string literal or identifier after here"#]],
+            error at 15..21: unexpected end of file
+            | error for 15..21: expected string literal or identifier after here"#]],
     );
 }
 
@@ -6244,7 +6401,8 @@ fn recover_just_forward() {
               StmtList@0..7
                 Error@0..7
                   KwForward@0..7 "forward"
-            error at 0..7: expected ‘function’ or ‘procedure’ after here"#]],
+            error at 0..7: unexpected end of file
+            | error for 0..7: expected ‘function’ or ‘procedure’ after here"#]],
     );
 }
 
@@ -6275,7 +6433,8 @@ fn recover_on_forward() {
                     Whitespace@31..32 " "
                     Name@32..33
                       Identifier@32..33 "a"
-            error at 19..26: expected expression, but found ‘forward’"#]],
+            error at 19..26: unexpected token
+            | error for 19..26: expected expression, but found ‘forward’"#]],
     );
 }
 
@@ -6708,7 +6867,8 @@ fn recover_body_plain_missing_name() {
                     KwEnd@15..18 "end"
                     Whitespace@18..19 " "
                     Identifier@19..20 "a"
-            error at 5..6: expected ‘function’, ‘procedure’ or identifier, but found ‘(’"#]],
+            error at 5..6: unexpected token
+            | error for 5..6: expected ‘function’, ‘procedure’ or identifier, but found ‘(’"#]],
     );
 }
 
@@ -6724,7 +6884,8 @@ fn recover_just_body() {
                   PlainHeader@4..4
                   StmtList@4..4
                   EndGroup@4..4
-            error at 0..4: expected ‘function’, ‘procedure’ or identifier after here"#]],
+            error at 0..4: unexpected end of file
+            | error for 0..4: expected ‘function’, ‘procedure’ or identifier after here"#]],
     );
 }
 
@@ -6760,7 +6921,8 @@ fn recover_on_body() {
                     KwEnd@29..32 "end"
                     Whitespace@32..33 " "
                     Identifier@33..34 "a"
-            error at 18..22: expected expression, but found ‘body’"#]],
+            error at 18..22: unexpected token
+            | error for 18..22: expected expression, but found ‘body’"#]],
     );
 }
 
@@ -6947,7 +7109,8 @@ fn recover_module_decl_double_implement() {
                     KwEnd@33..36 "end"
                     Whitespace@36..37 " "
                     Identifier@37..38 "a"
-            error at 31..32: expected ‘by’, but found identifier"#]],
+            error at 31..32: unexpected token
+            | error for 31..32: expected ‘by’, but found identifier"#]],
     );
 }
 
@@ -7139,8 +7302,10 @@ fn recover_module_decl_double_post() {
                   NameExpr@27..28
                     Name@27..28
                       Identifier@27..28 "a"
-            error at 16..20: expected ‘end’, but found ‘post’
-            error at 23..26: expected statement, but found ‘end’"#]],
+            error at 16..20: unexpected token
+            | error for 16..20: expected ‘end’, but found ‘post’
+            error at 23..26: unexpected token
+            | error for 23..26: expected statement, but found ‘end’"#]],
     );
 }
 
@@ -7159,7 +7324,8 @@ fn recover_module_decl_missing_name() {
                     KwEnd@7..10 "end"
                     Whitespace@10..11 " "
                     Identifier@11..12 "a"
-            error at 7..10: expected identifier, but found ‘end’"#]],
+            error at 7..10: unexpected token
+            | error for 7..10: expected identifier, but found ‘end’"#]],
     );
 }
 
@@ -7179,7 +7345,8 @@ fn recover_module_decl_missing_tail_name() {
                   StmtList@9..9
                   EndGroup@9..12
                     KwEnd@9..12 "end"
-            error at 9..12: expected identifier after here"#]],
+            error at 9..12: unexpected end of file
+            | error for 9..12: expected identifier after here"#]],
     );
 }
 
@@ -7194,7 +7361,8 @@ fn recover_just_module() {
                   KwModule@0..6 "module"
                   StmtList@6..6
                   EndGroup@6..6
-            error at 0..6: expected identifier after here"#]],
+            error at 0..6: unexpected end of file
+            | error for 0..6: expected identifier after here"#]],
     );
 }
 
@@ -7225,7 +7393,8 @@ fn recover_on_module() {
                     KwEnd@19..22 "end"
                     Whitespace@22..23 " "
                     Identifier@23..24 "a"
-            error at 10..16: expected expression, but found ‘module’"#]],
+            error at 10..16: unexpected token
+            | error for 10..16: expected expression, but found ‘module’"#]],
     );
 }
 
@@ -7317,7 +7486,8 @@ fn recover_class_decl_missing_name() {
                     KwEnd@6..9 "end"
                     Whitespace@9..10 " "
                     Identifier@10..11 "a"
-            error at 6..9: expected identifier, but found ‘end’"#]],
+            error at 6..9: unexpected token
+            | error for 6..9: expected identifier, but found ‘end’"#]],
     );
 }
 
@@ -7337,7 +7507,8 @@ fn recover_class_decl_missing_tail_name() {
                   StmtList@8..8
                   EndGroup@8..11
                     KwEnd@8..11 "end"
-            error at 8..11: expected identifier after here"#]],
+            error at 8..11: unexpected end of file
+            | error for 8..11: expected identifier after here"#]],
     );
 }
 
@@ -7352,7 +7523,8 @@ fn recover_just_class() {
                   KwClass@0..5 "class"
                   StmtList@5..5
                   EndGroup@5..5
-            error at 0..5: expected identifier after here"#]],
+            error at 0..5: unexpected end of file
+            | error for 0..5: expected identifier after here"#]],
     );
 }
 
@@ -7383,7 +7555,8 @@ fn recover_on_class() {
                     KwEnd@18..21 "end"
                     Whitespace@21..22 " "
                     Identifier@22..23 "a"
-            error at 10..15: expected expression, but found ‘class’"#]],
+            error at 10..15: unexpected token
+            | error for 10..15: expected expression, but found ‘class’"#]],
     );
 }
 
@@ -7486,7 +7659,8 @@ fn recover_monitor_decl_missing_dev_spec_expr() {
                     KwEnd@12..15 "end"
                     Whitespace@15..16 " "
                     Identifier@16..17 "a"
-            error at 12..15: expected expression, but found ‘end’"#]],
+            error at 12..15: unexpected token
+            | error for 12..15: expected expression, but found ‘end’"#]],
     );
 }
 
@@ -7505,7 +7679,8 @@ fn recover_monitor_decl_missing_name() {
                     KwEnd@8..11 "end"
                     Whitespace@11..12 " "
                     Identifier@12..13 "a"
-            error at 8..11: expected identifier, but found ‘end’"#]],
+            error at 8..11: unexpected token
+            | error for 8..11: expected identifier, but found ‘end’"#]],
     );
 }
 
@@ -7525,7 +7700,8 @@ fn recover_monitor_decl_missing_tail_name() {
                   StmtList@10..10
                   EndGroup@10..13
                     KwEnd@10..13 "end"
-            error at 10..13: expected identifier after here"#]],
+            error at 10..13: unexpected end of file
+            | error for 10..13: expected identifier after here"#]],
     );
 }
 
@@ -7540,7 +7716,8 @@ fn recover_just_monitor() {
                   KwMonitor@0..7 "monitor"
                   StmtList@7..7
                   EndGroup@7..7
-            error at 0..7: expected identifier after here"#]],
+            error at 0..7: unexpected end of file
+            | error for 0..7: expected identifier after here"#]],
     );
 }
 
@@ -7571,7 +7748,8 @@ fn recover_on_monitor() {
                     KwEnd@20..23 "end"
                     Whitespace@23..24 " "
                     Identifier@24..25 "a"
-            error at 10..17: expected expression, but found ‘monitor’"#]],
+            error at 10..17: unexpected token
+            | error for 10..17: expected expression, but found ‘monitor’"#]],
     );
 }
 
@@ -7725,7 +7903,8 @@ fn parse_process_decl() {
                     KwEnd@40..43 "end"
                     Whitespace@43..44 " "
                     Identifier@44..45 "a"
-            error at 17..18: expected ‘,’ or ‘:’, but found ‘)’"#]],
+            error at 17..18: unexpected token
+            | error for 17..18: expected ‘,’ or ‘:’, but found ‘)’"#]],
     );
 }
 
@@ -7777,7 +7956,8 @@ fn parse_process_decl_opt_stack_size() {
                     KwEnd@48..51 "end"
                     Whitespace@51..52 " "
                     Identifier@52..53 "a"
-            error at 17..18: expected ‘,’ or ‘:’, but found ‘)’"#]],
+            error at 17..18: unexpected token
+            | error for 17..18: expected ‘,’ or ‘:’, but found ‘)’"#]],
     );
 }
 
@@ -7862,7 +8042,8 @@ fn recover_process_decl_missing_stack_size_expr() {
                     KwEnd@21..24 "end"
                     Whitespace@24..25 " "
                     Identifier@25..26 "a"
-            error at 21..24: expected expression, but found ‘end’"#]],
+            error at 21..24: unexpected token
+            | error for 21..24: expected expression, but found ‘end’"#]],
     );
 }
 
@@ -7884,7 +8065,8 @@ fn recover_process_decl_missing_name() {
                     KwEnd@17..20 "end"
                     Whitespace@20..21 " "
                     Identifier@21..22 "a"
-            error at 17..20: expected identifier, but found ‘end’"#]],
+            error at 17..20: unexpected token
+            | error for 17..20: expected identifier, but found ‘end’"#]],
     );
 }
 
@@ -7907,7 +8089,8 @@ fn recover_process_decl_missing_tail_name() {
                   StmtList@19..19
                   EndGroup@19..22
                     KwEnd@19..22 "end"
-            error at 19..22: expected identifier after here"#]],
+            error at 19..22: unexpected end of file
+            | error for 19..22: expected identifier after here"#]],
     );
 }
 
@@ -7922,7 +8105,8 @@ fn recover_just_process() {
                   KwProcess@0..7 "process"
                   StmtList@7..7
                   EndGroup@7..7
-            error at 0..7: expected identifier after here"#]],
+            error at 0..7: unexpected end of file
+            | error for 0..7: expected identifier after here"#]],
     );
 }
 
@@ -7957,7 +8141,8 @@ fn recover_on_process() {
                     KwEnd@32..35 "end"
                     Whitespace@35..36 " "
                     Identifier@36..37 "a"
-            error at 18..25: expected expression, but found ‘process’"#]],
+            error at 18..25: unexpected token
+            | error for 18..25: expected expression, but found ‘process’"#]],
     );
 }
 
@@ -8155,7 +8340,8 @@ fn parse_external_var_alt_init() {
                     Whitespace@26..27 " "
                     LiteralExpr@27..28
                       IntLiteral@27..28 "1"
-            warn at 25..26: ‘=’ found, assuming it to be ‘:=’"#]],
+            warn at 25..26: ‘=’ found
+            | warn for 25..26: assuming it to be ‘:=’"#]],
     );
 }
 
@@ -8265,7 +8451,8 @@ fn recover_external_var_bare() {
                     Whitespace@22..23 " "
                     Name@23..24
                       Identifier@23..24 "a"
-            error at 23..24: expected ‘:’ or ‘:=’ after here"#]],
+            error at 23..24: unexpected end of file
+            | error for 23..24: expected ‘:’ or ‘:=’ after here"#]],
     );
 }
 
@@ -8296,7 +8483,8 @@ fn recover_external_on_const() {
                   Whitespace@25..26 " "
                   LiteralExpr@26..27
                     IntLiteral@26..27 "1"
-            error at 9..14: expected ‘function’, ‘procedure’ or ‘var’, but found ‘const’"#]],
+            error at 9..14: unexpected token
+            | error for 9..14: expected ‘function’, ‘procedure’ or ‘var’, but found ‘const’"#]],
     );
 }
 
@@ -8309,7 +8497,8 @@ fn recover_just_external() {
               StmtList@0..8
                 ExternalDecl@0..8
                   KwExternal@0..8 "external"
-            error at 0..8: expected ‘function’, ‘procedure’ or ‘var’ after here"#]],
+            error at 0..8: unexpected end of file
+            | error for 0..8: expected ‘function’, ‘procedure’ or ‘var’ after here"#]],
     );
 }
 
@@ -8337,8 +8526,10 @@ fn recover_on_external() {
                     Whitespace@22..23 " "
                     Name@23..24
                       Identifier@23..24 "i"
-            error at 10..18: expected expression, but found ‘external’
-            error at 23..24: expected ‘:’ or ‘:=’ after here"#]],
+            error at 10..18: unexpected token
+            | error for 10..18: expected expression, but found ‘external’
+            error at 23..24: unexpected end of file
+            | error for 23..24: expected ‘:’ or ‘:=’ after here"#]],
     );
 }
 
@@ -8407,7 +8598,8 @@ fn recover_inherit_stmt_missing_left_paren() {
                       Identifier@8..9 "p"
                 Error@9..10
                   RightParen@9..10 ")"
-            error at 9..10: expected statement, but found ‘)’"#]],
+            error at 9..10: unexpected token
+            | error for 9..10: expected statement, but found ‘)’"#]],
     );
 }
 
@@ -8425,7 +8617,8 @@ fn recover_inherit_stmt_missing_right_paren() {
                   ExternalItem@9..10
                     Name@9..10
                       Identifier@9..10 "p"
-            error at 9..10: expected ‘in’ or ‘)’ after here"#]],
+            error at 9..10: unexpected end of file
+            | error for 9..10: expected ‘in’ or ‘)’ after here"#]],
     );
 }
 
@@ -8442,7 +8635,8 @@ fn recover_inherit_just_parens() {
                   LeftParen@8..9 "("
                   ExternalItem@9..9
                   RightParen@9..10 ")"
-            error at 9..10: expected string literal or identifier, but found ‘)’"#]],
+            error at 9..10: unexpected token
+            | error for 9..10: expected string literal or identifier, but found ‘)’"#]],
     );
 }
 
@@ -8456,7 +8650,8 @@ fn recover_just_inherit() {
                 InheritStmt@0..7
                   KwInherit@0..7 "inherit"
                   ExternalItem@7..7
-            error at 0..7: expected string literal or identifier after here"#]],
+            error at 0..7: unexpected end of file
+            | error for 0..7: expected string literal or identifier after here"#]],
     );
 }
 
@@ -8482,7 +8677,8 @@ fn recover_on_inherit() {
                   ExternalItem@17..18
                     Name@17..18
                       Identifier@17..18 "p"
-            error at 9..16: expected expression, but found ‘inherit’"#]],
+            error at 9..16: unexpected token
+            | error for 9..16: expected expression, but found ‘inherit’"#]],
     );
 }
 
@@ -8571,7 +8767,8 @@ fn recover_implement_just_parens() {
                   LeftParen@10..11 "("
                   ExternalItem@11..11
                   RightParen@11..12 ")"
-            error at 11..12: expected string literal or identifier, but found ‘)’"#]],
+            error at 11..12: unexpected token
+            | error for 11..12: expected string literal or identifier, but found ‘)’"#]],
     );
 }
 
@@ -8590,7 +8787,8 @@ fn recover_implement_by_just_parens() {
                   LeftParen@13..14 "("
                   ExternalItem@14..14
                   RightParen@14..15 ")"
-            error at 14..15: expected string literal or identifier, but found ‘)’"#]],
+            error at 14..15: unexpected token
+            | error for 14..15: expected string literal or identifier, but found ‘)’"#]],
     );
 }
 
@@ -8604,7 +8802,8 @@ fn recover_just_implement() {
                 ImplementStmt@0..9
                   KwImplement@0..9 "implement"
                   ExternalItem@9..9
-            error at 0..9: expected ‘by’, string literal or identifier after here"#]],
+            error at 0..9: unexpected end of file
+            | error for 0..9: expected ‘by’, string literal or identifier after here"#]],
     );
 }
 
@@ -8630,7 +8829,8 @@ fn recover_on_implement() {
                   ExternalItem@19..20
                     Name@19..20
                       Identifier@19..20 "p"
-            error at 9..18: expected expression, but found ‘implement’"#]],
+            error at 9..18: unexpected token
+            | error for 9..18: expected expression, but found ‘implement’"#]],
     );
 }
 
@@ -8797,7 +8997,8 @@ fn recover_import_stmt_missing_name_after_attr() {
                       KwVar@7..10 "var"
                     ExternalItem@10..10
               StmtList@10..10
-            error at 7..10: expected string literal or identifier after here"#]],
+            error at 7..10: unexpected end of file
+            | error for 7..10: expected string literal or identifier after here"#]],
     );
 }
 
@@ -8813,7 +9014,8 @@ fn recover_just_import() {
                   ImportItem@6..6
                     ExternalItem@6..6
               StmtList@6..6
-            error at 0..6: expected string literal or identifier after here"#]],
+            error at 0..6: unexpected end of file
+            | error for 0..6: expected string literal or identifier after here"#]],
     );
 }
 
@@ -8838,7 +9040,8 @@ fn recover_on_import() {
                   Whitespace@16..17 " "
                   LeftParen@17..18 "("
                   RightParen@18..19 ")"
-            error at 10..16: expected expression, but found ‘import’"#]],
+            error at 10..16: unexpected token
+            | error for 10..16: expected expression, but found ‘import’"#]],
     );
 }
 
@@ -9026,7 +9229,8 @@ fn recover_export_stmt_missing_dot_after_not() {
                       Tilde@7..8 "~"
                     Name@8..9
                       Identifier@8..9 "i"
-            error at 8..9: expected ‘.’, but found identifier"#]],
+            error at 8..9: unexpected token
+            | error for 8..9: expected ‘.’, but found identifier"#]],
     );
 }
 
@@ -9040,7 +9244,8 @@ fn recover_just_export() {
                 ExportStmt@0..6
                   KwExport@0..6 "export"
                   ExportItem@6..6
-            error at 0..6: expected ‘all’ or identifier after here"#]],
+            error at 0..6: unexpected end of file
+            | error for 0..6: expected ‘all’ or identifier after here"#]],
     );
 }
 
@@ -9065,7 +9270,8 @@ fn recover_on_export() {
                   Whitespace@16..17 " "
                   LeftParen@17..18 "("
                   RightParen@18..19 ")"
-            error at 10..16: expected expression, but found ‘export’"#]],
+            error at 10..16: unexpected token
+            | error for 10..16: expected expression, but found ‘export’"#]],
     );
 }
 
@@ -9097,7 +9303,8 @@ fn recover_just_include() {
                 PreprocGlob@0..7
                   PPInclude@0..7
                     KwInclude@0..7 "include"
-            error at 0..7: expected string literal after here"#]],
+            error at 0..7: unexpected end of file
+            | error for 0..7: expected string literal after here"#]],
     );
 }
 
@@ -9120,8 +9327,10 @@ fn recover_on_include() {
                         LiteralExpr@12..24
                           StringLiteral@12..24 "\"still_here\""
                   EndGroup@24..24
-            error at 4..11: expected identifier or ‘:’, but found ‘include’
-            error at 12..24: expected ‘end’ after here"#]],
+            error at 4..11: unexpected token
+            | error for 4..11: expected identifier or ‘:’, but found ‘include’
+            error at 12..24: unexpected end of file
+            | error for 12..24: expected ‘end’ after here"#]],
     )
 }
 
@@ -9151,8 +9360,10 @@ fn recover_many_units() {
                 Whitespace@9..10 " "
                 Error@10..14
                   KwUnit@10..14 "unit"
-            error at 5..9: expected statement, but found ‘unit’
-            error at 10..14: expected statement, but found ‘unit’"#]],
+            error at 5..9: unexpected token
+            | error for 5..9: expected statement, but found ‘unit’
+            error at 10..14: unexpected token
+            | error for 10..14: expected statement, but found ‘unit’"#]],
     );
 }
 
@@ -9222,7 +9433,8 @@ fn recover_tell_stmt_missing_file_ref() {
                   NameExpr@9..10
                     Name@9..10
                       Identifier@9..10 "a"
-            error at 7..8: expected expression, but found ‘,’"#]],
+            error at 7..8: unexpected token
+            | error for 7..8: expected expression, but found ‘,’"#]],
     );
 }
 
@@ -9244,7 +9456,8 @@ fn recover_tell_stmt_missing_tell_dest() {
                         Identifier@7..8 "a"
                   Comma@8..9 ","
               Whitespace@9..10 " "
-            error at 8..9: expected expression after here"#]],
+            error at 8..9: unexpected end of file
+            | error for 8..9: expected expression after here"#]],
     );
 }
 
@@ -9257,7 +9470,8 @@ fn recover_just_tell() {
               StmtList@0..4
                 TellStmt@0..4
                   KwTell@0..4 "tell"
-            error at 0..4: expected ‘:’ after here"#]],
+            error at 0..4: unexpected end of file
+            | error for 0..4: expected ‘:’ after here"#]],
     );
 }
 
@@ -9291,7 +9505,8 @@ fn recover_on_tell() {
                   NameExpr@20..21
                     Name@20..21
                       Identifier@20..21 "b"
-            error at 10..14: expected expression, but found ‘tell’"#]],
+            error at 10..14: unexpected token
+            | error for 10..14: expected expression, but found ‘tell’"#]],
     );
 }
 
@@ -9365,7 +9580,8 @@ fn recover_seek_stmt_missing_file_ref() {
                   NameExpr@9..10
                     Name@9..10
                       Identifier@9..10 "a"
-            error at 7..8: expected expression, but found ‘,’"#]],
+            error at 7..8: unexpected token
+            | error for 7..8: expected expression, but found ‘,’"#]],
     );
 }
 
@@ -9387,7 +9603,8 @@ fn recover_seek_stmt_missing_to_expr() {
                         Identifier@7..8 "a"
                   Comma@8..9 ","
               Whitespace@9..10 " "
-            error at 8..9: expected expression after here"#]],
+            error at 8..9: unexpected end of file
+            | error for 8..9: expected expression after here"#]],
     );
 }
 
@@ -9400,7 +9617,8 @@ fn recover_just_seek() {
               StmtList@0..4
                 SeekStmt@0..4
                   KwSeek@0..4 "seek"
-            error at 0..4: expected ‘:’ after here"#]],
+            error at 0..4: unexpected end of file
+            | error for 0..4: expected ‘:’ after here"#]],
     );
 }
 
@@ -9434,7 +9652,8 @@ fn recover_on_seek() {
                   NameExpr@20..21
                     Name@20..21
                       Identifier@20..21 "b"
-            error at 10..14: expected expression, but found ‘seek’"#]],
+            error at 10..14: unexpected token
+            | error for 10..14: expected expression, but found ‘seek’"#]],
     );
 }
 
@@ -9623,7 +9842,8 @@ fn recover_read_stmt_missing_actual_sz_expr() {
                       NameExpr@27..28
                         Name@27..28
                           Identifier@27..28 "b"
-            error at 25..26: expected expression, but found ‘,’"#]],
+            error at 25..26: unexpected token
+            | error for 25..26: expected expression, but found ‘,’"#]],
     );
 }
 
@@ -9666,7 +9886,8 @@ fn recover_read_stmt_missing_req_sz_expr() {
                       NameExpr@24..25
                         Name@24..25
                           Identifier@24..25 "b"
-            error at 18..19: expected expression, but found ‘:’"#]],
+            error at 18..19: unexpected token
+            | error for 18..19: expected expression, but found ‘:’"#]],
     );
 }
 
@@ -9709,7 +9930,8 @@ fn recover_read_stmt_missing_item_data_expr() {
                       NameExpr@26..27
                         Name@26..27
                           Identifier@26..27 "b"
-            error at 14..15: expected expression, but found ‘:’"#]],
+            error at 14..15: unexpected token
+            | error for 14..15: expected expression, but found ‘:’"#]],
     );
 }
 
@@ -9759,7 +9981,8 @@ fn recover_read_stmt_missing_sts_ref() {
                       NameExpr@30..31
                         Name@30..31
                           Identifier@30..31 "b"
-            error at 14..15: expected expression, but found ‘,’"#]],
+            error at 14..15: unexpected token
+            | error for 14..15: expected expression, but found ‘,’"#]],
     );
 }
 
@@ -9808,7 +10031,8 @@ fn recover_read_stmt_missing_file_ref() {
                       NameExpr@28..29
                         Name@28..29
                           Identifier@28..29 "b"
-            error at 7..8: expected expression, but found ‘:’"#]],
+            error at 7..8: unexpected token
+            | error for 7..8: expected expression, but found ‘:’"#]],
     );
 }
 
@@ -9823,7 +10047,8 @@ fn recover_just_read() {
                   KwRead@0..4 "read"
                   BinaryIO@4..4
                     BinaryItem@4..4
-            error at 0..4: expected ‘:’ after here"#]],
+            error at 0..4: unexpected end of file
+            | error for 0..4: expected ‘:’ after here"#]],
     );
 }
 
@@ -9859,7 +10084,8 @@ fn recover_on_read() {
                       NameExpr@20..21
                         Name@20..21
                           Identifier@20..21 "b"
-            error at 10..14: expected expression, but found ‘read’"#]],
+            error at 10..14: unexpected token
+            | error for 10..14: expected expression, but found ‘read’"#]],
     );
 }
 
@@ -10048,7 +10274,8 @@ fn recover_write_stmt_missing_actual_sz_expr() {
                       NameExpr@28..29
                         Name@28..29
                           Identifier@28..29 "b"
-            error at 26..27: expected expression, but found ‘,’"#]],
+            error at 26..27: unexpected token
+            | error for 26..27: expected expression, but found ‘,’"#]],
     );
 }
 
@@ -10091,7 +10318,8 @@ fn recover_write_stmt_missing_req_sz_expr() {
                       NameExpr@25..26
                         Name@25..26
                           Identifier@25..26 "b"
-            error at 19..20: expected expression, but found ‘:’"#]],
+            error at 19..20: unexpected token
+            | error for 19..20: expected expression, but found ‘:’"#]],
     );
 }
 
@@ -10134,7 +10362,8 @@ fn recover_write_stmt_missing_item_data_expr() {
                       NameExpr@27..28
                         Name@27..28
                           Identifier@27..28 "b"
-            error at 15..16: expected expression, but found ‘:’"#]],
+            error at 15..16: unexpected token
+            | error for 15..16: expected expression, but found ‘:’"#]],
     );
 }
 
@@ -10184,7 +10413,8 @@ fn recover_write_stmt_missing_sts_ref() {
                       NameExpr@31..32
                         Name@31..32
                           Identifier@31..32 "b"
-            error at 15..16: expected expression, but found ‘,’"#]],
+            error at 15..16: unexpected token
+            | error for 15..16: expected expression, but found ‘,’"#]],
     );
 }
 
@@ -10233,7 +10463,8 @@ fn recover_write_stmt_missing_file_ref() {
                       NameExpr@29..30
                         Name@29..30
                           Identifier@29..30 "b"
-            error at 8..9: expected expression, but found ‘:’"#]],
+            error at 8..9: unexpected token
+            | error for 8..9: expected expression, but found ‘:’"#]],
     );
 }
 
@@ -10248,7 +10479,8 @@ fn recover_just_write() {
                   KwWrite@0..5 "write"
                   BinaryIO@5..5
                     BinaryItem@5..5
-            error at 0..5: expected ‘:’ after here"#]],
+            error at 0..5: unexpected end of file
+            | error for 0..5: expected ‘:’ after here"#]],
     );
 }
 
@@ -10284,7 +10516,8 @@ fn recover_on_write() {
                       NameExpr@21..22
                         Name@21..22
                           Identifier@21..22 "b"
-            error at 10..15: expected expression, but found ‘write’"#]],
+            error at 10..15: unexpected token
+            | error for 10..15: expected expression, but found ‘write’"#]],
     );
 }
 
@@ -10342,9 +10575,12 @@ fn recover_old_open_missing_left_paren() {
                       StringLiteral@19..24 "\"rw+\""
                 Error@24..25
                   RightParen@24..25 ")"
-            error at 5..6: expected ‘(’ or ‘:’, but found identifier
-            error at 19..24: expected ‘get’, ‘put’, ‘read’, ‘write’, ‘seek’ or ‘mod’, but found string literal
-            error at 24..25: expected statement, but found ‘)’"#]],
+            error at 5..6: unexpected token
+            | error for 5..6: expected ‘(’ or ‘:’, but found identifier
+            error at 19..24: unexpected token
+            | error for 19..24: expected ‘get’, ‘put’, ‘read’, ‘write’, ‘seek’ or ‘mod’, but found string literal
+            error at 24..25: unexpected token
+            | error for 24..25: expected statement, but found ‘)’"#]],
     );
 }
 
@@ -10371,7 +10607,8 @@ fn recover_old_open_missing_file_ref() {
                       LiteralExpr@19..24
                         StringLiteral@19..24 "\"rw+\""
                     RightParen@24..25 ")"
-            error at 6..7: expected expression, but found ‘,’"#]],
+            error at 6..7: unexpected token
+            | error for 6..7: expected expression, but found ‘,’"#]],
     );
 }
 
@@ -10398,7 +10635,8 @@ fn recover_old_open_missing_path() {
                       LiteralExpr@11..16
                         StringLiteral@11..16 "\"rw+\""
                     RightParen@16..17 ")"
-            error at 9..10: expected expression, but found ‘,’"#]],
+            error at 9..10: unexpected token
+            | error for 9..10: expected expression, but found ‘,’"#]],
     );
 }
 
@@ -10454,7 +10692,8 @@ fn recover_old_open_missing_mode() {
                     Comma@18..19 ","
                     Whitespace@19..20 " "
                     RightParen@20..21 ")"
-            error at 20..21: expected expression, but found ‘)’"#]],
+            error at 20..21: unexpected token
+            | error for 20..21: expected expression, but found ‘)’"#]],
     );
 }
 
@@ -10483,7 +10722,8 @@ fn recover_old_open_missing_right_paren() {
                     OpenMode@20..25
                       LiteralExpr@20..25
                         StringLiteral@20..25 "\"rw+\""
-            error at 20..25: expected ‘)’ after here"#]],
+            error at 20..25: unexpected end of file
+            | error for 20..25: expected ‘)’ after here"#]],
     );
 }
 
@@ -10560,7 +10800,8 @@ fn recover_new_open_missing_mode() {
                           Identifier@13..19 "a_path"
                     Comma@19..20 ","
               Whitespace@20..21 " "
-            error at 19..20: expected ‘get’, ‘put’, ‘read’, ‘write’, ‘seek’ or ‘mod’ after here"#]],
+            error at 19..20: unexpected end of file
+            | error for 19..20: expected ‘get’, ‘put’, ‘read’, ‘write’, ‘seek’ or ‘mod’ after here"#]],
     );
 }
 
@@ -10596,7 +10837,8 @@ fn recover_new_open_missing_mode_in_list() {
                     Whitespace@27..28 " "
                     IoCap@28..31
                       KwMod@28..31 "mod"
-            error at 26..27: expected ‘get’, ‘put’, ‘read’, ‘write’, ‘seek’ or ‘mod’, but found ‘,’"#]],
+            error at 26..27: unexpected token
+            | error for 26..27: expected ‘get’, ‘put’, ‘read’, ‘write’, ‘seek’ or ‘mod’, but found ‘,’"#]],
     );
 }
 
@@ -10622,7 +10864,8 @@ fn recover_new_open_missing_path() {
                     Whitespace@14..15 " "
                     IoCap@15..18
                       KwGet@15..18 "get"
-            error at 13..14: expected expression, but found ‘,’"#]],
+            error at 13..14: unexpected token
+            | error for 13..14: expected expression, but found ‘,’"#]],
     );
 }
 
@@ -10649,7 +10892,8 @@ fn recover_new_open_missing_file_ref() {
                     Whitespace@16..17 " "
                     IoCap@17..20
                       KwGet@17..20 "get"
-            error at 7..8: expected expression, but found ‘,’"#]],
+            error at 7..8: unexpected token
+            | error for 7..8: expected expression, but found ‘,’"#]],
     );
 }
 
@@ -10677,7 +10921,8 @@ fn recover_new_open_missing_colon() {
                     Whitespace@18..19 " "
                     IoCap@19..22
                       KwGet@19..22 "get"
-            error at 5..9: expected ‘(’ or ‘:’, but found identifier"#]],
+            error at 5..9: unexpected token
+            | error for 5..9: expected ‘(’ or ‘:’, but found identifier"#]],
     );
 }
 
@@ -10691,7 +10936,8 @@ fn recover_just_open() {
                 OpenStmt@0..4
                   KwOpen@0..4 "open"
                   NewOpen@4..4
-            error at 0..4: expected ‘(’ or ‘:’ after here"#]],
+            error at 0..4: unexpected end of file
+            | error for 0..4: expected ‘(’ or ‘:’ after here"#]],
     );
 }
 
@@ -10733,7 +10979,8 @@ fn recover_on_open() {
                     Whitespace@46..47 " "
                     IoCap@47..50
                       KwGet@47..50 "get"
-            error at 26..30: expected expression, but found ‘open’"#]],
+            error at 26..30: unexpected token
+            | error for 26..30: expected expression, but found ‘open’"#]],
     );
 }
 
@@ -10775,7 +11022,8 @@ fn recover_old_close_missing_right_paren() {
                       Name@8..16
                         Identifier@8..16 "some_ref"
               Whitespace@16..17 " "
-            error at 8..16: expected ‘)’ after here"#]],
+            error at 8..16: unexpected end of file
+            | error for 8..16: expected ‘)’ after here"#]],
     );
 }
 
@@ -10793,7 +11041,8 @@ fn recover_old_close_missing_file_ref() {
                     LeftParen@6..7 "("
                     Whitespace@7..9 "  "
                     RightParen@9..10 ")"
-            error at 9..10: expected expression, but found ‘)’"#]],
+            error at 9..10: unexpected token
+            | error for 9..10: expected expression, but found ‘)’"#]],
     );
 }
 
@@ -10814,8 +11063,10 @@ fn recover_old_close_missing_left_paren() {
                 Whitespace@15..16 " "
                 Error@16..17
                   RightParen@16..17 ")"
-            error at 7..15: expected ‘(’ or ‘:’, but found identifier
-            error at 16..17: expected statement, but found ‘)’"#]],
+            error at 7..15: unexpected token
+            | error for 7..15: expected ‘(’ or ‘:’, but found identifier
+            error at 16..17: unexpected token
+            | error for 16..17: expected statement, but found ‘)’"#]],
     );
 }
 
@@ -10851,7 +11102,8 @@ fn recover_new_close_missing_file_ref() {
                   NewClose@6..7
                     Colon@6..7 ":"
               Whitespace@7..8 " "
-            error at 6..7: expected expression after here"#]],
+            error at 6..7: unexpected end of file
+            | error for 6..7: expected expression after here"#]],
     );
 }
 
@@ -10869,7 +11121,8 @@ fn recover_new_close_missing_colon() {
                     NameExpr@6..14
                       Name@6..14
                         Identifier@6..14 "some_ref"
-            error at 6..14: expected ‘(’ or ‘:’, but found identifier"#]],
+            error at 6..14: unexpected token
+            | error for 6..14: expected ‘(’ or ‘:’, but found identifier"#]],
     );
 }
 
@@ -10883,7 +11136,8 @@ fn recover_just_close() {
                 CloseStmt@0..5
                   KwClose@0..5 "close"
                   NewClose@5..5
-            error at 0..5: expected ‘(’ or ‘:’ after here"#]],
+            error at 0..5: unexpected end of file
+            | error for 0..5: expected ‘(’ or ‘:’ after here"#]],
     );
 }
 
@@ -10915,7 +11169,8 @@ fn recover_on_close() {
                     NameExpr@34..42
                       Name@34..42
                         Identifier@34..42 "some_ref"
-            error at 26..31: expected expression, but found ‘close’"#]],
+            error at 26..31: unexpected token
+            | error for 26..31: expected expression, but found ‘close’"#]],
     );
 }
 
@@ -11080,7 +11335,8 @@ fn recover_put_stmt_missing_opt_exp_expr() {
                       Whitespace@23..25 "  "
                       Error@25..27
                         Range@25..27 ".."
-            error at 25..27: expected expression, but found ‘..’"#]],
+            error at 25..27: unexpected token
+            | error for 25..27: expected expression, but found ‘..’"#]],
     );
 }
 
@@ -11125,7 +11381,8 @@ fn recover_put_stmt_missing_opt_fract_expr() {
                           Identifier@23..24 "e"
                   Whitespace@24..25 " "
                   Range@25..27 ".."
-            error at 21..22: expected expression, but found ‘:’"#]],
+            error at 21..22: unexpected token
+            | error for 21..22: expected expression, but found ‘:’"#]],
     );
 }
 
@@ -11170,7 +11427,8 @@ fn recover_put_stmt_missing_width_expr() {
                           Identifier@23..24 "e"
                   Whitespace@24..25 " "
                   Range@25..27 ".."
-            error at 17..18: expected expression, but found ‘:’"#]],
+            error at 17..18: unexpected token
+            | error for 17..18: expected expression, but found ‘:’"#]],
     );
 }
 
@@ -11195,7 +11453,8 @@ fn recover_put_stmt_missing_item() {
                   PutItem@10..12
                     Error@10..12
                       Range@10..12 ".."
-            error at 10..12: expected expression, but found ‘..’"#]],
+            error at 10..12: unexpected token
+            | error for 10..12: expected expression, but found ‘..’"#]],
     );
 }
 
@@ -11225,7 +11484,8 @@ fn recover_put_stmt_missing_item_in_list() {
                       Name@11..12
                         Identifier@11..12 "a"
                   Range@12..14 ".."
-            error at 9..10: expected expression, but found ‘,’"#]],
+            error at 9..10: unexpected token
+            | error for 9..10: expected expression, but found ‘,’"#]],
     );
 }
 
@@ -11271,7 +11531,8 @@ fn recover_put_stmt_missing_stream_expr() {
                           Identifier@23..24 "e"
                   Whitespace@24..25 " "
                   Range@25..27 ".."
-            error at 6..7: expected expression, but found ‘,’"#]],
+            error at 6..7: unexpected token
+            | error for 6..7: expected expression, but found ‘,’"#]],
     );
 }
 
@@ -11285,7 +11546,8 @@ fn recover_just_put() {
                 PutStmt@0..3
                   KwPut@0..3 "put"
                   PutItem@3..3
-            error at 0..3: expected expression after here"#]],
+            error at 0..3: unexpected end of file
+            | error for 0..3: expected expression after here"#]],
     );
 }
 
@@ -11313,7 +11575,8 @@ fn recover_on_put() {
                   Whitespace@21..22 " "
                   PutItem@22..26
                     KwSkip@22..26 "skip"
-            error at 18..21: expected expression, but found ‘put’"#]],
+            error at 18..21: unexpected token
+            | error for 18..21: expected expression, but found ‘put’"#]],
     );
 }
 
@@ -11418,7 +11681,8 @@ fn recover_get_stmt_missing_width_expr() {
                     GetWidth@14..15
                       Colon@14..15 ":"
               Whitespace@15..16 " "
-            error at 14..15: expected expression after here"#]],
+            error at 14..15: unexpected end of file
+            | error for 14..15: expected expression after here"#]],
     );
 }
 
@@ -11464,7 +11728,8 @@ fn recover_get_stmt_missing_item() {
                       Whitespace@21..22 " "
                       LiteralExpr@22..23
                         IntLiteral@22..23 "2"
-            error at 9..10: expected expression, but found ‘,’"#]],
+            error at 9..10: unexpected token
+            | error for 9..10: expected expression, but found ‘,’"#]],
     );
 }
 
@@ -11509,7 +11774,8 @@ fn recover_get_stmt_missing_item_in_list() {
                       Whitespace@21..22 " "
                       LiteralExpr@22..23
                         IntLiteral@22..23 "2"
-            error at 13..14: expected expression, but found ‘:’"#]],
+            error at 13..14: unexpected token
+            | error for 13..14: expected expression, but found ‘:’"#]],
     );
 }
 
@@ -11555,7 +11821,8 @@ fn recover_get_stmt_missing_stream_expr() {
                       Whitespace@21..22 " "
                       LiteralExpr@22..23
                         IntLiteral@22..23 "2"
-            error at 6..7: expected expression, but found ‘,’"#]],
+            error at 6..7: unexpected token
+            | error for 6..7: expected expression, but found ‘,’"#]],
     );
 }
 
@@ -11569,7 +11836,8 @@ fn recover_just_get() {
                 GetStmt@0..3
                   KwGet@0..3 "get"
                   GetItem@3..3
-            error at 0..3: expected expression after here"#]],
+            error at 0..3: unexpected end of file
+            | error for 0..3: expected expression after here"#]],
     );
 }
 
@@ -11597,7 +11865,8 @@ fn recover_on_get() {
                   Whitespace@21..22 " "
                   GetItem@22..26
                     KwSkip@22..26 "skip"
-            error at 18..21: expected expression, but found ‘get’"#]],
+            error at 18..21: unexpected token
+            | error for 18..21: expected expression, but found ‘get’"#]],
     );
 }
 
@@ -11707,7 +11976,8 @@ fn recover_wait_stmt_missing_opt_arg_expr() {
                       Identifier@5..6 "a"
                   Comma@6..7 ","
               Whitespace@7..8 " "
-            error at 6..7: expected expression after here"#]],
+            error at 6..7: unexpected end of file
+            | error for 6..7: expected expression after here"#]],
     );
 }
 
@@ -11720,7 +11990,8 @@ fn recover_just_wait() {
               StmtList@0..4
                 WaitStmt@0..4
                   KwWait@0..4 "wait"
-            error at 0..4: expected expression after here"#]],
+            error at 0..4: unexpected end of file
+            | error for 0..4: expected expression after here"#]],
     );
 }
 
@@ -11746,7 +12017,8 @@ fn recover_on_wait() {
                   NameExpr@15..16
                     Name@15..16
                       Identifier@15..16 "q"
-            error at 10..14: expected expression, but found ‘wait’"#]],
+            error at 10..14: unexpected token
+            | error for 10..14: expected expression, but found ‘wait’"#]],
     );
 }
 
@@ -11780,7 +12052,8 @@ fn recover_on_break() {
                 Whitespace@8..10 " \n"
                 BreakStmt@10..15
                   KwBreak@10..15 "break"
-            error at 10..15: expected expression, but found ‘break’"#]],
+            error at 10..15: unexpected token
+            | error for 10..15: expected expression, but found ‘break’"#]],
     );
 }
 
@@ -11812,7 +12085,8 @@ fn recover_fcn_decl_safe_end() {
                     KwEnd@16..19 "end"
                     Whitespace@19..20 " "
                     Identifier@20..21 "a"
-            error at 16..19: expected expression, but found ‘end’"#]],
+            error at 16..19: unexpected token
+            | error for 16..19: expected expression, but found ‘end’"#]],
     );
 }
 
@@ -11838,7 +12112,8 @@ fn recover_proc_decl_safe_end() {
                     KwEnd@11..14 "end"
                     Whitespace@14..15 " "
                     Identifier@15..16 "a"
-            error at 11..14: expected expression, but found ‘end’"#]],
+            error at 11..14: unexpected token
+            | error for 11..14: expected expression, but found ‘end’"#]],
     );
 }
 
@@ -11863,7 +12138,8 @@ fn recover_process_decl_safe_end() {
                     KwEnd@14..17 "end"
                     Whitespace@17..18 " "
                     Identifier@18..19 "a"
-            error at 14..17: expected expression, but found ‘end’"#]],
+            error at 14..17: unexpected token
+            | error for 14..17: expected expression, but found ‘end’"#]],
     );
 }
 
@@ -11888,7 +12164,8 @@ fn recover_module_decl_safe_end() {
                     KwEnd@13..16 "end"
                     Whitespace@16..17 " "
                     Identifier@17..18 "a"
-            error at 13..16: expected expression, but found ‘end’"#]],
+            error at 13..16: unexpected token
+            | error for 13..16: expected expression, but found ‘end’"#]],
     );
 }
 
@@ -11913,7 +12190,8 @@ fn recover_monitor_decl_safe_end() {
                     KwEnd@14..17 "end"
                     Whitespace@17..18 " "
                     Identifier@18..19 "a"
-            error at 14..17: expected expression, but found ‘end’"#]],
+            error at 14..17: unexpected token
+            | error for 14..17: expected expression, but found ‘end’"#]],
     );
 }
 
@@ -11938,7 +12216,8 @@ fn recover_class_decl_safe_end() {
                     KwEnd@12..15 "end"
                     Whitespace@15..16 " "
                     Identifier@16..17 "a"
-            error at 12..15: expected expression, but found ‘end’"#]],
+            error at 12..15: unexpected token
+            | error for 12..15: expected expression, but found ‘end’"#]],
     );
 }
 
@@ -11947,20 +12226,21 @@ fn recover_for_stmt_safe_end() {
     check(
         "for : end for",
         expect![[r#"
-        Source@0..13
-          StmtList@0..13
-            ForStmt@0..13
-              KwFor@0..3 "for"
-              Whitespace@3..4 " "
-              Colon@4..5 ":"
-              Whitespace@5..6 " "
-              ForBounds@6..6
-              StmtList@6..6
-              EndGroup@6..13
-                KwEnd@6..9 "end"
-                Whitespace@9..10 " "
-                KwFor@10..13 "for"
-        error at 6..9: expected expression, but found ‘end’"#]],
+            Source@0..13
+              StmtList@0..13
+                ForStmt@0..13
+                  KwFor@0..3 "for"
+                  Whitespace@3..4 " "
+                  Colon@4..5 ":"
+                  Whitespace@5..6 " "
+                  ForBounds@6..6
+                  StmtList@6..6
+                  EndGroup@6..13
+                    KwEnd@6..9 "end"
+                    Whitespace@9..10 " "
+                    KwFor@10..13 "for"
+            error at 6..9: unexpected token
+            | error for 6..9: expected expression, but found ‘end’"#]],
     );
 }
 
@@ -11969,19 +12249,21 @@ fn recover_for_stmt_safe_end_alt() {
     check(
         "for : endfor",
         expect![[r#"
-        Source@0..12
-          StmtList@0..12
-            ForStmt@0..12
-              KwFor@0..3 "for"
-              Whitespace@3..4 " "
-              Colon@4..5 ":"
-              Whitespace@5..6 " "
-              ForBounds@6..6
-              StmtList@6..6
-              EndGroup@6..12
-                KwEndFor@6..12 "endfor"
-        error at 6..12: expected expression, but found ‘endfor’
-        warn at 6..12: ‘endfor’ found, assuming it to be ’end for’"#]],
+            Source@0..12
+              StmtList@0..12
+                ForStmt@0..12
+                  KwFor@0..3 "for"
+                  Whitespace@3..4 " "
+                  Colon@4..5 ":"
+                  Whitespace@5..6 " "
+                  ForBounds@6..6
+                  StmtList@6..6
+                  EndGroup@6..12
+                    KwEndFor@6..12 "endfor"
+            error at 6..12: unexpected token
+            | error for 6..12: expected expression, but found ‘endfor’
+            warn at 6..12: ‘endfor’ found
+            | warn for 6..12: assuming it to be ’end for’"#]],
     );
 }
 
@@ -12003,7 +12285,8 @@ fn recover_loop_stmt_safe_end() {
                     KwEnd@15..18 "end"
                     Whitespace@18..19 " "
                     KwLoop@19..23 "loop"
-            error at 15..18: expected expression, but found ‘end’"#]],
+            error at 15..18: unexpected token
+            | error for 15..18: expected expression, but found ‘end’"#]],
     );
 }
 
@@ -12023,8 +12306,10 @@ fn recover_loop_stmt_safe_end_alt() {
                   Whitespace@14..15 " "
                   EndGroup@15..22
                     KwEndLoop@15..22 "endloop"
-            error at 15..22: expected expression, but found ‘endloop’
-            warn at 15..22: ‘endloop’ found, assuming it to be ’end loop’"#]],
+            error at 15..22: unexpected token
+            | error for 15..22: expected expression, but found ‘endloop’
+            warn at 15..22: ‘endloop’ found
+            | warn for 15..22: assuming it to be ’end loop’"#]],
     );
 }
 
@@ -12053,7 +12338,8 @@ fn recover_if_stmt_safe_end() {
                     KwEnd@17..20 "end"
                     Whitespace@20..21 " "
                     KwIf@21..23 "if"
-            error at 17..20: expected expression, but found ‘end’"#]],
+            error at 17..20: unexpected token
+            | error for 17..20: expected expression, but found ‘end’"#]],
     );
 }
 
@@ -12080,8 +12366,10 @@ fn recover_if_stmt_safe_end_alt() {
                   Whitespace@16..17 " "
                   EndGroup@17..22
                     KwEndIf@17..22 "endif"
-            error at 17..22: expected expression, but found ‘endif’
-            warn at 17..22: ‘endif’ found, assuming it to be ’end if’"#]],
+            error at 17..22: unexpected token
+            | error for 17..22: expected expression, but found ‘endif’
+            warn at 17..22: ‘endif’ found
+            | warn for 17..22: assuming it to be ’end if’"#]],
     );
 }
 
@@ -12110,7 +12398,8 @@ fn recover_elsif_stmt_safe_end() {
                     KwEnd@20..23 "end"
                     Whitespace@23..24 " "
                     KwIf@24..26 "if"
-            error at 20..23: expected expression, but found ‘end’"#]],
+            error at 20..23: unexpected token
+            | error for 20..23: expected expression, but found ‘end’"#]],
     );
 }
 
@@ -12137,8 +12426,10 @@ fn recover_elsif_stmt_safe_end_alt() {
                   Whitespace@19..20 " "
                   EndGroup@20..25
                     KwEndIf@20..25 "endif"
-            error at 20..25: expected expression, but found ‘endif’
-            warn at 20..25: ‘endif’ found, assuming it to be ’end if’"#]],
+            error at 20..25: unexpected token
+            | error for 20..25: expected expression, but found ‘endif’
+            warn at 20..25: ‘endif’ found
+            | warn for 20..25: assuming it to be ’end if’"#]],
     );
 }
 
@@ -12160,7 +12451,8 @@ fn recover_else_stmt_safe_end() {
                     KwEnd@12..15 "end"
                     Whitespace@15..16 " "
                     KwIf@16..18 "if"
-            error at 12..15: expected expression, but found ‘end’"#]],
+            error at 12..15: unexpected token
+            | error for 12..15: expected expression, but found ‘end’"#]],
     );
 }
 
@@ -12180,8 +12472,10 @@ fn recover_else_stmt_safe_end_alt() {
                   Whitespace@11..12 " "
                   EndGroup@12..17
                     KwEndIf@12..17 "endif"
-            error at 12..17: expected expression, but found ‘endif’
-            warn at 12..17: ‘endif’ found, assuming it to be ’end if’"#]],
+            error at 12..17: unexpected token
+            | error for 12..17: expected expression, but found ‘endif’
+            warn at 12..17: ‘endif’ found
+            | warn for 12..17: assuming it to be ’end if’"#]],
     );
 }
 
@@ -12210,7 +12504,8 @@ fn recover_case_stmt_safe_end() {
                     KwEnd@16..19 "end"
                     Whitespace@19..20 " "
                     KwCase@20..24 "case"
-            error at 16..19: expected expression, but found ‘end’"#]],
+            error at 16..19: unexpected token
+            | error for 16..19: expected expression, but found ‘end’"#]],
     );
 }
 
@@ -12237,8 +12532,10 @@ fn recover_case_stmt_safe_alt_end() {
                     StmtList@16..16
                   EndGroup@16..23
                     KwEndCase@16..23 "endcase"
-            error at 16..23: expected expression, but found ‘endcase’
-            warn at 16..23: ‘endcase’ found, assuming it to be ’end case’"#]],
+            error at 16..23: unexpected token
+            | error for 16..23: expected expression, but found ‘endcase’
+            warn at 16..23: ‘endcase’ found
+            | warn for 16..23: assuming it to be ’end case’"#]],
     );
 }
 
@@ -12258,7 +12555,8 @@ fn recover_block_stmt_safe_end() {
                   Whitespace@12..13 " "
                   EndGroup@13..16
                     KwEnd@13..16 "end"
-            error at 13..16: expected expression, but found ‘end’"#]],
+            error at 13..16: unexpected token
+            | error for 13..16: expected expression, but found ‘end’"#]],
     );
 }
 
@@ -12285,7 +12583,8 @@ fn recover_handler_stmt_safe_end() {
                     KwEnd@19..22 "end"
                     Whitespace@22..23 " "
                     KwHandler@23..30 "handler"
-            error at 19..22: expected expression, but found ‘end’"#]],
+            error at 19..22: unexpected token
+            | error for 19..22: expected expression, but found ‘end’"#]],
     );
 }
 
@@ -12294,11 +12593,12 @@ fn recover_just_end() {
     check(
         "end",
         expect![[r#"
-        Source@0..3
-          StmtList@0..3
-            Error@0..3
-              KwEnd@0..3 "end"
-        error at 0..3: expected statement, but found ‘end’"#]],
+            Source@0..3
+              StmtList@0..3
+                Error@0..3
+                  KwEnd@0..3 "end"
+            error at 0..3: unexpected token
+            | error for 0..3: expected statement, but found ‘end’"#]],
     );
 }
 
@@ -12307,11 +12607,12 @@ fn recover_just_endif() {
     check(
         "endif",
         expect![[r#"
-        Source@0..5
-          StmtList@0..5
-            Error@0..5
-              KwEndIf@0..5 "endif"
-        error at 0..5: expected statement, but found ‘endif’"#]],
+            Source@0..5
+              StmtList@0..5
+                Error@0..5
+                  KwEndIf@0..5 "endif"
+            error at 0..5: unexpected token
+            | error for 0..5: expected statement, but found ‘endif’"#]],
     );
 }
 
@@ -12320,11 +12621,12 @@ fn recover_just_endloop() {
     check(
         "endloop",
         expect![[r#"
-        Source@0..7
-          StmtList@0..7
-            Error@0..7
-              KwEndLoop@0..7 "endloop"
-        error at 0..7: expected statement, but found ‘endloop’"#]],
+            Source@0..7
+              StmtList@0..7
+                Error@0..7
+                  KwEndLoop@0..7 "endloop"
+            error at 0..7: unexpected token
+            | error for 0..7: expected statement, but found ‘endloop’"#]],
     );
 }
 
@@ -12333,11 +12635,12 @@ fn recover_just_endfor() {
     check(
         "endfor",
         expect![[r#"
-        Source@0..6
-          StmtList@0..6
-            Error@0..6
-              KwEndFor@0..6 "endfor"
-        error at 0..6: expected statement, but found ‘endfor’"#]],
+            Source@0..6
+              StmtList@0..6
+                Error@0..6
+                  KwEndFor@0..6 "endfor"
+            error at 0..6: unexpected token
+            | error for 0..6: expected statement, but found ‘endfor’"#]],
     );
 }
 
@@ -12346,11 +12649,12 @@ fn recover_just_endcase() {
     check(
         "endcase",
         expect![[r#"
-        Source@0..7
-          StmtList@0..7
-            Error@0..7
-              KwEndCase@0..7 "endcase"
-        error at 0..7: expected statement, but found ‘endcase’"#]],
+            Source@0..7
+              StmtList@0..7
+                Error@0..7
+                  KwEndCase@0..7 "endcase"
+            error at 0..7: unexpected token
+            | error for 0..7: expected statement, but found ‘endcase’"#]],
     );
 }
 
@@ -12359,20 +12663,22 @@ fn recover_mixed_endings() {
     check(
         "loop begin endloop",
         expect![[r#"
-        Source@0..18
-          StmtList@0..18
-            LoopStmt@0..18
-              KwLoop@0..4 "loop"
-              Whitespace@4..5 " "
-              StmtList@5..11
-                BlockStmt@5..11
-                  KwBegin@5..10 "begin"
-                  Whitespace@10..11 " "
-                  StmtList@11..11
-                  EndGroup@11..11
-              EndGroup@11..18
-                KwEndLoop@11..18 "endloop"
-        error at 11..18: expected ‘end’, but found ‘endloop’
-        warn at 11..18: ‘endloop’ found, assuming it to be ’end loop’"#]],
+            Source@0..18
+              StmtList@0..18
+                LoopStmt@0..18
+                  KwLoop@0..4 "loop"
+                  Whitespace@4..5 " "
+                  StmtList@5..11
+                    BlockStmt@5..11
+                      KwBegin@5..10 "begin"
+                      Whitespace@10..11 " "
+                      StmtList@11..11
+                      EndGroup@11..11
+                  EndGroup@11..18
+                    KwEndLoop@11..18 "endloop"
+            error at 11..18: unexpected token
+            | error for 11..18: expected ‘end’, but found ‘endloop’
+            warn at 11..18: ‘endloop’ found
+            | warn for 11..18: assuming it to be ’end loop’"#]],
     );
 }

--- a/compiler/toc_parser/src/grammar/ty/test.rs
+++ b/compiler/toc_parser/src/grammar/ty/test.rs
@@ -3143,7 +3143,7 @@ fn recover_just_packed() {
                   Error@9..15
                     KwPacked@9..15 "packed"
               Whitespace@15..16 " "
-            error at 15..16: expected ‘record’ or ‘union’ after here"#]],
+            error at 9..15: expected ‘record’ or ‘union’ after here"#]],
     );
 }
 

--- a/compiler/toc_parser/src/grammar/ty/test.rs
+++ b/compiler/toc_parser/src/grammar/ty/test.rs
@@ -331,7 +331,8 @@ fn recover_empty_sized_char_type() {
                       LeftParen@14..15 "("
                       SeqLength@15..15
                       RightParen@15..16 ")"
-            error at 15..16: expected expression, but found ‘)’"#]],
+            error at 15..16: unexpected token
+            | error for 15..16: expected expression, but found ‘)’"#]],
     );
 }
 
@@ -356,7 +357,8 @@ fn recover_empty_sized_string_type() {
                       LeftParen@16..17 "("
                       SeqLength@17..17
                       RightParen@17..18 ")"
-            error at 17..18: expected expression, but found ‘)’"#]],
+            error at 17..18: unexpected token
+            | error for 17..18: expected expression, but found ‘)’"#]],
     );
 }
 
@@ -383,7 +385,8 @@ fn recover_not_expr_in_sized_char_type() {
                         Error@15..17
                           KwTo@15..17 "to"
                       RightParen@17..18 ")"
-            error at 15..17: expected expression, but found ‘to’"#]],
+            error at 15..17: unexpected token
+            | error for 15..17: expected expression, but found ‘to’"#]],
     );
 }
 
@@ -410,7 +413,8 @@ fn recover_not_expr_in_sized_string_type() {
                         Error@17..19
                           KwTo@17..19 "to"
                       RightParen@19..20 ")"
-            error at 17..19: expected expression, but found ‘to’"#]],
+            error at 17..19: unexpected token
+            | error for 17..19: expected expression, but found ‘to’"#]],
     );
 }
 
@@ -436,7 +440,8 @@ fn recover_missing_right_paren_in_sized_char_type() {
                       SeqLength@15..16
                         LiteralExpr@15..16
                           IntLiteral@15..16 "1"
-            error at 15..16: expected ‘)’ after here"#]],
+            error at 15..16: unexpected end of file
+            | error for 15..16: expected ‘)’ after here"#]],
     );
 }
 
@@ -462,7 +467,8 @@ fn recover_missing_right_paren_in_sized_string_type() {
                       SeqLength@17..18
                         LiteralExpr@17..18
                           IntLiteral@17..18 "1"
-            error at 17..18: expected ‘)’ after here"#]],
+            error at 17..18: unexpected end of file
+            | error for 17..18: expected ‘)’ after here"#]],
     );
 }
 
@@ -664,7 +670,8 @@ fn recover_range_type_missing_tail() {
                       IntLiteral@9..10 "1"
                     Whitespace@10..11 " "
                     Range@11..13 ".."
-            error at 11..13: expected expression after here"#]],
+            error at 11..13: unexpected end of file
+            | error for 11..13: expected expression after here"#]],
     );
 }
 
@@ -692,7 +699,8 @@ fn recover_range_type_not_an_expr() {
                     Error@14..21
                       PrimType@14..21
                         KwBoolean@14..21 "boolean"
-            error at 14..21: expected ‘@’ after here"#]],
+            error at 14..21: unexpected end of file
+            | error for 14..21: expected ‘@’ after here"#]],
     );
 }
 
@@ -849,7 +857,8 @@ fn recover_pointer_type_missing_to() {
                     Whitespace@16..17 " "
                     PrimType@17..27
                       KwAddressint@17..27 "addressint"
-            error at 17..27: expected ‘to’, but found ‘addressint’"#]],
+            error at 17..27: unexpected token
+            | error for 17..27: expected ‘to’, but found ‘addressint’"#]],
     );
 }
 
@@ -870,7 +879,8 @@ fn recover_pointer_type_just_unchecked() {
                   Whitespace@8..9 " "
                   PointerType@9..18
                     KwUnchecked@9..18 "unchecked"
-            error at 9..18: expected ‘^’ or ‘pointer’ after here"#]],
+            error at 9..18: unexpected end of file
+            | error for 9..18: expected ‘^’ or ‘pointer’ after here"#]],
     );
 }
 
@@ -967,8 +977,10 @@ fn recover_enum_type_missing_delimiter() {
                       Identifier@20..21 "c"
                 Error@21..22
                   RightParen@21..22 ")"
-            error at 20..21: expected ‘,’ or ‘)’, but found identifier
-            error at 21..22: expected statement, but found ‘)’"#]],
+            error at 20..21: unexpected token
+            | error for 20..21: expected ‘,’ or ‘)’, but found identifier
+            error at 21..22: unexpected token
+            | error for 21..22: expected statement, but found ‘)’"#]],
     )
 }
 
@@ -1001,7 +1013,8 @@ fn recover_enum_type_missing_name() {
                       Comma@19..20 ","
                     Whitespace@20..21 " "
                     RightParen@21..22 ")"
-            error at 21..22: expected identifier, but found ‘)’"#]],
+            error at 21..22: unexpected token
+            | error for 21..22: expected identifier, but found ‘)’"#]],
     );
 
     check(
@@ -1031,7 +1044,8 @@ fn recover_enum_type_missing_name() {
                       Name@20..21
                         Identifier@20..21 "c"
                     RightParen@21..22 ")"
-            error at 18..19: expected identifier, but found ‘,’"#]],
+            error at 18..19: unexpected token
+            | error for 18..19: expected identifier, but found ‘,’"#]],
     );
 }
 
@@ -1062,7 +1076,8 @@ fn recover_enum_type_missing_name_and_right_paren() {
                       Name@18..19
                         Identifier@18..19 "b"
                       Comma@19..20 ","
-            error at 19..20: expected identifier after here"#]],
+            error at 19..20: unexpected end of file
+            | error for 19..20: expected identifier after here"#]],
     )
 }
 
@@ -1092,7 +1107,8 @@ fn recover_enum_type_missing_right_paren() {
                       Whitespace@17..18 " "
                       Name@18..19
                         Identifier@18..19 "b"
-            error at 18..19: expected ‘,’ or ‘)’ after here"#]],
+            error at 18..19: unexpected end of file
+            | error for 18..19: expected ‘,’ or ‘)’ after here"#]],
     )
 }
 
@@ -1117,7 +1133,8 @@ fn recover_enum_type_missing_names() {
                     LeftParen@14..15 "("
                     NameList@15..15
                     RightParen@15..16 ")"
-            error at 15..16: expected identifier, but found ‘)’"#]],
+            error at 15..16: unexpected token
+            | error for 15..16: expected identifier, but found ‘)’"#]],
     )
 }
 
@@ -1256,7 +1273,8 @@ fn recover_set_type_missing_of() {
                     Whitespace@12..13 " "
                     PrimType@13..17
                       KwChar@13..17 "char"
-            error at 13..17: expected ‘of’, but found ‘char’"#]],
+            error at 13..17: unexpected token
+            | error for 13..17: expected ‘of’, but found ‘char’"#]],
     );
 }
 
@@ -1280,7 +1298,8 @@ fn recover_set_type_missing_ty() {
                     KwSet@9..12 "set"
                     Whitespace@12..13 " "
                     KwOf@13..15 "of"
-            error at 13..15: expected type specifier after here"#]],
+            error at 13..15: unexpected end of file
+            | error for 13..15: expected type specifier after here"#]],
     );
 }
 
@@ -1302,7 +1321,8 @@ fn recover_just_set() {
                   Whitespace@8..9 " "
                   SetType@9..12
                     KwSet@9..12 "set"
-            error at 9..12: expected ‘of’ after here"#]],
+            error at 9..12: unexpected end of file
+            | error for 9..12: expected ‘of’ after here"#]],
     );
 }
 
@@ -1408,7 +1428,8 @@ fn recover_condition_type_attrs_without_condition() {
                     Whitespace@17..18 " "
                     Error@18..31
                       Identifier@18..31 "not_condition"
-            error at 18..31: expected ‘condition’, but found identifier"#]],
+            error at 18..31: unexpected token
+            | error for 18..31: expected ‘condition’, but found identifier"#]],
     );
 }
 
@@ -1483,7 +1504,8 @@ fn recover_collection_type_no_ty() {
                     KwCollection@9..19 "collection"
                     Whitespace@19..20 " "
                     KwOf@20..22 "of"
-            error at 20..22: expected type specifier after here"#]],
+            error at 20..22: unexpected end of file
+            | error for 20..22: expected type specifier after here"#]],
     )
 }
 
@@ -1507,7 +1529,8 @@ fn recover_collection_type_no_of() {
                     Whitespace@19..20 " "
                     PrimType@20..23
                       KwInt@20..23 "int"
-            error at 20..23: expected ‘of’, but found ‘int’"#]],
+            error at 20..23: unexpected token
+            | error for 20..23: expected ‘of’, but found ‘int’"#]],
     )
 }
 
@@ -1532,7 +1555,8 @@ fn recover_collection_type_no_forward_name() {
                     KwOf@20..22 "of"
                     Whitespace@22..23 " "
                     KwForward@23..30 "forward"
-            error at 23..30: expected identifier after here"#]],
+            error at 23..30: unexpected end of file
+            | error for 23..30: expected identifier after here"#]],
     )
 }
 
@@ -1553,7 +1577,8 @@ fn recover_just_collection() {
                   Whitespace@8..9 " "
                   CollectionType@9..19
                     KwCollection@9..19 "collection"
-            error at 9..19: expected ‘of’ after here"#]],
+            error at 9..19: unexpected end of file
+            | error for 9..19: expected ‘of’ after here"#]],
     )
 }
 
@@ -1701,7 +1726,8 @@ fn recover_flexible_not_array() {
                   NameExpr@28..35
                     Name@28..35
                       Identifier@28..35 "im_stmt"
-            error at 18..27: expected ‘array’, but found identifier"#]],
+            error at 18..27: unexpected token
+            | error for 18..27: expected ‘array’, but found identifier"#]],
     );
 }
 
@@ -1728,7 +1754,8 @@ fn recover_array_empty_range_list() {
                     Whitespace@17..18 " "
                     PrimType@18..21
                       KwInt@18..21 "int"
-            error at 15..17: expected type specifier, but found ‘of’"#]],
+            error at 15..17: unexpected token
+            | error for 15..17: expected type specifier, but found ‘of’"#]],
     );
 }
 
@@ -1761,7 +1788,8 @@ fn recover_array_no_elem_ty() {
                           IntLiteral@20..21 "3"
                     Whitespace@21..22 " "
                     KwOf@22..24 "of"
-            error at 22..24: expected type specifier after here"#]],
+            error at 22..24: unexpected end of file
+            | error for 22..24: expected type specifier after here"#]],
     );
 }
 
@@ -1894,8 +1922,10 @@ fn recover_proc_type_with_result_ty() {
                 Error@37..40
                   PrimType@37..40
                     KwInt@37..40 "int"
-            error at 35..36: expected statement, but found ‘:’
-            error at 37..40: expected ‘@’ after here"#]],
+            error at 35..36: unexpected token
+            | error for 35..36: expected statement, but found ‘:’
+            error at 37..40: unexpected end of file
+            | error for 37..40: expected ‘@’ after here"#]],
     );
 }
 
@@ -1936,7 +1966,8 @@ fn recover_fcn_type_without_result_ty() {
                         PrimType@29..32
                           KwInt@29..32 "int"
                       RightParen@32..33 ")"
-            error at 32..33: expected ‘:’ after here"#]],
+            error at 32..33: unexpected end of file
+            | error for 32..33: expected ‘:’ after here"#]],
     );
 }
 
@@ -2168,7 +2199,8 @@ fn recover_proc_type_constvar_attrs_missing_name() {
                         PrimType@38..41
                           KwInt@38..41 "int"
                       RightParen@41..42 ")"
-            error at 36..37: expected identifier, but found ‘:’"#]],
+            error at 36..37: unexpected token
+            | error for 36..37: expected identifier, but found ‘:’"#]],
     );
     check(
         "type _ : procedure _a (var : int)",
@@ -2200,7 +2232,8 @@ fn recover_proc_type_constvar_attrs_missing_name() {
                         PrimType@29..32
                           KwInt@29..32 "int"
                       RightParen@32..33 ")"
-            error at 27..28: expected ‘register’ or identifier, but found ‘:’"#]],
+            error at 27..28: unexpected token
+            | error for 27..28: expected ‘register’ or identifier, but found ‘:’"#]],
     );
     check(
         "type _ : procedure _a (register : int)",
@@ -2232,7 +2265,8 @@ fn recover_proc_type_constvar_attrs_missing_name() {
                         PrimType@34..37
                           KwInt@34..37 "int"
                       RightParen@37..38 ")"
-            error at 32..33: expected identifier, but found ‘:’"#]],
+            error at 32..33: unexpected token
+            | error for 32..33: expected identifier, but found ‘:’"#]],
     );
 }
 
@@ -2267,7 +2301,8 @@ fn recover_proc_type_constvar_missing_ty() {
                         Colon@25..26 ":"
                       Whitespace@26..27 " "
                       RightParen@27..28 ")"
-            error at 27..28: expected type specifier, but found ‘)’"#]],
+            error at 27..28: unexpected token
+            | error for 27..28: expected type specifier, but found ‘)’"#]],
     );
 }
 
@@ -2554,7 +2589,8 @@ fn recover_record_type_missing_last_name() {
                       KwEnd@25..28 "end"
                       Whitespace@28..29 " "
                       KwRecord@29..35 "record"
-            error at 19..20: expected identifier, but found ‘:’"#]],
+            error at 19..20: unexpected token
+            | error for 19..20: expected identifier, but found ‘:’"#]],
     );
 }
 
@@ -2576,7 +2612,8 @@ fn recover_just_record() {
                   RecordType@9..15
                     KwRecord@9..15 "record"
                     EndGroup@15..15
-            error at 9..15: expected ‘end’ after here"#]],
+            error at 9..15: unexpected end of file
+            | error for 9..15: expected ‘end’ after here"#]],
     );
 }
 
@@ -2697,7 +2734,8 @@ fn recover_just_union() {
                   UnionType@9..14
                     KwUnion@9..14 "union"
                     EndGroup@14..14
-            error at 9..14: expected identifier or ‘:’ after here"#]],
+            error at 9..14: unexpected end of file
+            | error for 9..14: expected identifier or ‘:’ after here"#]],
     );
 }
 
@@ -2726,7 +2764,8 @@ fn recover_just_union_head() {
                     Whitespace@24..25 " "
                     KwOf@25..27 "of"
                     EndGroup@27..27
-            error at 25..27: expected ‘label’ or ‘end’ after here"#]],
+            error at 25..27: unexpected end of file
+            | error for 25..27: expected ‘label’ or ‘end’ after here"#]],
     );
 }
 
@@ -2909,7 +2948,8 @@ fn recover_union_type_missing_label_colon() {
                       KwEnd@31..34 "end"
                       Whitespace@34..35 " "
                       KwUnion@35..40 "union"
-            error at 31..34: expected expression, but found ‘end’"#]],
+            error at 31..34: unexpected token
+            | error for 31..34: expected expression, but found ‘end’"#]],
     );
 }
 
@@ -2951,9 +2991,12 @@ fn recover_union_type_not_label() {
                 Whitespace@33..34 " "
                 Error@34..39
                   KwUnion@34..39 "union"
-            error at 25..29: expected ‘label’ or ‘end’, but found identifier
-            error at 30..33: expected ‘union’, but found ‘end’
-            error at 34..39: expected statement, but found ‘union’"#]],
+            error at 25..29: unexpected token
+            | error for 25..29: expected ‘label’ or ‘end’, but found identifier
+            error at 30..33: unexpected token
+            | error for 30..33: expected ‘union’, but found ‘end’
+            error at 34..39: unexpected token
+            | error for 34..39: expected statement, but found ‘union’"#]],
     );
 }
 
@@ -3014,7 +3057,8 @@ fn recover_bare_union_type() {
                       KwEnd@15..18 "end"
                       Whitespace@18..19 " "
                       KwUnion@19..24 "union"
-            error at 15..18: expected identifier or ‘:’, but found ‘end’"#]],
+            error at 15..18: unexpected token
+            | error for 15..18: expected identifier or ‘:’, but found ‘end’"#]],
     );
 }
 
@@ -3050,7 +3094,8 @@ fn recover_record_type_on_var() {
                   Whitespace@23..24 " "
                   PrimType@24..27
                     KwInt@24..27 "int"
-            error at 16..19: expected ‘end’ or identifier, but found ‘var’"#]],
+            error at 16..19: unexpected token
+            | error for 16..19: expected ‘end’ or identifier, but found ‘var’"#]],
     );
 }
 
@@ -3098,7 +3143,8 @@ fn recover_union_variant_type_on_var() {
                   Whitespace@43..44 " "
                   PrimType@44..47
                     KwInt@44..47 "int"
-            error at 36..39: expected ‘end’, ‘label’ or identifier, but found ‘var’"#]],
+            error at 36..39: unexpected token
+            | error for 36..39: expected ‘end’, ‘label’ or identifier, but found ‘var’"#]],
     );
 }
 
@@ -3121,7 +3167,8 @@ fn recover_packed_not_packable_type() {
                     KwPacked@9..15 "packed"
                     Whitespace@15..16 " "
                     KwInt@16..19 "int"
-            error at 16..19: expected ‘record’ or ‘union’, but found ‘int’"#]],
+            error at 16..19: unexpected token
+            | error for 16..19: expected ‘record’ or ‘union’, but found ‘int’"#]],
     );
 }
 
@@ -3143,7 +3190,8 @@ fn recover_just_packed() {
                   Error@9..15
                     KwPacked@9..15 "packed"
               Whitespace@15..16 " "
-            error at 9..15: expected ‘record’ or ‘union’ after here"#]],
+            error at 9..15: unexpected end of file
+            | error for 9..15: expected ‘record’ or ‘union’ after here"#]],
     );
 }
 
@@ -3170,6 +3218,7 @@ fn recover_include_glob_ty() {
                     LiteralExpr@17..40
                       StringLiteral@17..40 "\"some_foreign_location\""
               Whitespace@40..41 " "
-            error at 9..16: expected type specifier, but found ‘include’"#]],
+            error at 9..16: unexpected token
+            | error for 9..16: expected type specifier, but found ‘include’"#]],
     )
 }

--- a/compiler/toc_parser/src/lib.rs
+++ b/compiler/toc_parser/src/lib.rs
@@ -24,9 +24,8 @@ pub fn parse(file: Option<FileId>, source: &str) -> CompileResult<ParseTree> {
 
     let source = Source::new(&tokens);
     let parser = parser::Parser::new(file, source);
-    let (events, mut parser_msgs) = parser.parse();
-    parser_msgs.dedup_shared_ranges();
-    let sink = Sink::new(&tokens, events, vec![scanner_msgs, parser_msgs]);
+    let (events, parser_msgs) = parser.parse();
+    let sink = Sink::new(&tokens, events, scanner_msgs.combine(parser_msgs));
 
     sink.finish()
 }
@@ -68,7 +67,7 @@ pub(crate) fn check(source: &str, expected: expect_test::Expect) {
     // trim trailing newline
     debug_tree.pop();
 
-    for err in res.messages() {
+    for err in res.messages().iter() {
         debug_tree.push_str(&format!("\n{}", err));
     }
 

--- a/compiler/toc_parser/src/parser/mod.rs
+++ b/compiler/toc_parser/src/parser/mod.rs
@@ -4,7 +4,7 @@ pub(crate) mod marker;
 
 use drop_bomb::DropBomb;
 pub(crate) use error::Expected;
-use toc_reporting::MessageSink;
+use toc_reporting::{MessageBundle, MessageSink};
 use toc_span::{FileId, Span};
 
 use crate::event::Event;
@@ -121,9 +121,9 @@ impl<'t, 'src> Parser<'t, 'src> {
         }
     }
 
-    pub(crate) fn parse(mut self) -> (Vec<Event>, MessageSink) {
+    pub(crate) fn parse(mut self) -> (Vec<Event>, MessageBundle) {
         grammar::source(&mut self);
-        (self.events, self.msg_sink)
+        (self.events, self.msg_sink.finish())
     }
 
     fn peek(&mut self) -> Option<TokenKind> {

--- a/compiler/toc_parser/src/parser/mod.rs
+++ b/compiler/toc_parser/src/parser/mod.rs
@@ -241,7 +241,8 @@ impl<'t, 'src> Parser<'t, 'src> {
         let span = Span::new(self.file, range);
 
         self.msg_sink.warn(
-            &format!("{} found, assuming it to be {}", found, normal),
+            &format!("{} found", found),
+            &format!("assuming it to be {}", normal),
             span,
         );
     }
@@ -351,8 +352,14 @@ impl<'p, 't, 's> UnexpectedBuilder<'p, 't, 's> {
         );
 
         let span = Span::new(self.p.file, range);
+        let header = if found.is_some() {
+            "unexpected token"
+        } else {
+            "unexpected end of file"
+        };
 
         self.p.msg_sink.error(
+            header,
             &format!(
                 "{}",
                 ParseMessage::UnexpectedToken {

--- a/compiler/toc_parser/src/parser/mod.rs
+++ b/compiler/toc_parser/src/parser/mod.rs
@@ -341,7 +341,7 @@ impl<'p, 't, 's> UnexpectedBuilder<'p, 't, 's> {
 
         let (found, range) = match current {
             Some(token) => (Some(token.kind), token.range),
-            None => (None, self.p.source.last_token_range().unwrap()), // Last token always exists in a non-empty file
+            None => (None, self.p.source.last_non_trivia_token_range().unwrap()), // Last token always exists in a non-empty file
         };
 
         // push error

--- a/compiler/toc_parser/src/sink.rs
+++ b/compiler/toc_parser/src/sink.rs
@@ -4,7 +4,7 @@ use crate::ParseTree;
 
 use rowan::GreenNodeBuilder;
 use std::mem;
-use toc_reporting::{CompileResult, MessageSink, ReportMessage};
+use toc_reporting::{CompileResult, MessageBundle};
 use toc_scanner::token::{Token, TokenKind};
 use toc_syntax::SyntaxKind;
 
@@ -16,14 +16,14 @@ pub(super) struct Sink<'t, 'src> {
     cursor: usize,
     depth: usize,
     events: Vec<Event>,
-    messages: Vec<ReportMessage>,
+    messages: MessageBundle,
 }
 
 impl<'t, 'src> Sink<'t, 'src> {
     pub(super) fn new(
         tokens: &'t [Token<'src>],
         events: Vec<Event>,
-        collected_sinks: Vec<MessageSink>,
+        messages: MessageBundle,
     ) -> Self {
         Self {
             builder: GreenNodeBuilder::new(),
@@ -31,11 +31,7 @@ impl<'t, 'src> Sink<'t, 'src> {
             cursor: 0,
             depth: 0,
             events,
-            messages: collected_sinks
-                .into_iter()
-                .map(|s| s.finish())
-                .flatten()
-                .collect(),
+            messages,
         }
     }
 

--- a/compiler/toc_parser/src/source.rs
+++ b/compiler/toc_parser/src/source.rs
@@ -32,8 +32,14 @@ impl<'t, 'src> Source<'t, 'src> {
         self.token_at(self.cursor)
     }
 
-    pub(crate) fn last_token_range(&self) -> Option<TokenRange> {
-        self.tokens.last().map(|Token { range, .. }| *range)
+    /// Gets the last non-trivia token, or looks up the last token
+    pub(crate) fn last_non_trivia_token_range(&self) -> Option<TokenRange> {
+        self.tokens
+            .iter()
+            .rev()
+            .find(|tok| !tok.kind.is_trivia())
+            .or_else(|| self.tokens.last())
+            .map(|Token { range, .. }| *range)
     }
 
     fn token_kind_at(&self, cursor: usize) -> Option<TokenKind> {

--- a/compiler/toc_reporting/src/annotate.rs
+++ b/compiler/toc_reporting/src/annotate.rs
@@ -1,0 +1,102 @@
+//! Source annotations
+
+use std::fmt;
+
+use toc_span::Span;
+
+/// Type of annotation added to a message
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum AnnotateKind {
+    /// Information related to the main message.
+    /// May be context specific.
+    Note,
+    /// More detailed related to the message.
+    Info,
+    /// Warning annotation
+    Warning,
+    /// Error annotation
+    Error,
+}
+
+impl fmt::Display for AnnotateKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            AnnotateKind::Note => "note",
+            AnnotateKind::Info => "info",
+            AnnotateKind::Warning => "warn",
+            AnnotateKind::Error => "error",
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SourceAnnotation {
+    // FIXME: These don't need to be pub crate
+    pub(crate) annotation: Annotation,
+    pub(crate) span: Span,
+}
+
+impl SourceAnnotation {
+    /// Gets the kind of annotation reported
+    pub fn kind(&self) -> AnnotateKind {
+        self.annotation.kind()
+    }
+
+    /// Gets the annotation's message
+    pub fn message(&self) -> &str {
+        self.annotation.message()
+    }
+
+    /// Gets the span of text the annotation covers.
+    pub fn span(&self) -> Span {
+        self.span
+    }
+}
+
+impl fmt::Display for SourceAnnotation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let file_id = self.span.file;
+        let (start, end) = (
+            u32::from(self.span.range.start()),
+            u32::from(self.span.range.end()),
+        );
+
+        write!(f, "{}", self.kind())?;
+
+        if let Some(file_id) = file_id {
+            write!(f, " in file {:?}", file_id)?;
+        }
+
+        if f.alternate() {
+            write!(f, " for {}..{}: {}", start, end, self.message())?;
+        } else {
+            write!(f, " at {}..{}: {}", start, end, self.message())?;
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Annotation {
+    pub(crate) kind: AnnotateKind,
+    pub(crate) msg: String,
+}
+
+impl Annotation {
+    /// Gets the kind of annotation reported
+    pub fn kind(&self) -> AnnotateKind {
+        self.kind
+    }
+
+    /// Gets the annotation's message
+    pub fn message(&self) -> &str {
+        &self.msg
+    }
+}
+
+impl fmt::Display for Annotation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}: {}", self.kind(), self.msg)
+    }
+}

--- a/compiler/toc_reporting/src/lib.rs
+++ b/compiler/toc_reporting/src/lib.rs
@@ -1,17 +1,23 @@
 //! Common message reporting for all compiler libraries
-use std::{fmt, sync::Arc};
+use std::sync::Arc;
 
-use toc_span::Span;
+mod annotate;
+mod message;
+mod reporter;
+
+pub use annotate::{AnnotateKind, Annotation, SourceAnnotation};
+pub use message::{MessageBundle, ReportMessage};
+pub use reporter::{MessageBuilder, MessageSink};
 
 /// A compilation result, including a bundle of associated messages
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CompileResult<T> {
     result: T,
-    messages: Arc<Vec<ReportMessage>>,
+    messages: Arc<MessageBundle>,
 }
 
 impl<T> CompileResult<T> {
-    pub fn new(result: T, messages: Vec<ReportMessage>) -> Self {
+    pub fn new(result: T, messages: MessageBundle) -> Self {
         Self {
             result,
             messages: Arc::new(messages),
@@ -23,359 +29,22 @@ impl<T> CompileResult<T> {
         &self.result
     }
 
-    /// Gets the associated messages.
-    pub fn messages(&self) -> &[ReportMessage] {
+    /// Gets the associated message bundle.
+    pub fn messages(&self) -> &MessageBundle {
         &self.messages
     }
 
-    /// Extracts messages from this result into a destination sink.
-    pub fn bundle_messages(&self, dest: &mut Vec<ReportMessage>) {
-        dest.extend_from_slice(&self.messages);
+    pub fn bundle_messages(&self, bundle: &mut MessageBundle) {
+        bundle.aggregate(self.messages())
     }
 
     /// Destructures the result into its component parts
     ///
     /// There must not be any other clones to self
-    pub fn take(mut self) -> (T, Vec<ReportMessage>) {
+    pub fn take(mut self) -> (T, MessageBundle) {
         let messages =
             Arc::get_mut(&mut self.messages).expect("other clones of CompileResult exists");
         let messages = std::mem::take(messages);
         (self.result, messages)
-    }
-}
-
-/// A reported message
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ReportMessage {
-    header: SourceAnnotation,
-    annotations: Vec<SourceAnnotation>,
-    footer: Vec<Annotation>,
-}
-
-impl ReportMessage {
-    /// Gets the kind of message reported
-    pub fn kind(&self) -> AnnotateKind {
-        self.header.annotation.kind
-    }
-
-    /// Gets the reported message
-    pub fn message(&self) -> &str {
-        self.header.annotation.message()
-    }
-
-    /// Gets the span of text the message covers
-    pub fn span(&self) -> Span {
-        self.header.span
-    }
-
-    /// Gets any associated annotations
-    pub fn annotations(&self) -> &[SourceAnnotation] {
-        &self.annotations
-    }
-
-    /// Gets any footer annotations (any annotation without a location in the source)
-    pub fn footer(&self) -> &[Annotation] {
-        &self.footer
-    }
-}
-
-impl fmt::Display for ReportMessage {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.header)?;
-
-        // Report any annotations
-        for annotation in &self.annotations {
-            write!(f, "\n| {:#}", annotation)?;
-        }
-
-        // Report any footer messages
-        for annotation in &self.footer {
-            write!(f, "\n| {:#}", annotation)?;
-        }
-
-        Ok(())
-    }
-}
-
-/// Type of annotation added to a message
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum AnnotateKind {
-    /// Information related to the main message.
-    /// May be context specific.
-    Note,
-    /// More detailed related to the message.
-    Info,
-    /// Warning annotation
-    Warning,
-    /// Error annotation
-    Error,
-}
-
-impl fmt::Display for AnnotateKind {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(match self {
-            AnnotateKind::Note => "note",
-            AnnotateKind::Info => "info",
-            AnnotateKind::Warning => "warn",
-            AnnotateKind::Error => "error",
-        })
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct SourceAnnotation {
-    annotation: Annotation,
-    span: Span,
-}
-
-impl SourceAnnotation {
-    /// Gets the kind of annotation reported
-    pub fn kind(&self) -> AnnotateKind {
-        self.annotation.kind()
-    }
-
-    /// Gets the annotation's message
-    pub fn message(&self) -> &str {
-        self.annotation.message()
-    }
-
-    /// Gets the span of text the annotation covers.
-    pub fn span(&self) -> Span {
-        self.span
-    }
-}
-
-impl fmt::Display for SourceAnnotation {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let file_id = self.span.file;
-        let (start, end) = (
-            u32::from(self.span.range.start()),
-            u32::from(self.span.range.end()),
-        );
-
-        write!(f, "{}", self.kind())?;
-
-        if let Some(file_id) = file_id {
-            write!(f, " in file {:?}", file_id)?;
-        }
-
-        if f.alternate() {
-            write!(f, " for {}..{}: {}", start, end, self.message())?;
-        } else {
-            write!(f, " at {}..{}: {}", start, end, self.message())?;
-        }
-
-        Ok(())
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Annotation {
-    kind: AnnotateKind,
-    msg: String,
-}
-
-impl Annotation {
-    /// Gets the kind of annotation reported
-    pub fn kind(&self) -> AnnotateKind {
-        self.kind
-    }
-
-    /// Gets the annotation's message
-    pub fn message(&self) -> &str {
-        &self.msg
-    }
-}
-
-impl fmt::Display for Annotation {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}: {}", self.kind(), self.msg)
-    }
-}
-
-/// Sink for message reports
-#[derive(Debug, Default)]
-pub struct MessageSink {
-    messages: Vec<ReportMessage>,
-}
-
-impl MessageSink {
-    pub fn new() -> Self {
-        Self { messages: vec![] }
-    }
-
-    /// Merges an existing set of messages into a new MessageSink
-    pub fn with_messages(messages: Vec<ReportMessage>) -> Self {
-        Self { messages }
-    }
-
-    /// Reports an error message
-    pub fn error(&mut self, message: &str, span: Span) {
-        self.report(AnnotateKind::Error, message, span)
-    }
-
-    /// Reports a detailed error message
-    pub fn error_detailed(&mut self, message: &str, span: Span) -> MessageBuilder {
-        self.report_detailed(AnnotateKind::Error, message, span)
-    }
-
-    /// Reports a warning message
-    pub fn warn(&mut self, message: &str, span: Span) {
-        self.report(AnnotateKind::Warning, message, span)
-    }
-
-    /// Reports a detailed warning message
-    pub fn warn_detailed(&mut self, message: &str, span: Span) -> MessageBuilder {
-        self.report_detailed(AnnotateKind::Warning, message, span)
-    }
-
-    /// Reports a message
-    ///
-    /// Does not add any annotations to the message
-    fn report(&mut self, kind: AnnotateKind, message: &str, span: Span) {
-        MessageBuilder::new(self, kind, message, span).finish();
-    }
-
-    /// Reports a detailed message
-    ///
-    /// Returns a builder for adding annotations
-    #[must_use = "message is not reported until `finish()` is called"]
-    fn report_detailed(&mut self, kind: AnnotateKind, message: &str, span: Span) -> MessageBuilder {
-        MessageBuilder::new(self, kind, message, span)
-    }
-
-    /// Removes any subsequent messages that share the same text range
-    pub fn dedup_shared_ranges(&mut self) {
-        self.messages
-            .dedup_by(|a, b| a.header.span == b.header.span && a.kind() == b.kind())
-    }
-
-    /// Finishes reporting any messages, giving back the final message list
-    pub fn finish(self) -> Vec<ReportMessage> {
-        self.messages
-    }
-}
-
-/// Builder for detailed messages
-#[derive(Debug)]
-pub struct MessageBuilder<'a> {
-    drop_bomb: drop_bomb::DropBomb,
-    reporter: &'a mut MessageSink,
-    kind: AnnotateKind,
-    message: String,
-    span: Span,
-    annotations: Vec<SourceAnnotation>,
-    footer: Vec<Annotation>,
-}
-
-impl<'a> MessageBuilder<'a> {
-    pub fn new(
-        reporter: &'a mut MessageSink,
-        kind: AnnotateKind,
-        message: &str,
-        span: Span,
-    ) -> Self {
-        Self {
-            drop_bomb: drop_bomb::DropBomb::new("Missing `finish()` for MessageBuilder"),
-            reporter,
-            kind,
-            message: message.to_string(),
-            span,
-            annotations: vec![],
-            footer: vec![],
-        }
-    }
-
-    pub fn with_note<S>(self, message: &str, span: S) -> Self
-    where
-        S: Into<Option<Span>>,
-    {
-        self.with_annotation(AnnotateKind::Note, message, span)
-    }
-
-    pub fn with_info<S>(self, message: &str, span: S) -> Self
-    where
-        S: Into<Option<Span>>,
-    {
-        self.with_annotation(AnnotateKind::Info, message, span)
-    }
-
-    fn with_annotation<R>(mut self, kind: AnnotateKind, message: &str, span: R) -> Self
-    where
-        R: Into<Option<Span>>,
-    {
-        match span.into() {
-            Some(span) => self.annotations.push(SourceAnnotation {
-                annotation: Annotation {
-                    kind,
-                    msg: message.to_string(),
-                },
-                span,
-            }),
-            None => self.footer.push(Annotation {
-                kind,
-                msg: message.to_string(),
-            }),
-        }
-
-        self
-    }
-
-    pub fn finish(self) {
-        let MessageBuilder {
-            mut drop_bomb,
-            reporter,
-            kind,
-            message,
-            span,
-            annotations,
-            footer,
-        } = self;
-
-        // Defuse bomb now
-        drop_bomb.defuse();
-
-        reporter.messages.push(ReportMessage {
-            header: SourceAnnotation {
-                annotation: Annotation { kind, msg: message },
-                span,
-            },
-            annotations,
-            footer,
-        });
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use toc_span::TextRange;
-
-    use super::*;
-
-    #[test]
-    fn report_message() {
-        let mut sink = MessageSink::new();
-        sink.report(
-            AnnotateKind::Error,
-            "an error message",
-            Span::new(None, TextRange::new(1.into(), 3.into())),
-        );
-
-        sink.report(
-            AnnotateKind::Warning,
-            "a warning message",
-            Span::new(None, TextRange::new(3.into(), 5.into())),
-        );
-
-        let msgs = sink.finish();
-        assert_eq!(
-            (msgs[0].message(), msgs[0].span().range),
-            ("an error message", TextRange::new(1.into(), 3.into()))
-        );
-
-        assert_eq!(
-            (msgs[1].message(), msgs[1].span().range),
-            ("a warning message", TextRange::new(3.into(), 5.into()))
-        );
     }
 }

--- a/compiler/toc_reporting/src/message.rs
+++ b/compiler/toc_reporting/src/message.rs
@@ -1,0 +1,114 @@
+//! Constructed messages
+
+use std::collections::HashSet;
+use std::fmt;
+
+use toc_span::Span;
+
+use crate::{AnnotateKind, Annotation, SourceAnnotation};
+
+/// A bundle of messages
+///
+/// Messages are already sorted by file, then by starting location
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct MessageBundle {
+    pub(crate) messages: Vec<ReportMessage>,
+}
+
+impl MessageBundle {
+    pub(crate) fn from_messages(messages: Vec<ReportMessage>) -> Self {
+        let mut s = Self { messages };
+        s.make_uniform();
+        s
+    }
+
+    /// Creates an empty message bundle
+    pub fn empty() -> Self {
+        Self { messages: vec![] }
+    }
+
+    /// Combines two message bundles together
+    pub fn combine(mut self, other: Self) -> Self {
+        self.messages.extend(other.messages.into_iter());
+        self.make_uniform();
+        self
+    }
+
+    /// Aggregates messages from another bundle
+    pub fn aggregate(&mut self, other: &Self) {
+        self.messages.extend_from_slice(&other.messages);
+        self.make_uniform();
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &'_ ReportMessage> + '_ {
+        // Perform message deduplication
+        // Earlier messages get reported over later ones
+        // Annotate kinds are considered separately from each other
+        // Spans that cover each-other are considered different
+
+        let mut reported_at = HashSet::new();
+        self.messages.iter().filter(move |msg| {
+            // Only report the first one at a given span & kind
+            reported_at.insert((msg.span(), msg.kind()))
+        })
+    }
+
+    /// Puts the message bundle into a consistent state (sorted + all other metadata is correct)
+    fn make_uniform(&mut self) {
+        self.messages.sort_by_key(|item| item.span());
+    }
+}
+
+/// A reported message
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReportMessage {
+    // FIXME: These don't need to be pub crate
+    pub(crate) header: SourceAnnotation,
+    pub(crate) annotations: Vec<SourceAnnotation>,
+    pub(crate) footer: Vec<Annotation>,
+}
+
+impl ReportMessage {
+    /// Gets the kind of message reported
+    pub fn kind(&self) -> AnnotateKind {
+        self.header.kind()
+    }
+
+    /// Gets the reported message
+    pub fn message(&self) -> &str {
+        self.header.message()
+    }
+
+    /// Gets the span of text the message covers
+    pub fn span(&self) -> Span {
+        self.header.span()
+    }
+
+    /// Gets any associated annotations
+    pub fn annotations(&self) -> &[SourceAnnotation] {
+        &self.annotations
+    }
+
+    /// Gets any footer annotations (any annotation without a location in the source)
+    pub fn footer(&self) -> &[Annotation] {
+        &self.footer
+    }
+}
+
+impl fmt::Display for ReportMessage {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.header)?;
+
+        // Report any annotations
+        for annotation in &self.annotations {
+            write!(f, "\n| {:#}", annotation)?;
+        }
+
+        // Report any footer messages
+        for annotation in &self.footer {
+            write!(f, "\n| {:#}", annotation)?;
+        }
+
+        Ok(())
+    }
+}

--- a/compiler/toc_reporting/src/reporter.rs
+++ b/compiler/toc_reporting/src/reporter.rs
@@ -1,0 +1,196 @@
+//! Message generation
+
+use toc_span::Span;
+
+use crate::{AnnotateKind, Annotation, MessageBundle, ReportMessage, SourceAnnotation};
+
+/// Sink for message reports
+#[derive(Debug, Default)]
+pub struct MessageSink {
+    messages: Vec<ReportMessage>,
+}
+
+impl MessageSink {
+    pub fn new() -> Self {
+        Self { messages: vec![] }
+    }
+
+    /// Merges an existing set of messages into a new MessageSink
+    pub fn with_messages(messages: Vec<ReportMessage>) -> Self {
+        Self { messages }
+    }
+
+    /// Reports an error message
+    pub fn error(&mut self, message: &str, span: Span) {
+        self.report(AnnotateKind::Error, message, span)
+    }
+
+    /// Reports a detailed error message
+    pub fn error_detailed(&mut self, message: &str, span: Span) -> MessageBuilder {
+        self.report_detailed(AnnotateKind::Error, message, span)
+    }
+
+    /// Reports a warning message
+    pub fn warn(&mut self, message: &str, span: Span) {
+        self.report(AnnotateKind::Warning, message, span)
+    }
+
+    /// Reports a detailed warning message
+    pub fn warn_detailed(&mut self, message: &str, span: Span) -> MessageBuilder {
+        self.report_detailed(AnnotateKind::Warning, message, span)
+    }
+
+    /// Reports a message
+    ///
+    /// Does not add any annotations to the message
+    fn report(&mut self, kind: AnnotateKind, message: &str, span: Span) {
+        MessageBuilder::new(self, kind, message, span).finish();
+    }
+
+    /// Reports a detailed message
+    ///
+    /// Returns a builder for adding annotations
+    #[must_use = "message is not reported until `finish()` is called"]
+    fn report_detailed(&mut self, kind: AnnotateKind, message: &str, span: Span) -> MessageBuilder {
+        MessageBuilder::new(self, kind, message, span)
+    }
+
+    /* /// Removes any subsequent messages that share the same text range
+    pub fn dedup_shared_ranges(&mut self) {
+        self.messages
+            .dedup_by(|a, b| a.header.span == b.header.span && a.kind() == b.kind())
+    } */
+
+    /// Finishes reporting any messages, giving back the final message list
+    pub fn finish(self) -> MessageBundle {
+        MessageBundle::from_messages(self.messages)
+    }
+}
+
+/// Builder for detailed messages
+#[derive(Debug)]
+pub struct MessageBuilder<'a> {
+    drop_bomb: drop_bomb::DropBomb,
+    reporter: &'a mut MessageSink,
+    kind: AnnotateKind,
+    message: String,
+    span: Span,
+    annotations: Vec<SourceAnnotation>,
+    footer: Vec<Annotation>,
+}
+
+impl<'a> MessageBuilder<'a> {
+    pub fn new(
+        reporter: &'a mut MessageSink,
+        kind: AnnotateKind,
+        message: &str,
+        span: Span,
+    ) -> Self {
+        Self {
+            drop_bomb: drop_bomb::DropBomb::new("Missing `finish()` for MessageBuilder"),
+            reporter,
+            kind,
+            message: message.to_string(),
+            span,
+            annotations: vec![],
+            footer: vec![],
+        }
+    }
+
+    pub fn with_note<S>(self, message: &str, span: S) -> Self
+    where
+        S: Into<Option<Span>>,
+    {
+        self.with_annotation(AnnotateKind::Note, message, span)
+    }
+
+    pub fn with_info<S>(self, message: &str, span: S) -> Self
+    where
+        S: Into<Option<Span>>,
+    {
+        self.with_annotation(AnnotateKind::Info, message, span)
+    }
+
+    fn with_annotation<R>(mut self, kind: AnnotateKind, message: &str, span: R) -> Self
+    where
+        R: Into<Option<Span>>,
+    {
+        match span.into() {
+            Some(span) => self.annotations.push(SourceAnnotation {
+                annotation: Annotation {
+                    kind,
+                    msg: message.to_string(),
+                },
+                span,
+            }),
+            None => self.footer.push(Annotation {
+                kind,
+                msg: message.to_string(),
+            }),
+        }
+
+        self
+    }
+
+    pub fn finish(self) {
+        let MessageBuilder {
+            mut drop_bomb,
+            reporter,
+            kind,
+            message,
+            span,
+            annotations,
+            footer,
+        } = self;
+
+        // Defuse bomb now
+        drop_bomb.defuse();
+
+        reporter.messages.push(ReportMessage {
+            header: SourceAnnotation {
+                annotation: Annotation { kind, msg: message },
+                span,
+            },
+            annotations,
+            footer,
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use toc_span::TextRange;
+
+    use super::*;
+
+    #[test]
+    fn report_message() {
+        // Test message sorting as well
+        let mut sink = MessageSink::new();
+        sink.report(
+            AnnotateKind::Warning,
+            "a warning message",
+            Span::new(None, TextRange::new(3.into(), 5.into())),
+        );
+
+        sink.report(
+            AnnotateKind::Error,
+            "an error message",
+            Span::new(None, TextRange::new(1.into(), 3.into())),
+        );
+
+        let msgs = sink.finish();
+        let mut iter = msgs.iter();
+        let msg = iter.next().unwrap();
+        assert_eq!(
+            (msg.message(), msg.span().range),
+            ("an error message", TextRange::new(1.into(), 3.into()))
+        );
+
+        let msg = iter.next().unwrap();
+        assert_eq!(
+            (msg.message(), msg.span().range),
+            ("a warning message", TextRange::new(3.into(), 5.into()))
+        );
+    }
+}

--- a/compiler/toc_scanner/src/lib.rs
+++ b/compiler/toc_scanner/src/lib.rs
@@ -3,7 +3,7 @@ pub mod token;
 
 use logos::Logos;
 use std::ops::Range;
-use toc_reporting::MessageSink;
+use toc_reporting::{MessageBundle, MessageSink};
 use toc_span::FileId;
 use token::{NumberKind, Token, TokenKind};
 
@@ -21,8 +21,8 @@ impl ErrorFerry {
             .error(message, toc_span::Span::new(self.file_id, range));
     }
 
-    pub(crate) fn finish(self) -> MessageSink {
-        self.sink
+    pub(crate) fn finish(self) -> MessageBundle {
+        self.sink.finish()
     }
 }
 
@@ -40,7 +40,7 @@ impl<'s> Scanner<'s> {
         Self { inner }
     }
 
-    pub fn collect_all(mut self) -> (Vec<Token<'s>>, MessageSink) {
+    pub fn collect_all(mut self) -> (Vec<Token<'s>>, MessageBundle) {
         let mut toks = vec![];
 
         for token in &mut self {
@@ -98,11 +98,10 @@ mod test {
         (toks, errors)
     }
 
-    fn build_error_list(sink: MessageSink) -> String {
-        let errors = sink.finish();
+    fn build_error_list(errors: MessageBundle) -> String {
         let mut buf = String::new();
 
-        for msg in errors {
+        for msg in errors.iter() {
             let at = msg.span().range;
             let msg = msg.message();
 

--- a/compiler/toc_scanner/src/lib.rs
+++ b/compiler/toc_scanner/src/lib.rs
@@ -59,11 +59,9 @@ impl<'s> Scanner<'s> {
             },
             TokenKind::Error => {
                 // Report the invalid character
-                self.inner.extras.push_error(
-                    "invalid character",
-                    "", // intentionally left empty, message says it all
-                    self.inner.span(),
-                );
+                self.inner
+                    .extras
+                    .push_error("invalid character", "here", self.inner.span());
                 TokenKind::Error
             }
             other => other,
@@ -106,7 +104,6 @@ mod test {
         for msg in errors.iter() {
             buf.push_str(&msg.to_string());
         }
-        buf.pop();
 
         buf
     }
@@ -174,53 +171,73 @@ mod test {
         expect_with_error(
             "[",
             &TokenKind::Error,
-            expect![[r#"error at 0..1: invalid character"#]],
+            expect![[r#"
+                error at 0..1: invalid character
+                | error for 0..1: here"#]],
         );
         expect_with_error(
             "]",
             &TokenKind::Error,
-            expect![[r#"error at 0..1: invalid character"#]],
+            expect![[r#"
+                error at 0..1: invalid character
+                | error for 0..1: here"#]],
         );
         expect_with_error(
             "{",
             &TokenKind::Error,
-            expect![[r#"error at 0..1: invalid character"#]],
+            expect![[r#"
+                error at 0..1: invalid character
+                | error for 0..1: here"#]],
         );
         expect_with_error(
             "}",
             &TokenKind::Error,
-            expect![[r#"error at 0..1: invalid character"#]],
+            expect![[r#"
+                error at 0..1: invalid character
+                | error for 0..1: here"#]],
         );
         expect_with_error(
             "!",
             &TokenKind::Error,
-            expect![[r#"error at 0..1: invalid character"#]],
+            expect![[r#"
+                error at 0..1: invalid character
+                | error for 0..1: here"#]],
         );
         expect_with_error(
             "$",
             &TokenKind::Error,
-            expect![[r#"error at 0..1: invalid character"#]],
+            expect![[r#"
+                error at 0..1: invalid character
+                | error for 0..1: here"#]],
         );
         expect_with_error(
             "?",
             &TokenKind::Error,
-            expect![[r#"error at 0..1: invalid character"#]],
+            expect![[r#"
+                error at 0..1: invalid character
+                | error for 0..1: here"#]],
         );
         expect_with_error(
             "`",
             &TokenKind::Error,
-            expect![[r#"error at 0..1: invalid character"#]],
+            expect![[r#"
+                error at 0..1: invalid character
+                | error for 0..1: here"#]],
         );
         expect_with_error(
             "\\",
             &TokenKind::Error,
-            expect![[r#"error at 0..1: invalid character"#]],
+            expect![[r#"
+                error at 0..1: invalid character
+                | error for 0..1: here"#]],
         );
         // Was originally `🧑‍🔬` but that gets split up into multiple tokens
         expect_with_error(
             "🧑",
             &TokenKind::Error,
-            expect![[r#"error at 0..4: invalid character"#]],
+            expect![[r#"
+                error at 0..4: invalid character
+                | error for 0..4: here"#]],
         );
     }
 
@@ -612,21 +629,27 @@ mod test {
         expect_with_error(
             "/* ",
             &TokenKind::Comment,
-            expect![[r#"error at 0..3: block comment is missing terminating ’*/’"#]],
+            expect![[r#"
+                error at 0..3: unterminated block comment
+                | error for 0..3: block comment is missing terminating ’*/’"#]],
         );
 
         // Respecting nesting
         expect_with_error(
             "/* /* abcd */",
             &TokenKind::Comment,
-            expect![[r#"error at 0..13: block comment is missing terminating ’*/’"#]],
+            expect![[r#"
+                error at 0..13: unterminated block comment
+                | error for 0..13: block comment is missing terminating ’*/’"#]],
         );
 
         // With trailing spaces
         expect_with_error(
             "/* /* abcd */ ",
             &TokenKind::Comment,
-            expect![[r#"error at 0..14: block comment is missing terminating ’*/’"#]],
+            expect![[r#"
+                error at 0..14: unterminated block comment
+                | error for 0..14: block comment is missing terminating ’*/’"#]],
         );
     }
 
@@ -742,7 +765,9 @@ mod test {
         expect_with_error(
             "/*/*",
             &TokenKind::Comment,
-            expect![[r#"error at 0..4: block comment is missing terminating ’*/’"#]],
+            expect![[r#"
+                error at 0..4: unterminated block comment
+                | error for 0..4: block comment is missing terminating ’*/’"#]],
         );
     }
 
@@ -751,7 +776,9 @@ mod test {
         expect_seq_with_errors(
             "2#پ",
             &[(TokenKind::RadixLiteral, "2#"), (TokenKind::Error, "پ")],
-            expect![[r#"error at 2..4: invalid character"#]],
+            expect![[r#"
+                error at 2..4: invalid character
+                | error for 2..4: here"#]],
         );
     }
 }

--- a/compiler/toc_scanner/src/token.rs
+++ b/compiler/toc_scanner/src/token.rs
@@ -411,9 +411,11 @@ fn lex_block_comment(lexer: &mut logos::Lexer<TokenKind>) {
     // missing terminator
     lexer.bump(bump_len);
 
-    lexer
-        .extras
-        .push_error("block comment is missing terminating ’*/’", lexer.span());
+    lexer.extras.push_error(
+        "unterminated block comment",
+        "block comment is missing terminating ’*/’",
+        lexer.span(),
+    );
 }
 
 fn nom_char_literal(lexer: &mut logos::Lexer<TokenKind>) {

--- a/compiler/toc_span/src/lib.rs
+++ b/compiler/toc_span/src/lib.rs
@@ -31,6 +31,21 @@ pub struct Span {
     pub range: TextRange,
 }
 
+impl Ord for Span {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        // Sorted by file, then by start range
+        self.file
+            .cmp(&other.file)
+            .then(self.range.start().cmp(&other.range.start()))
+    }
+}
+
+impl PartialOrd for Span {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
 impl Span {
     pub fn new(file: Option<FileId>, range: TextRange) -> Self {
         Span { file, range }

--- a/compiler/toc_syntax/src/ast/nodes_ext.rs
+++ b/compiler/toc_syntax/src/ast/nodes_ext.rs
@@ -619,7 +619,7 @@ impl IoCap {
 
 impl AsnOp {
     pub fn asn_kind(&self) -> Option<AssignOp> {
-        let op = self.asn_node()?;
+        let op = self.asn_op()?;
 
         let kind = match op.kind() {
             SyntaxKind::Assign => AssignOp::None,
@@ -645,7 +645,7 @@ impl AsnOp {
         Some(kind)
     }
 
-    pub fn asn_node(&self) -> Option<SyntaxElement> {
+    pub fn asn_op(&self) -> Option<SyntaxElement> {
         self.syntax().children_with_tokens().next()
     }
 }

--- a/compiler/toc_syntax/src/ast/nodes_ext.rs
+++ b/compiler/toc_syntax/src/ast/nodes_ext.rs
@@ -294,11 +294,6 @@ impl<'a> CharSeqExtractor<'a> {
         // Do the extraction
         extractor.do_extraction();
 
-        if !as_str_literal && text.is_empty() {
-            // Zero-length char-seq string
-            extractor.push_error(InvalidChar::EmptySequence, 0, 1);
-        }
-
         let Self {
             extracted_text,
             errors,
@@ -319,6 +314,10 @@ impl<'a> CharSeqExtractor<'a> {
                 _ => {
                     if current == self.ending_delimiter {
                         // At the ending delimiter, stop
+                        if self.ending_delimiter == '\'' && self.extracted_text.is_empty() {
+                            // Zero-length char-seq string
+                            self.push_error(InvalidChar::EmptySequence, 0, 1);
+                        }
                         return;
                     } else {
                         // Append character

--- a/compiler/toc_syntax/src/lib.rs
+++ b/compiler/toc_syntax/src/lib.rs
@@ -719,7 +719,7 @@ pub enum InvalidInt {
     BaseInvalidDigit(char, u8, Range<usize>),
     #[error("missing radix digits")]
     MissingRadix,
-    #[error("base for explicit int literal is not between 2 - 36")]
+    #[error("base is not between 2 - 36")]
     InvalidBase(Range<usize>),
     #[error("invalid literal")]
     Invalid,

--- a/compiler/toc_syntax/src/lib.rs
+++ b/compiler/toc_syntax/src/lib.rs
@@ -3,8 +3,12 @@
 #[allow(clippy::upper_case_acronyms)] // Names are pulled from the grammar file exactly
 pub mod ast;
 
+use std::fmt;
+use std::ops::Range;
+
 use num_traits::{FromPrimitive, ToPrimitive};
 use rowan::Language;
+use toc_span::TextRange;
 
 #[macro_use]
 extern crate num_derive;
@@ -641,68 +645,114 @@ pub enum LiteralValue {
 
 #[derive(Debug, thiserror::Error)]
 pub enum LiteralParseError {
-    // Real Literals
-    #[error("real literal is too large")]
-    RealTooLarge,
-    #[error("real literal is too small")]
-    RealTooSmall,
-    #[error("invalid real literal")]
-    RealInvalid,
-    #[error("real literal is missing exponent digits")]
-    RealMissingExponent,
-    // Int Literals
-    #[error("int literal is too large")]
-    IntTooLarge,
-    #[error("explicit int literal is too large")]
-    IntRadixTooLarge,
-    #[error("invalid digit for the specified base")]
-    IntRadixInvalidDigit(usize, usize),
-    #[error("explicit int literal is missing radix digits")]
-    IntMissingRadix,
-    #[error("base for explicit int literal is not between 2 - 36")]
-    IntInvalidBase,
-    #[error("invalid int literal")]
-    IntInvalid,
-    // Char Sequences
-    #[error("invalid string literal: {0:}")]
-    StringError(CharSeqParseError, usize, usize),
-    #[error("invalid char literal: {0:}")]
-    CharError(CharSeqParseError, usize, usize),
+    #[error("invalid real literal: {0: }")]
+    Real(InvalidReal),
+    #[error("invalid int literal: {0:}")]
+    Int(InvalidInt),
+    #[error("invalid string literal\n{0:}")]
+    String(InvalidCharsList),
+    #[error("invalid char literal\n{0:}")]
+    Char(InvalidCharsList),
 }
 
 impl LiteralParseError {
-    pub fn message_at(&self, span: toc_span::TextRange) -> (toc_span::TextRange, &Self) {
-        use std::convert::TryInto;
-        use toc_span::{TextRange, TextSize};
-
-        /// Offsets the given range pair by `source_span`
-        fn offset_span(start: usize, end: usize, source_span: TextRange) -> TextRange {
-            let (start, end): (TextSize, TextSize) = (
-                start
-                    .try_into()
-                    .unwrap_or_else(|_| TextSize::from(u32::MAX)),
-                end.try_into().unwrap_or_else(|_| TextSize::from(u32::MAX)),
-            );
-
-            TextRange::new(source_span.start() + start, source_span.start() + end)
+    pub fn header(&self) -> &str {
+        match self {
+            LiteralParseError::Real(_) => "invalid real literal",
+            LiteralParseError::Int(_) => "invalid int literal",
+            LiteralParseError::String(_) => "invalid string literal",
+            LiteralParseError::Char(_) => "invalid char literal",
         }
+    }
 
-        // Offset the text pair to the correct location
-        let report_span = match self {
-            LiteralParseError::StringError(_, start, end)
-            | LiteralParseError::CharError(_, start, end)
-            | LiteralParseError::IntRadixInvalidDigit(start, end) => {
-                offset_span(*start, *end, span)
-            }
-            _ => span,
-        };
-
-        (report_span, self)
+    pub fn parts(&self, base_span: TextRange) -> Vec<(String, TextRange)> {
+        match self {
+            LiteralParseError::Real(kind) => vec![(kind.to_string(), base_span)],
+            LiteralParseError::Int(kind) => vec![(kind.to_string(), kind.span(base_span))],
+            LiteralParseError::String(errs) | LiteralParseError::Char(errs) => errs
+                .0
+                .iter()
+                .map(|(err, at)| (err.to_string(), offset_span(at, base_span)))
+                .collect(),
+        }
     }
 }
 
+/// Offsets the given range pair by `source_span`
+fn offset_span(range: &Range<usize>, base_span: TextRange) -> TextRange {
+    use std::convert::TryInto;
+    use toc_span::TextSize;
+
+    let (start, end): (TextSize, TextSize) = (
+        range
+            .start
+            .try_into()
+            .unwrap_or_else(|_| TextSize::from(u32::MAX)),
+        range
+            .end
+            .try_into()
+            .unwrap_or_else(|_| TextSize::from(u32::MAX)),
+    );
+
+    TextRange::new(base_span.start() + start, base_span.start() + end)
+}
+
 #[derive(Debug, thiserror::Error)]
-pub enum CharSeqParseError {
+pub enum InvalidReal {
+    #[error("number is too large")]
+    TooLarge,
+    #[error("number is too small")]
+    TooSmall,
+    #[error("missing exponent digits")]
+    MissingExponent,
+    #[error("invalid literal")]
+    Invalid,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum InvalidInt {
+    #[error("number is too large")]
+    TooLarge,
+    #[error("number is too large")]
+    RadixTooLarge(Range<usize>),
+    #[error("`{0:}` is not a digit in base {1:}")]
+    BaseInvalidDigit(char, u8, Range<usize>),
+    #[error("missing radix digits")]
+    MissingRadix,
+    #[error("base for explicit int literal is not between 2 - 36")]
+    InvalidBase(Range<usize>),
+    #[error("invalid literal")]
+    Invalid,
+}
+
+impl InvalidInt {
+    fn span(&self, span: TextRange) -> TextRange {
+        match self {
+            InvalidInt::RadixTooLarge(range)
+            | InvalidInt::BaseInvalidDigit(_, _, range)
+            | InvalidInt::InvalidBase(range) => offset_span(range, span),
+            _ => span,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct InvalidCharsList(pub(crate) Vec<(InvalidChar, Range<usize>)>);
+
+impl fmt::Display for InvalidCharsList {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for (err, range) in self.0.iter() {
+            writeln!(f, "| at {:?}: {}", range, err)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl std::error::Error for InvalidCharsList {}
+
+#[derive(Debug, thiserror::Error)]
+pub enum InvalidChar {
     #[error("octal character value is greater than \\377 (decimal 255)")]
     InvalidOctalChar,
     #[error("unicode codepoint value is greater than U+10FFFF")]

--- a/compiler/toc_validate/src/preproc/test.rs
+++ b/compiler/toc_validate/src/preproc/test.rs
@@ -6,7 +6,9 @@ use expect_test::expect;
 fn report_dangling_pp_else() {
     check(
         "#else #end if",
-        expect![[r##"error at 0..5: found ‘#else’ without matching ‘#if’"##]],
+        expect![[r##"
+            error at 0..5: found dangling ‘#else’
+            | error for 0..5: this ‘#else’ does not have a matching ‘#if’"##]],
     );
 }
 
@@ -14,7 +16,9 @@ fn report_dangling_pp_else() {
 fn report_dangling_pp_elseif() {
     check(
         "#elsif Some then #end if",
-        expect![[r##"error at 0..6: found ‘#elsif’ without matching ‘#if’"##]],
+        expect![[r##"
+            error at 0..6: found dangling ‘#elsif’
+            | error for 0..6: this ‘#elsif’ does not have a matching ‘#if’"##]],
     );
 }
 
@@ -22,7 +26,9 @@ fn report_dangling_pp_elseif() {
 fn report_dangling_pp_endif() {
     check(
         "#end if",
-        expect![[r##"error at 0..4: found ‘#end’ without matching ‘#if’"##]],
+        expect![[r##"
+            error at 0..4: found dangling ‘#end’
+            | error for 0..4: this ‘#end’ does not have a matching ‘#if’"##]],
     );
 }
 

--- a/compiler/toc_validate/src/stmt/test.rs
+++ b/compiler/toc_validate/src/stmt/test.rs
@@ -6,7 +6,9 @@ use expect_test::expect;
 fn report_dangling_else() {
     check(
         "else end if",
-        expect![[r#"error at 0..4: found ‘else’ without matching ‘if’"#]],
+        expect![[r#"
+            error at 0..4: found dangling ‘else’
+            | error for 0..4: this ‘else’ does not have a matching ‘if’"#]],
     );
 }
 
@@ -14,7 +16,9 @@ fn report_dangling_else() {
 fn report_dangling_elseif() {
     check(
         "elsif true then end if",
-        expect![[r#"error at 0..5: found ‘elsif’ without matching ‘if’"#]],
+        expect![[r#"
+            error at 0..5: found dangling ‘elsif’
+            | error for 0..5: this ‘elsif’ does not have a matching ‘if’"#]],
     );
 }
 
@@ -22,7 +26,9 @@ fn report_dangling_elseif() {
 fn report_monitor_class_with_dev_spec() {
     check(
         "monitor class a : 1 end a",
-        expect![[r#"error at 16..19: device specification is not allowed for monitor classes"#]],
+        expect![[r#"
+            error at 16..19: device specification is not allowed here
+            | error for 16..19: device specification is not allowed for monitor classes"#]],
     );
 }
 
@@ -63,7 +69,9 @@ fn report_mismatched_monitor_names() {
 fn only_missing_module_decl_name() {
     check(
         "monitor end b",
-        expect![[r#"error at 8..11: expected identifier, but found ‘end’"#]],
+        expect![[r#"
+            error at 8..11: unexpected token
+            | error for 8..11: expected identifier, but found ‘end’"#]],
     );
 }
 
@@ -71,7 +79,9 @@ fn only_missing_module_decl_name() {
 fn only_missing_module_end_name() {
     check(
         "monitor a end",
-        expect![[r#"error at 10..13: expected identifier after here"#]],
+        expect![[r#"
+            error at 10..13: unexpected end of file
+            | error for 10..13: expected identifier after here"#]],
     );
 }
 
@@ -79,9 +89,9 @@ fn only_missing_module_end_name() {
 fn report_var_register_attr_in_main() {
     check(
         "var register a : int",
-        expect![[
-            r#"error at 4..12: ‘register’ attribute is not allowed at module-like or program level"#
-        ]],
+        expect![[r#"
+            error at 4..12: cannot use ‘register’ here
+            | error for 4..12: ‘register’ attribute is not allowed at module-like or program level"#]],
     );
 }
 
@@ -90,8 +100,10 @@ fn report_var_register_attr_in_unit() {
     check(
         "unit var register a : int",
         expect![[r#"
-            error at 5..25: expected a module, class, or monitor declaration
-            error at 9..17: ‘register’ attribute is not allowed at module-like or program level"#]],
+            error at 5..25: invalid unit file
+            | error for 5..25: expected a module, class, or monitor declaration
+            error at 9..17: cannot use ‘register’ here
+            | error for 9..17: ‘register’ attribute is not allowed at module-like or program level"#]],
     );
 }
 
@@ -99,9 +111,9 @@ fn report_var_register_attr_in_unit() {
 fn report_var_register_attr_in_module() {
     check(
         "module a var register a : int end a",
-        expect![[
-            r#"error at 13..21: ‘register’ attribute is not allowed at module-like or program level"#
-        ]],
+        expect![[r#"
+            error at 13..21: cannot use ‘register’ here
+            | error for 13..21: ‘register’ attribute is not allowed at module-like or program level"#]],
     );
 }
 
@@ -109,9 +121,9 @@ fn report_var_register_attr_in_module() {
 fn report_var_register_attr_in_monitor() {
     check(
         "monitor a var register a : int end a",
-        expect![[
-            r#"error at 14..22: ‘register’ attribute is not allowed at module-like or program level"#
-        ]],
+        expect![[r#"
+            error at 14..22: cannot use ‘register’ here
+            | error for 14..22: ‘register’ attribute is not allowed at module-like or program level"#]],
     );
 }
 
@@ -119,9 +131,9 @@ fn report_var_register_attr_in_monitor() {
 fn report_var_register_attr_in_class() {
     check(
         "class a var register a : int end a",
-        expect![[
-            r#"error at 12..20: ‘register’ attribute is not allowed at module-like or program level"#
-        ]],
+        expect![[r#"
+            error at 12..20: cannot use ‘register’ here
+            | error for 12..20: ‘register’ attribute is not allowed at module-like or program level"#]],
     );
 }
 
@@ -178,8 +190,10 @@ end b
 end a
     "#,
         expect![[r#"
-            error at 24..29: classes cannot be declared inside of other classes
-            error at 62..67: monitor classes cannot be declared inside of classes"#]],
+            error at 24..29: cannot declare a ‘class’ here
+            | error for 24..29: classes cannot be declared inside of other classes
+            error at 62..67: cannot declare a ‘monitor class’ here
+            | error for 62..67: monitor classes cannot be declared inside of classes"#]],
     );
 }
 
@@ -199,9 +213,12 @@ end b
 end a
     "#,
         expect![[r#"
-            error at 26..31: classes cannot be declared inside of monitors
-            error at 40..47: monitors cannot be declared inside of other monitors
-            error at 64..69: monitor classes cannot be declared inside of monitors"#]],
+            error at 26..31: cannot declare a ‘class’ here
+            | error for 26..31: classes cannot be declared inside of monitors
+            error at 40..47: cannot declare a ‘monitor’ here
+            | error for 40..47: monitors cannot be declared inside of other monitors
+            error at 64..69: cannot declare a ‘monitor class’ here
+            | error for 64..69: monitor classes cannot be declared inside of monitors"#]],
     );
 }
 
@@ -221,9 +238,12 @@ end b
 end a
     "#,
         expect![[r#"
-            error at 32..37: classes cannot be declared inside of monitors
-            error at 46..53: monitors cannot be declared inside of other monitors
-            error at 70..75: monitor classes cannot be declared inside of monitors"#]],
+            error at 32..37: cannot declare a ‘class’ here
+            | error for 32..37: classes cannot be declared inside of monitors
+            error at 46..53: cannot declare a ‘monitor’ here
+            | error for 46..53: monitors cannot be declared inside of other monitors
+            error at 70..75: cannot declare a ‘monitor class’ here
+            | error for 70..75: monitor classes cannot be declared inside of monitors"#]],
     );
 }
 
@@ -231,9 +251,9 @@ end a
 fn report_bind_decl_in_main_block() {
     check(
         "bind a to b",
-        expect![[
-            r#"error at 0..11: ‘bind’ declaration is not allowed at module-like or program level"#
-        ]],
+        expect![[r#"
+            error at 0..11: cannot use ‘bind’ here
+            | error for 0..11: ‘bind’ declaration is not allowed at module-like or program level"#]],
     );
 }
 
@@ -241,9 +261,9 @@ fn report_bind_decl_in_main_block() {
 fn report_bind_decl_in_module_block() {
     check(
         "module q bind a to b end q",
-        expect![[
-            r#"error at 9..20: ‘bind’ declaration is not allowed at module-like or program level"#
-        ]],
+        expect![[r#"
+            error at 9..20: cannot use ‘bind’ here
+            | error for 9..20: ‘bind’ declaration is not allowed at module-like or program level"#]],
     );
 }
 
@@ -251,9 +271,9 @@ fn report_bind_decl_in_module_block() {
 fn report_bind_decl_in_class_block() {
     check(
         "class q bind a to b end q",
-        expect![[
-            r#"error at 8..19: ‘bind’ declaration is not allowed at module-like or program level"#
-        ]],
+        expect![[r#"
+            error at 8..19: cannot use ‘bind’ here
+            | error for 8..19: ‘bind’ declaration is not allowed at module-like or program level"#]],
     );
 }
 
@@ -261,9 +281,9 @@ fn report_bind_decl_in_class_block() {
 fn report_bind_decl_in_monitor_block() {
     check(
         "monitor q bind a to b end q",
-        expect![[
-            r#"error at 10..21: ‘bind’ declaration is not allowed at module-like or program level"#
-        ]],
+        expect![[r#"
+            error at 10..21: cannot use ‘bind’ here
+            | error for 10..21: ‘bind’ declaration is not allowed at module-like or program level"#]],
     );
 }
 
@@ -271,9 +291,9 @@ fn report_bind_decl_in_monitor_block() {
 fn report_bind_decl_in_monitor_class_block() {
     check(
         "monitor class q bind a to b end q",
-        expect![[
-            r#"error at 16..27: ‘bind’ declaration is not allowed at module-like or program level"#
-        ]],
+        expect![[r#"
+            error at 16..27: cannot use ‘bind’ here
+            | error for 16..27: ‘bind’ declaration is not allowed at module-like or program level"#]],
     );
 }
 
@@ -290,8 +310,9 @@ fn report_init_expr_with_int_ty() {
     check(
         "var a : int := init(1)",
         expect![[r#"
-            error at 15..22: ‘init’ initializer is not allowed here
-            | note for 8..11: cannot use ‘init’ initializer with this type
+            error at 15..22: mismatched initializer
+            | error for 15..22: ‘init’ initializer is not allowed here
+            | error for 8..11: cannot use ‘init’ initializer with this type
             | info: ‘init’ initializer can only be used with array, record, or union types"#]],
     );
 }
@@ -300,7 +321,10 @@ fn report_init_expr_with_int_ty() {
 fn report_init_expr_with_no_ty() {
     check(
         "var a := init(1)",
-        expect![[r#"error at 9..16: ‘init’ initializer is not allowed here"#]],
+        expect![[r#"
+            error at 9..16: mismatched initializer
+            | error for 9..16: ‘init’ initializer is not allowed here
+            | info: ‘init’ initializer requires a type to be specified"#]],
     );
 }
 
@@ -327,7 +351,8 @@ fn report_not_init_expr_with_unbounded_array() {
     check(
         "var a : array 1 .. * of int := 2",
         expect![[r#"
-            error at 31..32: ‘init’ initializer is required here
+            error at 31..32: mismatched initializer
+            | error for 31..32: ‘init’ initializer required here
             | note for 8..27: this is an unbounded array type
             | info: unbounded arrays have their upper bounds specified by ‘init’ initializers"#]],
     );
@@ -338,7 +363,8 @@ fn report_no_initializer_with_unbounded_array() {
     check(
         "var a : array 1 .. * of int",
         expect![[r#"
-            error at 8..27: ‘init’ initializer is required after here
+            error at 8..27: mismatched initializer
+            | error for 8..27: ‘init’ initializer required after here
             | note for 8..27: this is an unbounded array type
             | info: unbounded arrays have their upper bounds specified by ‘init’ initializers"#]],
     );
@@ -358,9 +384,9 @@ fn proc_decl_in_module() {
 fn report_proc_decl_in_proc_decl() {
     check(
         "proc a proc a end a end a",
-        expect![[
-            r#"error at 7..19: ‘procedure’ declaration is only allowed at module-like or program level"#
-        ]],
+        expect![[r#"
+            error at 7..19: cannot use ‘procedure’ declaration here
+            | error for 7..19: ‘procedure’ declaration is only allowed at module-like or program level"#]],
     );
 }
 
@@ -368,9 +394,9 @@ fn report_proc_decl_in_proc_decl() {
 fn report_proc_decl_in_block_stmt() {
     check(
         "begin proc a end a end",
-        expect![[
-            r#"error at 6..18: ‘procedure’ declaration is only allowed at module-like or program level"#
-        ]],
+        expect![[r#"
+            error at 6..18: cannot use ‘procedure’ declaration here
+            | error for 6..18: ‘procedure’ declaration is only allowed at module-like or program level"#]],
     );
 }
 
@@ -378,7 +404,9 @@ fn report_proc_decl_in_block_stmt() {
 fn report_dev_spec_in_forward_decl() {
     check(
         "forward proc a : 2",
-        expect![[r#"error at 15..18: device specification is not allowed here"#]],
+        expect![[r#"
+            error at 15..18: device specification is not allowed here
+            | error for 15..18: not part of a ‘procedure’ declaration"#]],
     );
 }
 
@@ -386,7 +414,9 @@ fn report_dev_spec_in_forward_decl() {
 fn report_dev_spec_in_main_proc() {
     check(
         "proc a : 2 end a",
-        expect![[r#"error at 7..10: device specification is not allowed here"#]],
+        expect![[r#"
+            error at 7..10: device specification is not allowed here
+            | error for 7..10: ‘procedure’ is not in a device monitor"#]],
     );
 }
 
@@ -394,7 +424,9 @@ fn report_dev_spec_in_main_proc() {
 fn report_dev_spec_in_monitor_proc() {
     check(
         "monitor a proc a : 2 end a end a",
-        expect![[r#"error at 17..20: device specification is not allowed here"#]],
+        expect![[r#"
+            error at 17..20: device specification is not allowed here
+            | error for 17..20: ‘procedure’ is not in a device monitor"#]],
     );
 }
 
@@ -417,9 +449,9 @@ fn fcn_decl_in_module() {
 fn report_fcn_decl_in_fcn_decl() {
     check(
         "fcn a : int fcn a : int end a end a",
-        expect![[
-            r#"error at 12..29: ‘function’ declaration is only allowed at module-like or program level"#
-        ]],
+        expect![[r#"
+            error at 12..29: cannot use ‘function’ declaration here
+            | error for 12..29: ‘function’ declaration is only allowed at module-like or program level"#]],
     );
 }
 
@@ -427,9 +459,9 @@ fn report_fcn_decl_in_fcn_decl() {
 fn report_fcn_decl_in_block_stmt() {
     check(
         "begin fcn a : int end a end",
-        expect![[
-            r#"error at 6..23: ‘function’ declaration is only allowed at module-like or program level"#
-        ]],
+        expect![[r#"
+            error at 6..23: cannot use ‘function’ declaration here
+            | error for 6..23: ‘function’ declaration is only allowed at module-like or program level"#]],
     );
 }
 
@@ -452,9 +484,9 @@ fn process_decl_in_monitor() {
 fn report_process_decl_in_monitor_class() {
     check(
         "monitor class q process a end a end q",
-        expect![[
-            r#"error at 16..31: ‘process’ declarations is not allowed in classes or monitor classes"#
-        ]],
+        expect![[r#"
+            error at 16..31: cannot declare a ‘process’ here
+            | error for 16..31: ‘process’ declarations is not allowed in classes or monitor classes"#]],
     );
 }
 
@@ -462,9 +494,9 @@ fn report_process_decl_in_monitor_class() {
 fn report_process_decl_in_class() {
     check(
         "class q process a end a end q",
-        expect![[
-            r#"error at 8..23: ‘process’ declarations is not allowed in classes or monitor classes"#
-        ]],
+        expect![[r#"
+            error at 8..23: cannot declare a ‘process’ here
+            | error for 8..23: ‘process’ declarations is not allowed in classes or monitor classes"#]],
     );
 }
 
@@ -472,9 +504,9 @@ fn report_process_decl_in_class() {
 fn report_process_decl_in_process_decl() {
     check(
         "process a process a end a end a",
-        expect![[
-            r#"error at 10..25: ‘process’ declaration is only allowed at the top level of ‘monitor’s and ‘module’s"#
-        ]],
+        expect![[r#"
+            error at 10..25: cannot declare a ‘process’ here
+            | error for 10..25: ‘process’ declaration is only allowed at the top level of ‘monitor’s and ‘module’s"#]],
     );
 }
 
@@ -482,9 +514,9 @@ fn report_process_decl_in_process_decl() {
 fn report_process_decl_in_block_stmt() {
     check(
         "begin process a end a end",
-        expect![[
-            r#"error at 6..21: ‘process’ declaration is only allowed at the top level of ‘monitor’s and ‘module’s"#
-        ]],
+        expect![[r#"
+            error at 6..21: cannot declare a ‘process’ here
+            | error for 6..21: ‘process’ declaration is only allowed at the top level of ‘monitor’s and ‘module’s"#]],
     );
 }
 
@@ -492,7 +524,9 @@ fn report_process_decl_in_block_stmt() {
 fn report_external_var() {
     check(
         "external \"eee\" var a := 1",
-        expect![[r#"error at 15..25: ‘external’ variables are not supported in this compiler"#]],
+        expect![[r#"
+            error at 15..25: unsupported declaration
+            | error for 15..25: ‘external’ variables are not supported in this compiler"#]],
     );
 }
 
@@ -500,9 +534,9 @@ fn report_external_var() {
 fn report_deferred_decl_in_main() {
     check(
         "deferred proc a",
-        expect![[
-            r#"error at 0..15: ‘deferred’ declaration is only allowed in module-like blocks"#
-        ]],
+        expect![[r#"
+            error at 0..15: cannot use ‘deferred’ here
+            | error for 0..15: ‘deferred’ is only allowed in module-like blocks"#]],
     );
 }
 
@@ -540,9 +574,9 @@ fn forward_decl_in_module() {
 fn report_forward_decl_in_proc_decl() {
     check(
         "proc a forward proc a end a",
-        expect![[
-            r#"error at 7..21: ‘forward’ declaration is only allowed at module-like or program level"#
-        ]],
+        expect![[r#"
+            error at 7..21: cannot use ‘forward’ declaration here
+            | error for 7..21: ‘forward’ declaration is only allowed at module-like or program level"#]],
     );
 }
 
@@ -550,9 +584,9 @@ fn report_forward_decl_in_proc_decl() {
 fn report_forward_decl_in_block_stmt() {
     check(
         "begin forward proc a end",
-        expect![[
-            r#"error at 6..20: ‘forward’ declaration is only allowed at module-like or program level"#
-        ]],
+        expect![[r#"
+            error at 6..20: cannot use ‘forward’ declaration here
+            | error for 6..20: ‘forward’ declaration is only allowed at module-like or program level"#]],
     );
 }
 
@@ -570,9 +604,9 @@ fn body_decl_in_module() {
 fn report_body_decl_in_proc_decl() {
     check(
         "proc a body a end a end a",
-        expect![[
-            r#"error at 7..19: ‘body’ declaration is only allowed at module-like or program level"#
-        ]],
+        expect![[r#"
+            error at 7..19: cannot use ‘body’ declaration here
+            | error for 7..19: ‘body’ declaration is only allowed at module-like or program level"#]],
     );
 }
 
@@ -580,9 +614,9 @@ fn report_body_decl_in_proc_decl() {
 fn report_body_decl_in_block_stmt() {
     check(
         "begin body a end a end",
-        expect![[
-            r#"error at 6..18: ‘body’ declaration is only allowed at module-like or program level"#
-        ]],
+        expect![[r#"
+            error at 6..18: cannot use ‘body’ declaration here
+            | error for 6..18: ‘body’ declaration is only allowed at module-like or program level"#]],
     );
 }
 
@@ -650,7 +684,9 @@ fn for_stmt_full_decreasing() {
 fn report_for_stmt_partial_decreasing() {
     check(
         "for decreasing : a end for",
-        expect![[r#"error at 17..18: decreasing for-loop requires explicit end bound"#]],
+        expect![[r#"
+            error at 17..18: invalid loop bound specification
+            | error for 17..18: decreasing for-loop requires explicit end bound"#]],
     );
 }
 
@@ -659,7 +695,9 @@ fn for_stmt_partial_decreasing_no_bounds() {
     // Don't duplicate errors
     check(
         "for decreasing : end for",
-        expect![[r#"error at 17..20: expected expression, but found ‘end’"#]],
+        expect![[r#"
+            error at 17..20: unexpected token
+            | error for 17..20: expected expression, but found ‘end’"#]],
     );
 }
 
@@ -667,7 +705,9 @@ fn for_stmt_partial_decreasing_no_bounds() {
 fn report_case_stmt_missing_arms() {
     check(
         "case a of end case",
-        expect![[r#"error at 0..18: Missing ‘label’ arms for ‘case’ statement"#]],
+        expect![[r#"
+            error at 0..18: invalid ‘case’ statement
+            | error for 0..18: missing ‘label’ arms"#]],
     );
 }
 
@@ -680,9 +720,9 @@ fn case_stmt_one_arm() {
 fn report_case_stmt_one_arm_default() {
     check(
         "case a of label : end case",
-        expect![[
-            r#"error at 10..18: First ‘label’ arm must have at least one selector expression"#
-        ]],
+        expect![[r#"
+            error at 10..18: cannot have a default ‘label’ arm as the first ‘case’ arm
+            | error for 10..18: First ‘label’ arm must have at least one selector expression"#]],
     );
 }
 
@@ -700,7 +740,9 @@ fn case_stmt_many_arms() {
 fn report_case_stmt_many_arms_many_defaults() {
     check(
         "case a of label 1: label : label : end case",
-        expect![[r#"error at 27..35: Extra ‘label’ arm found after default arm"#]],
+        expect![[r#"
+            error at 27..35: extra ‘label’ arm found after default arm
+            | error for 27..35: extra ‘label’ arm"#]],
     );
 }
 
@@ -708,7 +750,9 @@ fn report_case_stmt_many_arms_many_defaults() {
 fn report_case_stmt_many_arms_many_after_default() {
     check(
         "case a of label 1: label : label 2: label 2: label : end case",
-        expect![[r#"error at 27..53: Extra ‘label’ arms found after default arm"#]],
+        expect![[r#"
+            error at 27..53: extra ‘label’ arms found after default arm
+            | error for 27..53: extra ‘label’ arms"#]],
     );
 }
 
@@ -717,8 +761,10 @@ fn report_case_stmt_many_arms_after_first_default() {
     check(
         "case a of label : label 2: label 2: label : end case",
         expect![[r#"
-            error at 10..18: First ‘label’ arm must have at least one selector expression
-            error at 18..44: Extra ‘label’ arms found after default arm"#]],
+            error at 10..18: cannot have a default ‘label’ arm as the first ‘case’ arm
+            | error for 10..18: First ‘label’ arm must have at least one selector expression
+            error at 18..44: extra ‘label’ arms found after default arm
+            | error for 18..44: extra ‘label’ arms"#]],
     );
 }
 
@@ -771,9 +817,9 @@ fn invariant_stmt_in_monitor_class() {
 fn report_invariant_stmt_in_main() {
     check(
         "invariant false",
-        expect![[
-            r#"error at 0..15: ‘invariant’ statement is only allowed in loop statements and module-kind declarations"#
-        ]],
+        expect![[r#"
+            error at 0..15: cannot use ‘invariant’ here
+            | error for 0..15: ‘invariant’ statement is only allowed in loop statements and module-kind declarations"#]],
     );
 }
 
@@ -781,8 +827,8 @@ fn report_invariant_stmt_in_main() {
 fn report_invariant_stmt_in_inner() {
     check(
         "begin invariant false end",
-        expect![[
-            r#"error at 6..21: ‘invariant’ statement is only allowed in loop statements and module-kind declarations"#
-        ]],
+        expect![[r#"
+            error at 6..21: cannot use ‘invariant’ here
+            | error for 6..21: ‘invariant’ statement is only allowed in loop statements and module-kind declarations"#]],
     );
 }

--- a/compiler/toc_validate/src/test.rs
+++ b/compiler/toc_validate/src/test.rs
@@ -26,7 +26,9 @@ fn unit_monitor_class() {
 fn report_unit_not_allowed_decl() {
     check(
         "unit begin end",
-        expect![[r#"error at 5..14: expected a module, class, or monitor declaration"#]],
+        expect![[r#"
+            error at 5..14: invalid unit file
+            | error for 5..14: expected a module, class, or monitor declaration"#]],
     );
 }
 
@@ -36,8 +38,10 @@ fn report_unit_not_allowed_decl_and_extra() {
     check(
         "unit begin end begin end begin end",
         expect![[r#"
-            error at 5..14: expected a module, class, or monitor declaration
-            error at 15..34: found extra text after unit declaration"#]],
+            error at 5..14: invalid unit file
+            | error for 5..14: expected a module, class, or monitor declaration
+            error at 15..34: invalid unit file
+            | error for 15..34: found extra text after unit declaration"#]],
     );
 }
 
@@ -45,6 +49,8 @@ fn report_unit_not_allowed_decl_and_extra() {
 fn report_just_unit() {
     check(
         "unit",
-        expect![[r#"error at 0..4: expected a module, class, or monitor declaration"#]],
+        expect![[r#"
+            error at 0..4: missing unit declaration
+            | error for 0..4: expected a module, class, or monitor declaration after here"#]],
     );
 }

--- a/compiler/toc_vfs/src/db.rs
+++ b/compiler/toc_vfs/src/db.rs
@@ -34,7 +34,7 @@ pub trait FileSystem: HasVfs {
     /// # Returns
     /// An owned file source, as well as an error message to be passed to a message sink
     #[salsa::input]
-    fn file_source(&self, file: FileId) -> Arc<(String, Option<LoadError>)>;
+    fn file_source(&self, file: FileId) -> (Arc<String>, Option<LoadError>);
 }
 
 /// Helper extension trait for databases with [`Vfs`]'s

--- a/compiler/toc_vfs/src/query.rs
+++ b/compiler/toc_vfs/src/query.rs
@@ -53,7 +53,8 @@ where
             // File does not exist, or was removed
             (String::new(), Some(LoadError::NotFound))
         };
+        let result = (Arc::new(result.0), result.1);
 
-        self.set_file_source(file_id, Arc::new(result));
+        self.set_file_source(file_id, result);
     }
 }

--- a/lsp-server/src/main.rs
+++ b/lsp-server/src/main.rs
@@ -147,11 +147,8 @@ fn check_file(uri: &lsp_types::Url, contents: &str) -> Vec<Diagnostic> {
 
     // TODO: Recursively load in files
 
-    let mut msgs = vec![];
-    db.analyze_libraries().bundle_messages(&mut msgs);
-
-    // Sort by start order
-    msgs.sort_by_key(|msg| msg.span().range.start());
+    let analyze_res = db.analyze_libraries();
+    let msgs = analyze_res.messages();
 
     eprintln!("finished analysis @ {:?}", uri.as_str());
 


### PR DESCRIPTION
Fixup reported spans & make the actual output prettier & useful

- [x] Use `ariadne` for report printer
- [x] Fix weird reporting spans
- [ ] Format types for display
- [x] Deduplicate errors from both const-eval & typeck