### PR TITLE
Ingest multiple files into database

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,6 +190,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fixedbitset"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "398ea4fabe40b9b0d885340a2a991a44c8a645624075ad966d21f88688e2b69e"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -548,6 +554,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "petgraph"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a13a2fa9d0b63e5f22328828741e523766fff0ee9e779316902290dff3f824f"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -842,6 +858,7 @@ dependencies = [
  "toc_parser",
  "toc_reporting",
  "toc_salsa",
+ "toc_source_graph",
  "toc_span",
  "toc_validate",
  "toc_vfs",
@@ -952,6 +969,14 @@ dependencies = [
  "expect-test",
  "logos",
  "toc_reporting",
+ "toc_span",
+]
+
+[[package]]
+name = "toc_source_graph"
+version = "0.1.0"
+dependencies = [
+ "petgraph",
  "toc_span",
 ]
 

--- a/compiler/toc_analysis/src/test_db.rs
+++ b/compiler/toc_analysis/src/test_db.rs
@@ -1,7 +1,9 @@
 //! Testing helpers
 
+use std::sync::Arc;
+
 use toc_ast_db::db::SourceParser;
-use toc_ast_db::SourceRoots;
+use toc_ast_db::SourceGraph;
 use toc_hir::library::LibraryId;
 use toc_hir_db::db::HirDatabase;
 use toc_salsa::salsa;
@@ -33,8 +35,9 @@ impl TestDb {
         let root_file = db.vfs.intern_path("src/main.t".into());
         db.update_file(root_file, Ok(LoadStatus::Modified(source.into())));
 
-        let source_roots = SourceRoots::new(vec![root_file]);
-        db.set_source_roots(source_roots);
+        let mut source_graph = SourceGraph::default();
+        source_graph.add_root(root_file);
+        db.set_source_graph(Arc::new(source_graph));
 
         let library_id = db.library_graph().result().library_of(root_file);
 

--- a/compiler/toc_analysis/src/test_db.rs
+++ b/compiler/toc_analysis/src/test_db.rs
@@ -6,6 +6,7 @@ use toc_hir::library::LibraryId;
 use toc_hir_db::db::HirDatabase;
 use toc_salsa::salsa;
 use toc_vfs::db::VfsDatabaseExt;
+use toc_vfs::LoadStatus;
 
 #[salsa::database(
     toc_vfs::db::FileSystemStorage,
@@ -30,7 +31,7 @@ impl TestDb {
     pub(crate) fn from_source(source: &str) -> (Self, LibraryId) {
         let mut db = TestDb::default();
         let root_file = db.vfs.intern_path("src/main.t".into());
-        db.update_file(root_file, Some(source.into()));
+        db.update_file(root_file, Ok(LoadStatus::Modified(source.into())));
 
         let source_roots = SourceRoots::new(vec![root_file]);
         db.set_source_roots(source_roots);

--- a/compiler/toc_analysis/src/ty.rs
+++ b/compiler/toc_analysis/src/ty.rs
@@ -128,6 +128,19 @@ pub enum TypeKind {
     Ref(Mutability, TypeId),
 }
 
+// Other types to add:
+// - array
+// - range
+// - enum
+// - union
+// - record
+// - set
+// - pointer
+// - alias
+// - function (fcn/proc/process)
+// - condition
+// - collection
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Mutability {
     Const,

--- a/compiler/toc_ast_db/Cargo.toml
+++ b/compiler/toc_ast_db/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 
 [dependencies]
 toc_salsa = { path = "../toc_salsa" }
+toc_source_graph = { path = "../toc_source_graph" }
 toc_span = { path = "../toc_span" }
 toc_vfs = { path = "../toc_vfs" }
 toc_parser = { path = "../toc_parser" }

--- a/compiler/toc_ast_db/src/db.rs
+++ b/compiler/toc_ast_db/src/db.rs
@@ -50,3 +50,8 @@ pub trait SpanMapping: toc_vfs::db::FileSystem {
     #[salsa::invoke(span::query::map_byte_index_to_character)]
     fn map_byte_index_to_character(&self, file: toc_span::FileId, index: usize) -> Option<usize>;
 }
+
+pub trait AstDatabaseExt: toc_vfs::db::FileSystem + SourceParser {
+    /// Reloads the source roots using the given file loader
+    fn reload_source_roots(&mut self, loader: &dyn toc_vfs::FileLoader);
+}

--- a/compiler/toc_ast_db/src/db.rs
+++ b/compiler/toc_ast_db/src/db.rs
@@ -4,17 +4,22 @@ use std::sync::Arc;
 
 use toc_reporting::CompileResult;
 use toc_salsa::salsa;
+use toc_source_graph::{DependGraph, SourceGraph, SourceKind};
 use toc_span::FileId;
 use toc_vfs::db::FileSystem;
 
 use crate::span::{LineInfo, LineMapping, LspPosition};
-use crate::{source, span, SourceRoots};
+use crate::{source, span};
 
 #[salsa::query_group(SourceParserStorage)]
 pub trait SourceParser: FileSystem {
-    /// Source roots for all of the libraries
+    /// Source graph of all of the libraries
     #[salsa::input]
-    fn source_roots(&self) -> SourceRoots;
+    fn source_graph(&self) -> Arc<SourceGraph>;
+
+    /// Source dependency graph of a given library
+    #[salsa::input]
+    fn depend_graph(&self, library: FileId) -> Arc<DependGraph>;
 
     /// Parses the given file
     #[salsa::invoke(source::parse_file)]
@@ -27,6 +32,15 @@ pub trait SourceParser: FileSystem {
     /// Parse out the dependencies of a file
     #[salsa::invoke(source::parse_depends)]
     fn parse_depends(&self, file_id: FileId) -> CompileResult<toc_parser::FileDepends>;
+
+    /// Gets the source dependency in a given library from the given file and the relative path
+    #[salsa::invoke(source::depend_of)]
+    fn depend_of(
+        &self,
+        library: FileId,
+        from: FileId,
+        relative_path: String,
+    ) -> (FileId, SourceKind);
 }
 
 #[salsa::query_group(SpanMappingStorage)]
@@ -52,6 +66,8 @@ pub trait SpanMapping: toc_vfs::db::FileSystem {
 }
 
 pub trait AstDatabaseExt: toc_vfs::db::FileSystem + SourceParser {
-    /// Reloads the source roots using the given file loader
-    fn reload_source_roots(&mut self, loader: &dyn toc_vfs::FileLoader);
+    /// Reloads all files accessible from the source roots using the given file loader
+    ///
+    /// Also rebuilds all dependency graphs
+    fn invalidate_source_graph(&mut self, loader: &dyn toc_vfs::FileLoader);
 }

--- a/compiler/toc_ast_db/src/lib.rs
+++ b/compiler/toc_ast_db/src/lib.rs
@@ -1,29 +1,8 @@
 //! Database queries & structures for the AST level of compilation
 
-use std::sync::Arc;
-
-use toc_span::FileId;
-
 pub mod db;
 pub mod span;
 
 mod source;
 
-/// Library source roots
-#[derive(Debug, Clone)]
-pub struct SourceRoots {
-    roots: Arc<Vec<FileId>>,
-}
-
-impl SourceRoots {
-    pub fn new(roots: Vec<FileId>) -> Self {
-        Self {
-            roots: Arc::new(roots),
-        }
-    }
-
-    /// Iterates over the source roots, from the bottom of the dependency graph and up
-    pub fn roots(&self) -> impl Iterator<Item = FileId> + '_ {
-        self.roots.iter().copied()
-    }
-}
+pub use toc_source_graph::{DependGraph, SourceGraph};

--- a/compiler/toc_ast_db/src/source.rs
+++ b/compiler/toc_ast_db/src/source.rs
@@ -1,7 +1,10 @@
 //! Source file interpretation queries
 
+use std::collections::VecDeque;
+
 use toc_reporting::CompileResult;
 use toc_span::FileId;
+use toc_vfs::{db::VfsDatabaseExt, PathResolution};
 
 use crate::db;
 
@@ -25,4 +28,49 @@ pub(crate) fn parse_depends(
 ) -> CompileResult<toc_parser::FileDepends> {
     let cst = db.parse_file(file_id);
     toc_parser::parse_depends(Some(file_id), cst.result().syntax())
+}
+
+impl<T> db::AstDatabaseExt for T
+where
+    T: toc_vfs::db::FileSystem + db::SourceParser,
+{
+    fn reload_source_roots(&mut self, loader: &dyn toc_vfs::FileLoader) {
+        let db = self;
+        let source_roots = db.source_roots();
+        let mut reached_files = std::collections::HashSet::new();
+
+        let mut pending_files: VecDeque<_> = source_roots.roots().collect();
+        while let Some(current_file) = pending_files.pop_front() {
+            if !reached_files.insert(current_file) {
+                // We've already reached this file, don't enter into a cycle
+                // TODO: Report that we've reached a cycle if we're dealing with include chains
+                continue;
+            }
+
+            // Load in the file source
+            let path = db.get_vfs().lookup_path(current_file);
+            let res = loader.load_file(path);
+            db.update_file(current_file, res);
+
+            let deps = db.parse_depends(current_file);
+            for dep in deps.result().dependencies() {
+                let child = match db
+                    .get_vfs()
+                    .resolve_path(Some(current_file), &dep.relative_path)
+                {
+                    PathResolution::Interned(id) => id,
+                    PathResolution::NewPath(path) => {
+                        let intern_path = loader.normalize_path(&path).unwrap_or(path);
+                        db.get_vfs_mut().intern_path(intern_path)
+                    }
+                };
+
+                // Update the resolution path
+                // ???: Any way to reduce changes to this?
+                // Only needs to change if the parent file is modified
+                db.set_resolve_path(current_file, dep.relative_path.clone(), child);
+                pending_files.push_back(child);
+            }
+        }
+    }
 }

--- a/compiler/toc_driver/src/main.rs
+++ b/compiler/toc_driver/src/main.rs
@@ -1,35 +1,32 @@
 //! Dummy bin for running the new scanner and parser
 
 use std::collections::HashMap;
-use std::{env, fs, io};
+use std::{env, fs};
 
 use toc_analysis::db::HirAnalysis;
-use toc_ast_db::db::SourceParser;
 use toc_ast_db::db::SpanMapping;
+use toc_ast_db::db::{AstDatabaseExt, SourceParser};
 use toc_ast_db::SourceRoots;
 use toc_hir_db::db::HirDatabase;
 use toc_salsa::salsa;
 use toc_span::{FileId, Span};
-use toc_vfs::db::{FileSystem, VfsDatabaseExt};
-
-fn load_contents(path: &str) -> io::Result<String> {
-    let contents = fs::read(path)?;
-    let contents = String::from_utf8_lossy(&contents).to_string();
-    Ok(contents)
-}
+use toc_vfs::db::FileSystem;
+use toc_vfs::FileLoader;
 
 fn main() {
-    let path: String = env::args().nth(1).expect("Missing path to source file");
-    let contents = load_contents(&path).expect("Unable to load file");
+    let loader = MainFileLoader::default();
+    let str_path: String = env::args().nth(1).expect("Missing path to source file");
+    let path = std::path::Path::new(&str_path);
+    let path = loader.normalize_path(path).unwrap_or_else(|| path.into());
     let mut db = MainDatabase::default();
 
     // Add the root path to the db
     let root_file = db.vfs.intern_path(path.into());
-    db.update_file(root_file, Some(contents.into_bytes()));
 
     // Set the source root
     let source_roots = SourceRoots::new(vec![root_file]);
     db.set_source_roots(source_roots);
+    db.reload_source_roots(&loader);
 
     // Parse root CST & dump output
     // Note: this is only for temporary parse tree dumping
@@ -184,3 +181,24 @@ struct MainDatabase {
 impl salsa::Database for MainDatabase {}
 
 toc_vfs::impl_has_vfs!(MainDatabase, vfs);
+
+#[derive(Default)]
+struct MainFileLoader {}
+
+impl toc_vfs::FileLoader for MainFileLoader {
+    fn load_file(&self, path: &std::path::Path) -> toc_vfs::LoadResult {
+        match fs::read(path) {
+            Ok(contents) => Ok(toc_vfs::LoadStatus::Modified(contents)),
+            Err(err) => match err.kind() {
+                std::io::ErrorKind::NotFound => Err(toc_vfs::LoadError::NotFound),
+                _ => Err(toc_vfs::LoadError::Other(std::sync::Arc::new(
+                    err.to_string(),
+                ))),
+            },
+        }
+    }
+
+    fn normalize_path(&self, path: &std::path::Path) -> Option<std::path::PathBuf> {
+        fs::canonicalize(path).ok()
+    }
+}

--- a/compiler/toc_hir_db/src/query.rs
+++ b/compiler/toc_hir_db/src/query.rs
@@ -18,10 +18,10 @@ pub fn library_query(db: &dyn HirDatabase, library: LibraryId) -> LoweredLibrary
 
 pub fn library_graph_query(db: &dyn HirDatabase) -> CompileResult<LibraryGraph> {
     let mut messages = MessageBundle::default();
-    let source_roots = db.source_roots();
+    let source_graph = db.source_graph();
     let mut graph = GraphBuilder::new();
 
-    for root in source_roots.roots() {
+    for root in source_graph.library_roots() {
         graph.add_library(root);
         db.lower_library(root).bundle_messages(&mut messages);
     }

--- a/compiler/toc_hir_lowering/src/lower.rs
+++ b/compiler/toc_hir_lowering/src/lower.rs
@@ -51,11 +51,14 @@ where
 
         let mut pending_files = VecDeque::from(vec![library_root]);
         while let Some(current_file) = pending_files.pop_front() {
-            reachable_files.insert(current_file);
+            if !reachable_files.insert(current_file) {
+                // Already reached, don't enter into a cycle
+                continue;
+            }
 
             let deps = db.parse_depends(current_file);
             for dep in deps.result().dependencies() {
-                let child = db.resolve_path(current_file, &dep.relative_path);
+                let child = db.resolve_path(current_file, dep.relative_path.clone());
                 pending_files.push_back(child);
             }
         }

--- a/compiler/toc_hir_lowering/tests/lowering.rs
+++ b/compiler/toc_hir_lowering/tests/lowering.rs
@@ -38,8 +38,7 @@ struct LowerResult {
 
 fn assert_lower(src: &str) -> LowerResult {
     let mut db = TestHirDb::default();
-    let root_file = db.vfs.insert_file("src/main.t", src);
-    db.invalidate_files();
+    let root_file = db.insert_file("src/main.t", src);
 
     let lowered = db.lower_library(root_file);
 

--- a/compiler/toc_hir_lowering/tests/lowering.rs
+++ b/compiler/toc_hir_lowering/tests/lowering.rs
@@ -2,12 +2,13 @@
 use std::sync::Arc;
 
 use if_chain::if_chain;
+use toc_ast_db::db::{AstDatabaseExt, SourceParser};
+use toc_ast_db::SourceGraph;
 use toc_hir::{body, expr, item, library::LoweredLibrary, stmt, ty};
 use toc_hir_lowering::LoweringDb;
 use toc_reporting::CompileResult;
 use toc_salsa::salsa;
 use toc_span::FileId;
-use toc_vfs::db::VfsDatabaseExt;
 
 #[salsa::database(
     InternedTypeStorage,
@@ -38,7 +39,13 @@ struct LowerResult {
 
 fn assert_lower(src: &str) -> LowerResult {
     let mut db = TestHirDb::default();
-    let root_file = db.insert_file("src/main.t", src);
+    toc_vfs::generate_vfs(&mut db, src);
+
+    let root_file = db.vfs.intern_path("src/main.t".into());
+    let mut source_graph = SourceGraph::new();
+    source_graph.add_root(root_file);
+    db.set_source_graph(Arc::new(source_graph));
+    db.invalidate_source_graph(&toc_vfs::DummyFileLoader);
 
     let lowered = db.lower_library(root_file);
 

--- a/compiler/toc_parser/src/lib.rs
+++ b/compiler/toc_parser/src/lib.rs
@@ -16,7 +16,7 @@ use rowan::GreenNode;
 
 use crate::sink::Sink;
 
-pub use depends::{Dependency, FileDepends};
+pub use depends::{Dependency, DependencyKind, FileDepends};
 
 /// Parse a regular file into a [`ParseTree`]
 pub fn parse(file: Option<FileId>, source: &str) -> CompileResult<ParseTree> {

--- a/compiler/toc_source_graph/Cargo.toml
+++ b/compiler/toc_source_graph/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "toc_source_graph"
+version = "0.1.0"
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+toc_span = { path = "../toc_span" }
+
+petgraph = "0.6.0"

--- a/compiler/toc_source_graph/src/lib.rs
+++ b/compiler/toc_source_graph/src/lib.rs
@@ -1,0 +1,199 @@
+use std::collections::HashMap;
+
+use petgraph::graph::{DiGraph, EdgeIndex, NodeIndex};
+use petgraph::visit::{DfsPostOrder, Visitable};
+use toc_span::FileId;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SourceDepend {
+    pub relative_path: String,
+    pub kind: SourceKind,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SourceKind {
+    Unit,
+    Include,
+}
+
+type LibraryGraph = DiGraph<FileId, ()>;
+type SourceDepGraph = DiGraph<(FileId, SourceKind), ()>;
+
+/// Library source graph
+#[derive(Debug, Clone, Default)]
+pub struct SourceGraph {
+    /// Dependencies between library roots
+    libraries: LibraryGraph,
+    library_roots: Vec<NodeIndex>,
+    library_to_node: HashMap<FileId, NodeIndex>,
+}
+
+impl SourceGraph {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Adds a library to the source graph, marking it as a library graph root
+    pub fn add_root(&mut self, library: FileId) {
+        let root = self.get_or_insert_library(library);
+        self.library_roots.push(root);
+    }
+
+    // TODO: Add library removal for when we retain db in lsp-server
+
+    /// Adds a library dependency between library roots
+    ///
+    /// Automatically adds library nodes to the source graph
+    pub fn add_library_dep(&mut self, from: FileId, to: FileId) {
+        let from = self.get_or_insert_library(from);
+        let to = self.get_or_insert_library(to);
+        self.libraries.update_edge(from, to, ());
+    }
+
+    /// Traverses the library roots and their dependencies in DFS post-order
+    pub fn library_roots(&self) -> LibraryRoots<'_, '_> {
+        LibraryRoots {
+            graph: &self.libraries,
+            roots: self.library_roots.iter(),
+            visitor: None,
+        }
+    }
+
+    fn get_or_insert_library(&mut self, library: FileId) -> NodeIndex {
+        // Disjoint borrow because we aren't using new closure capture rules
+        // FIXME: Simplify once we're on Rust 2021
+        let libraries = &mut self.libraries;
+
+        *self
+            .library_to_node
+            .entry(library)
+            .or_insert_with(|| libraries.add_node(library))
+    }
+}
+
+/// Graph of the source dependencies of a given library
+#[derive(Debug, Clone)]
+pub struct DependGraph {
+    root: FileId,
+    /// Files accessible from the given library
+    source_deps: SourceDepGraph,
+    source_to_node: HashMap<FileId, NodeIndex>,
+    depend_links: HashMap<(NodeIndex, String), EdgeIndex>,
+}
+
+impl DependGraph {
+    pub fn new(root: FileId) -> Self {
+        let mut graph = Self {
+            root,
+            depend_links: Default::default(),
+            source_deps: Default::default(),
+            source_to_node: Default::default(),
+        };
+
+        // Insert the root node
+        graph.get_or_insert_dep(root, SourceKind::Unit);
+
+        graph
+    }
+
+    /// Adds a source dependency between two files
+    pub fn add_source_dep(&mut self, from: FileId, to: FileId, info: SourceDepend) {
+        let from = self.source_to_node.get(&from).copied().unwrap();
+        let to = self.get_or_insert_dep(to, info.kind);
+
+        let edge_idx = self.source_deps.update_edge(from, to, ());
+        self.depend_links
+            .insert((from, info.relative_path), edge_idx);
+    }
+
+    pub fn depend_of(&self, from: FileId, relative_path: String) -> (FileId, SourceKind) {
+        let from = self.source_to_node.get(&from).unwrap();
+        let dep_edge = *self
+            .depend_links
+            .get(&(*from, relative_path))
+            .expect("missing depend info");
+
+        let (_from, to) = self.source_deps.edge_endpoints(dep_edge).unwrap();
+        let to = self.source_deps[to];
+
+        to
+    }
+
+    /// Traverses the sources of the library in DFS post-order
+    ///
+    /// Ignores any non-unit sources
+    pub fn unit_sources(&self) -> LibrarySources<'_> {
+        let root = *self.source_to_node.get(&self.root).unwrap();
+
+        LibrarySources {
+            graph: &self.source_deps,
+            visitor: DfsPostOrder::new(&self.source_deps, root),
+        }
+    }
+
+    fn get_or_insert_dep(&mut self, dep: FileId, kind: SourceKind) -> NodeIndex {
+        // Disjoint borrow because we aren't using new closure capture rules
+        // FIXME: Simplify once we're on Rust 2021
+        let source_deps = &mut self.source_deps;
+
+        *self
+            .source_to_node
+            .entry(dep)
+            .or_insert_with(|| source_deps.add_node((dep, kind)))
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct LibraryRoots<'g, 'r> {
+    graph: &'g LibraryGraph,
+    roots: std::slice::Iter<'r, NodeIndex>,
+    visitor: Option<DfsPostOrder<NodeIndex, <LibraryGraph as Visitable>::Map>>,
+}
+
+impl Iterator for LibraryRoots<'_, '_> {
+    type Item = FileId;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            let node = {
+                // Disjoint borrows
+                let graph = self.graph;
+
+                self.visitor
+                    .as_mut()
+                    .and_then(|visitor| visitor.next(graph))
+            };
+
+            if let Some(node) = node {
+                let file = self.graph.node_weight(node).copied().unwrap();
+
+                break Some(file);
+            }
+
+            // Move to next (or first) root
+            let root = *self.roots.next()?;
+            self.visitor = Some(DfsPostOrder::new(self.graph, root));
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct LibrarySources<'g> {
+    graph: &'g SourceDepGraph,
+    visitor: DfsPostOrder<NodeIndex, <SourceDepGraph as Visitable>::Map>,
+}
+
+impl Iterator for LibrarySources<'_> {
+    type Item = FileId;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            let node = self.visitor.next(&self.graph)?;
+            let (file, kind) = self.graph.node_weight(node).copied().unwrap();
+
+            if matches!(kind, SourceKind::Unit) {
+                break Some(file);
+            }
+        }
+    }
+}

--- a/compiler/toc_syntax/src/ast.rs
+++ b/compiler/toc_syntax/src/ast.rs
@@ -20,6 +20,7 @@ mod nodes_ext;
 
 use super::SyntaxNode;
 pub use nodes::*;
+pub use nodes_ext::ExternalItemOwner;
 
 mod helper {
     use crate::{ast::AstNode, SyntaxKind, SyntaxNode, SyntaxToken};
@@ -46,3 +47,4 @@ pub trait AstNode: Sized {
 
     fn syntax(&self) -> &SyntaxNode;
 }
+

--- a/compiler/toc_syntax/src/ast.rs
+++ b/compiler/toc_syntax/src/ast.rs
@@ -47,4 +47,3 @@ pub trait AstNode: Sized {
 
     fn syntax(&self) -> &SyntaxNode;
 }
-

--- a/compiler/toc_vfs/src/db.rs
+++ b/compiler/toc_vfs/src/db.rs
@@ -12,20 +12,6 @@ use crate::{LoadError, LoadResult};
 /// Query interface into the virtual file system, backed by [`HasVfs`].
 #[salsa::query_group(FileSystemStorage)]
 pub trait FileSystem: HasVfs {
-    /// Resolves the given `relative_path` (with `base_path` as the file to have lookups relative to)
-    /// into a FileId.
-    ///
-    /// # Returns
-    /// A `FileId` corresponding to the final resolved path.
-    //
-    // Note: This should not be the entry point for where paths could be interned
-    //
-    // ???: How does this work where we have VFS results being submitted?
-    // Well, path resolutions are also part of the file system state, so they should
-    // also be kept track of
-    #[salsa::input]
-    fn resolve_path(&self, base_path: FileId, relative_path: String) -> FileId;
-
     /// Gets the file source of a text.
     ///
     /// Provides an `Option<LoadError>`, to notify of things like being unable to open a file,

--- a/compiler/toc_vfs/src/db.rs
+++ b/compiler/toc_vfs/src/db.rs
@@ -43,7 +43,7 @@ pub trait FileSystem: HasVfs {
 /// [`Vfs`]: crate::Vfs
 pub trait VfsDatabaseExt: HasVfs + FileSystem {
     /// Inserts a file into the database, producing a [`FileId`]
-    /// 
+    ///
     /// Mainly used in tests
     fn insert_file<P: AsRef<Path>>(&mut self, path: P, source: &str) -> FileId;
 

--- a/compiler/toc_vfs/src/db.rs
+++ b/compiler/toc_vfs/src/db.rs
@@ -1,5 +1,6 @@
 //! VFS query system definitions
 
+use std::path::Path;
 use std::sync::Arc;
 
 use toc_salsa::salsa;
@@ -41,9 +42,10 @@ pub trait FileSystem: HasVfs {
 ///
 /// [`Vfs`]: crate::Vfs
 pub trait VfsDatabaseExt: HasVfs + FileSystem {
-    /// Invalidates all files, uploading every single source into the database
-    /// regardless of if it has changed or not.
-    fn invalidate_files(&mut self);
+    /// Inserts a file into the database, producing a [`FileId`]
+    /// 
+    /// Mainly used in tests
+    fn insert_file<P: AsRef<Path>>(&mut self, path: P, source: &str) -> FileId;
 
     /// Updates the contents of the specified file.
     ///

--- a/compiler/toc_vfs/src/fixture.rs
+++ b/compiler/toc_vfs/src/fixture.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     db::{self, VfsDatabaseExt},
-    HasVfs,
+    HasVfs, LoadError, LoadStatus,
 };
 
 pub const FILE_DELIMITER_START: &str = "%%-";
@@ -128,7 +128,7 @@ pub fn generate_vfs<DB: db::FileSystem + HasVfs>(db: &mut DB, source: &str) {
         let file = db.get_vfs_mut().intern_path(path.into());
 
         let source = if is_removed {
-            None
+            Err(LoadError::NotFound)
         } else {
             // Rebuild the source!
             let mut source_lines = source.iter();
@@ -140,7 +140,7 @@ pub fn generate_vfs<DB: db::FileSystem + HasVfs>(db: &mut DB, source: &str) {
                 source.push_str(line);
             }
 
-            Some(source.into())
+            Ok(LoadStatus::Modified(source.into()))
         };
 
         db.update_file(file, source);

--- a/compiler/toc_vfs/src/fixture.rs
+++ b/compiler/toc_vfs/src/fixture.rs
@@ -1,0 +1,276 @@
+//! Test fixture generation
+
+use crate::{
+    db::{self, VfsDatabaseExt},
+    HasVfs,
+};
+
+pub const FILE_DELIMITER_START: &str = "%%-";
+
+/// Generates a VFS tree from the given text source
+///
+/// There are two kinds of text sources:
+///
+/// - Single file, implied to be in the `src/main.t` file
+/// - Multiple files, where each file source is specified
+///
+/// Files within a multi-file text source are delimited using the `%%-` characters.
+/// All file names must be specified in a multi-file source, as there is no implied
+/// `src/main.t` (it must be specified explicitly).
+///
+/// Specifying `removed` before the file path indicates that no file source should be added.
+///
+/// # Examples
+///
+/// Single file source:
+///
+/// ```rust,compile_fail
+/// generate_vfs(db, r#"i := "i am in a single file""#);
+/// ```
+///
+/// Multiple file source:
+///
+/// ```rust,compile_fail
+/// generate_vfs(db, r#"
+/// %%- /src/main.t
+/// put "i am in one file"
+/// %%- /src/test.t
+/// put "and i am in another"
+/// "#);
+/// ```
+pub fn generate_vfs<DB: db::FileSystem + HasVfs>(db: &mut DB, source: &str) {
+    // ???: How should we deal with inserting path resolutions
+
+    // Segment into lines
+    let lines: Vec<_> = source.split('\n').collect();
+
+    // Segment by starts, treat as endings
+    let mut file_ends = lines
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, line)| {
+            // Skip leading ws
+            let line = line.trim_start();
+            Some(idx).filter(|_| line.starts_with(FILE_DELIMITER_START))
+        })
+        .chain(Some(lines.len()));
+
+    let mut file_start = 0;
+    let mut file_end = 0;
+    let files: Vec<_> = std::iter::from_fn({
+        || {
+            file_start = file_end;
+            file_end = file_ends.next()?;
+            Some(&lines[file_start..file_end])
+        }
+    })
+    .skip_while(|file| {
+        // skip leading whitespace
+        file.iter().all(|line| line.trim_start().is_empty())
+    })
+    .collect();
+
+    // Ensure that there's no text before the first line
+    let is_single_file = if let Some(file) = files.first() {
+        let first_line = file.iter().find(|line| !line.trim_start().is_empty());
+
+        if let Some(first_line) = first_line {
+            if first_line.trim_start().starts_with(FILE_DELIMITER_START) {
+                // starts with the delimiter, proceed as normal
+                false
+            } else if files.len() > 1 {
+                // is multifile, but with leading text present
+                // make sure that the leading text is just whitespace
+                panic!("text present before first file (`src/main.t` must be expicitly defined)");
+            } else {
+                // is just a single file
+                true
+            }
+        } else {
+            // is empty, or a single file, in other words
+            true
+        }
+    } else {
+        // Guaranateed to be a single file source, since it's empty
+        true
+    };
+
+    if is_single_file {
+        db.insert_file("src/main.t", source);
+        return;
+    }
+
+    // Build up the files
+    for text in files {
+        let (config, source) = text.split_first().expect("missing file info args");
+        let (is_removed, path) = {
+            let mut config = config
+                .trim_start()
+                .strip_prefix(FILE_DELIMITER_START)
+                .expect("missing start delimiter");
+            let is_removed = if let Some(rest) = config.trim_start().strip_prefix("removed") {
+                if rest.starts_with('/') {
+                    // part of a path, don't take it
+                    false
+                } else {
+                    // is removed, eat it!
+                    config = rest;
+                    true
+                }
+            } else {
+                false
+            };
+            let path = config.trim_start().trim_end();
+
+            (is_removed, path)
+        };
+
+        let file = db.get_vfs_mut().intern_path(path.into());
+
+        let source = if is_removed {
+            None
+        } else {
+            // Rebuild the source!
+            let mut source_lines = source.iter();
+            let mut source = String::new();
+            source.push_str(source_lines.next().unwrap_or(&""));
+
+            while let Some(line) = source_lines.next() {
+                source.push('\n');
+                source.push_str(line);
+            }
+
+            Some(source.into())
+        };
+
+        db.update_file(file, source);
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use toc_salsa::salsa;
+
+    use crate::{
+        db::{FileSystem, FileSystemStorage},
+        impl_has_vfs, Vfs,
+    };
+
+    use super::*;
+
+    #[salsa::database(FileSystemStorage)]
+    #[derive(Default)]
+    struct VfsTestDB {
+        storage: salsa::Storage<Self>,
+        vfs: Vfs,
+    }
+
+    impl salsa::Database for VfsTestDB {}
+
+    impl_has_vfs!(VfsTestDB, vfs);
+
+    #[test]
+    fn single_file() {
+        let mut db = VfsTestDB::default();
+
+        generate_vfs(&mut db, "single file, yay");
+        let root_file = db.vfs.resolve_path(None, "src/main.t").into_file_id();
+        let source = db.file_source(root_file).0;
+        assert_eq!(source.as_str(), "single file, yay");
+    }
+
+    #[test]
+    fn single_file_empty() {
+        let mut db = VfsTestDB::default();
+
+        generate_vfs(&mut db, "");
+        let root_file = db.vfs.resolve_path(None, "src/main.t").into_file_id();
+        let res = db.file_source(root_file);
+        assert_eq!((res.0.as_str(), res.1), ("", None));
+    }
+
+    #[test]
+    fn single_file_many_lines() {
+        let mut db = VfsTestDB::default();
+
+        generate_vfs(&mut db, "single file\nbut multiple lines");
+        let root_file = db.vfs.resolve_path(None, "src/main.t").into_file_id();
+        let source = db.file_source(root_file).0;
+        assert_eq!(source.as_str(), "single file\nbut multiple lines");
+    }
+
+    #[test]
+    fn multifile() {
+        const FILE_SOURCES: &[&str] = &[
+            "file 0\ni have lines\nbut that's it",
+            "file 1\ni also have lines, and a trailing nl\n",
+            "file 2\ni also have a trailing nl at the end of the list\n",
+        ];
+        let mut db = VfsTestDB::default();
+
+        // Leading whitespace is okay
+        generate_vfs(
+            &mut db,
+            &format!(
+                "     \n    %%- src/main.t\n{0}\n%%- src/file1.t\n{1}\n%%- removed removed/ya.t\n%%- src/file2.t\n{2}",
+                FILE_SOURCES[0], FILE_SOURCES[1], FILE_SOURCES[2]
+            ),
+        );
+        let file = db.vfs.resolve_path(None, "src/main.t").into_file_id();
+        assert_eq!(db.file_source(file).0.as_str(), FILE_SOURCES[0]);
+        let file = db.vfs.resolve_path(None, "src/file1.t").into_file_id();
+        assert_eq!(db.file_source(file).0.as_str(), FILE_SOURCES[1]);
+        let file = db.vfs.resolve_path(None, "src/file2.t").into_file_id();
+        assert_eq!(db.file_source(file).0.as_str(), FILE_SOURCES[2]);
+        let file = db.vfs.resolve_path(None, "removed/ya.t").into_file_id();
+        let res = db.file_source(file);
+        assert_eq!(
+            (res.0.as_str(), res.1),
+            ("", Some(crate::LoadError::NotFound))
+        )
+    }
+
+    #[test]
+    fn multifile_one_file() {
+        const FILE_SOURCES: &[&str] = &["singular_file"];
+        let mut db = VfsTestDB::default();
+
+        generate_vfs(&mut db, &format!("%%- one/file.t\n{0}", FILE_SOURCES[0]));
+        let file = db.vfs.resolve_path(None, "one/file.t").into_file_id();
+        assert_eq!(db.file_source(file).0.as_str(), FILE_SOURCES[0]);
+    }
+
+    #[test]
+    fn multifile_removed_as_path() {
+        const FILE_SOURCES: &[&str] = &["not actually empty"];
+        let mut db = VfsTestDB::default();
+
+        generate_vfs(&mut db, &format!("%%- removed/ya.t\n{0}", FILE_SOURCES[0]));
+        let file = db.vfs.resolve_path(None, "removed/ya.t").into_file_id();
+        let res = db.file_source(file);
+        assert_eq!((res.0.as_str(), res.1), (FILE_SOURCES[0], None));
+    }
+
+    #[test]
+    fn multifile_empty_files() {
+        let mut db = VfsTestDB::default();
+
+        generate_vfs(
+            &mut db,
+            &format!("%%- empty/file0.t\n%%- empty/file1.t\n%%- empty/file2.t"),
+        );
+        let file = db.vfs.resolve_path(None, "empty/file0.t").into_file_id();
+        assert_eq!(db.file_source(file).0.as_str(), "");
+        let file = db.vfs.resolve_path(None, "empty/file1.t").into_file_id();
+        assert_eq!(db.file_source(file).0.as_str(), "");
+        let file = db.vfs.resolve_path(None, "empty/file2.t").into_file_id();
+        assert_eq!(db.file_source(file).0.as_str(), "");
+    }
+
+    #[test]
+    #[should_panic = "text present before first file (`src/main.t` must be expicitly defined)"]
+    fn multifile_with_leading_text() {
+        let mut db = VfsTestDB::default();
+        generate_vfs(&mut db, "        some text\n%%- src/a_file.t");
+    }
+}

--- a/compiler/toc_vfs/src/intern.rs
+++ b/compiler/toc_vfs/src/intern.rs
@@ -56,11 +56,18 @@ pub enum PathResolution {
 }
 
 impl PathResolution {
-    /// Extracts the file id from self.
-    pub fn into_file_id(self) -> Option<FileId> {
+    /// Tries to extract the file id from self.
+    pub fn as_file_id(&self) -> Option<FileId> {
         match self {
-            PathResolution::Interned(id) => Some(id),
+            PathResolution::Interned(id) => Some(*id),
             PathResolution::NewPath(_) => None,
         }
+    }
+
+    /// Extracts the file id from self.
+    ///
+    /// Panics if this does not represent an interned path
+    pub fn into_file_id(self) -> FileId {
+        self.as_file_id().expect("path was not interned")
     }
 }

--- a/compiler/toc_vfs/src/lib.rs
+++ b/compiler/toc_vfs/src/lib.rs
@@ -120,6 +120,16 @@ pub enum LoadError {
     Other(Arc<String>),
 }
 
+impl fmt::Display for LoadError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            LoadError::NotFound => f.write_str("File not found"),
+            LoadError::InvalidEncoding => f.write_str("Invalid file encoding"),
+            LoadError::Other(err) => f.write_str(err),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum LoadStatus {
     Unchanged,

--- a/compiler/toc_vfs/src/lib.rs
+++ b/compiler/toc_vfs/src/lib.rs
@@ -24,6 +24,7 @@
 // TODO: Generate a test fixture VFS tree from a given source string
 
 pub mod db;
+mod fixture;
 mod intern;
 mod query;
 mod vfs;
@@ -32,6 +33,8 @@ use std::convert::TryFrom;
 use std::fmt;
 use std::sync::Arc;
 
+pub use fixture::generate_vfs;
+pub use intern::PathResolution;
 pub use vfs::{HasVfs, Vfs};
 
 /// Helper for implementing the [`HasVfs`] trait.
@@ -188,7 +191,10 @@ mod test {
 
         // Lookup bar.t file source
         let bar_t = {
-            let bar_t = db.resolve_path(root_file, "foo/bar.t");
+            let bar_t = db
+                .vfs
+                .resolve_path(Some(root_file), "foo/bar.t")
+                .into_file_id();
             let res = db.file_source(bar_t);
             let (source, _load_error) = res;
 
@@ -198,7 +204,7 @@ mod test {
 
         // Lookup bap.t from bar.t
         {
-            let bap_t = db.resolve_path(bar_t, "bap.t");
+            let bap_t = db.vfs.resolve_path(Some(bar_t), "bap.t").into_file_id();
             let res = db.file_source(bap_t);
             let (source, _load_error) = res;
 
@@ -238,7 +244,10 @@ mod test {
 
         // Lookup Predefs.lst file source
         let predefs_list = {
-            let predefs_list = db.resolve_path(root_file, "%oot/support/Predefs.lst");
+            let predefs_list = db
+                .vfs
+                .resolve_path(Some(root_file), "%oot/support/Predefs.lst")
+                .into_file_id();
             let res = db.file_source(predefs_list);
             assert_eq!((res.0.as_str(), res.1), (FILE_SOURCES[1], None));
             predefs_list
@@ -246,31 +255,46 @@ mod test {
 
         // Lookup Net.tu from Predefs.lst
         {
-            let net_tu = db.resolve_path(predefs_list, "Net.tu");
+            let net_tu = db
+                .vfs
+                .resolve_path(Some(predefs_list), "Net.tu")
+                .into_file_id();
             let res = db.file_source(net_tu);
             assert_eq!((res.0.as_str(), res.1), (FILE_SOURCES[2], None));
         };
 
         {
-            let file = db.resolve_path(root_file, "%help/Keyword Lookup.txt");
+            let file = db
+                .vfs
+                .resolve_path(Some(root_file), "%help/Keyword Lookup.txt")
+                .into_file_id();
             let res = db.file_source(file);
             assert_eq!((res.0.as_str(), res.1), (FILE_SOURCES[3], None));
         };
 
         {
-            let file = db.resolve_path(root_file, "%home/special_file.t");
+            let file = db
+                .vfs
+                .resolve_path(Some(root_file), "%home/special_file.t")
+                .into_file_id();
             let res = db.file_source(file);
             assert_eq!((res.0.as_str(), res.1), (FILE_SOURCES[0], None));
         };
 
         {
-            let file = db.resolve_path(root_file, "%tmp/pre/made/some-temp-item");
+            let file = db
+                .vfs
+                .resolve_path(Some(root_file), "%tmp/pre/made/some-temp-item")
+                .into_file_id();
             let res = db.file_source(file);
             assert_eq!((res.0.as_str(), res.1), (FILE_SOURCES[0], None));
         };
 
         {
-            let file = db.resolve_path(root_file, "%job/to/make/job-item");
+            let file = db
+                .vfs
+                .resolve_path(Some(root_file), "%job/to/make/job-item")
+                .into_file_id();
             let res = db.file_source(file);
             assert_eq!((res.0.as_str(), res.1), (FILE_SOURCES[0], None));
         };

--- a/compiler/toc_vfs/src/lib.rs
+++ b/compiler/toc_vfs/src/lib.rs
@@ -135,6 +135,23 @@ pub trait FileLoader {
     fn normalize_path(&self, path: &Path) -> Option<PathBuf>;
 }
 
+/// Dummy file loader that effectively performs a no-op
+///
+/// Must ensure that all files are already loaded into the database,
+/// and that all paths passed are in normalized format. This can be
+/// done via [`generate_vfs`] for tests.
+pub struct DummyFileLoader;
+
+impl FileLoader for DummyFileLoader {
+    fn load_file(&self, _path: &Path) -> LoadResult {
+        Ok(LoadStatus::Unchanged)
+    }
+
+    fn normalize_path(&self, _path: &Path) -> Option<PathBuf> {
+        None
+    }
+}
+
 #[cfg(test)]
 mod test {
     use std::ops::Deref;

--- a/compiler/toc_vfs/src/lib.rs
+++ b/compiler/toc_vfs/src/lib.rs
@@ -4,20 +4,23 @@
 //! are held in the concrete [`Vfs`] type, and file sources for the compiler
 //! are accessed via the [`FileSystem::file_source`] query.
 //!
-//! Resolving paths into [`FileId`]s via the [`FileSystem::resolve_path`]
-//! query is required during lowering the concrete syntax tree into HIR,
+//! Resolving paths into [`FileId`]s via the [`Vfs::resolve_path`]
+//! method is required during lowering the concrete syntax tree into HIR,
 //! specifically during:
 //!
 //! - Include file expansion in order to get the file id for getting the parse tree
 //! - Import dependency resolution for generating dependencies between units
+//!
+//! However, the real path resolution should use the `depend_of` query in `toc_ast_db`,
+//! since we cache a source dependency graph in there.
 //!
 //! ## Note
 //!
 //! All paths must be encountered before executing any queries, since no paths are interned from queries
 //!
 //! [`Vfs`]: crate::Vfs
+//! [`Vfs::resolve_path`]: crate::Vfs::resolve_path
 //! [`FileSystem::file_source`]: crate::db::FileSystem::file_source
-//! [`FileSystem::resolve_path`]: crate::db::FileSystem::resolve_path
 //! [`FileId`]: toc_span::FileId
 
 // TODO: Flesh out documentation using VFS Interface.md

--- a/compiler/toc_vfs/src/query.rs
+++ b/compiler/toc_vfs/src/query.rs
@@ -9,13 +9,7 @@ use toc_span::FileId;
 
 use crate::db::{FileSystem, VfsDatabaseExt};
 use crate::vfs::HasVfs;
-use crate::LoadError;
-
-pub(crate) fn resolve_path(db: &dyn FileSystem, relative_to: FileId, path: &str) -> FileId {
-    db.get_vfs()
-        .resolve_path(Some(relative_to), path)
-        .into_file_id()
-}
+use crate::{LoadError, LoadResult, LoadStatus};
 
 // Non query stuff //
 
@@ -30,27 +24,31 @@ where
         file_id
     }
 
-    fn update_file(&mut self, file_id: FileId, new_source: Option<Vec<u8>>) {
-        let result = if let Some(byte_source) = new_source {
-            // FIXME: Deal with different character encodings (per `VFS Interface.md`)
-            // This is likely the place where we'd do it
+    fn update_file(&mut self, file_id: FileId, result: LoadResult) {
+        let result = match result {
+            Ok(LoadStatus::Unchanged) => return,
+            Ok(LoadStatus::Modified(byte_source)) => {
+                // FIXME: Deal with different character encodings (per `VFS Interface.md`)
+                // This is likely the place where we'd do it
 
-            // Try converting the file into UTF-8
-            let source = String::from_utf8_lossy(&byte_source);
+                // Try converting the file into UTF-8
+                let source = String::from_utf8_lossy(&byte_source);
 
-            match source {
-                Cow::Borrowed(_source) => {
-                    // Steal memory from the cloning process
-                    (String::from_utf8(byte_source).unwrap(), None)
-                }
-                Cow::Owned(invalid) => {
-                    // Non UTF-8 encoded characters
-                    (invalid, Some(LoadError::InvalidEncoding))
+                match source {
+                    Cow::Borrowed(_source) => {
+                        // Steal memory from the cloning process
+                        (String::from_utf8(byte_source).unwrap(), None)
+                    }
+                    Cow::Owned(invalid) => {
+                        // Non UTF-8 encoded characters
+                        (invalid, Some(LoadError::InvalidEncoding))
+                    }
                 }
             }
-        } else {
-            // File does not exist, or was removed
-            (String::new(), Some(LoadError::NotFound))
+            Err(err) => {
+                // Error encountered during loading
+                (String::new(), Some(err))
+            }
         };
         let result = (Arc::new(result.0), result.1);
 

--- a/compiler/toc_vfs/src/query.rs
+++ b/compiler/toc_vfs/src/query.rs
@@ -15,7 +15,6 @@ pub(crate) fn resolve_path(db: &dyn FileSystem, relative_to: FileId, path: &str)
     db.get_vfs()
         .resolve_path(Some(relative_to), path)
         .into_file_id()
-        .expect("path was not interned yet")
 }
 
 // Non query stuff //

--- a/compiler/toc_vfs/src/vfs.rs
+++ b/compiler/toc_vfs/src/vfs.rs
@@ -9,6 +9,9 @@ use toc_span::FileId;
 use crate::intern::{PathInterner, PathResolution};
 use crate::BuiltinPrefix;
 
+// TODO: Unify path slashes to the platform preferred separator
+// This should be dependent on if we have legacy-mode path transformations enabled
+
 /// Concrete virtual filesystem interface
 ///
 // TODO: This behaviour has changed, and the `Vfs` is now just a path tree abstraction
@@ -44,10 +47,15 @@ impl Vfs {
             // Tack on the parent path
             let mut parent_path = self.path_interner.lookup_path(relative_to).to_owned();
             assert!(parent_path.pop(), "parent path for file was empty");
-            parent_path.join(expanded_path)
+
+            // Join paths together, applying path de-dotting
+            join_dedot(parent_path, &expanded_path)
         } else {
             // The only place that I can think that needs an absolute path is
             // for looking up the predef list, which always becomes an absolute path.
+            //
+            // However, even then the predef list is usually accessible via the `%oot`
+            // prefix, so it's likely just bad practice that's happening here
             //
             // For now, treat as-is, but may or may not be an absolute path.
             expanded_path
@@ -70,7 +78,7 @@ impl Vfs {
         let prefix_name = if_chain::if_chain! {
             if let Some(Component::Normal(comp)) = path.components().next();
             // If the given path component is not a valid unicode string, then it's safe to bail out
-            // None of the builtin percent prefixes contain any unicode characters.
+            // None of the builtin percent prefixes only contain alphabetic ascii characters.
             if let Some(comp) = comp.to_str();
             if let Some(prefix_name) = comp.strip_prefix('%');
             then {
@@ -87,7 +95,10 @@ impl Vfs {
                     .builtin_expansions
                     .get(&prefix_path)
                     .expect("missing path prefix");
-                base_path.join(path.strip_prefix(prefix_path.to_string()).unwrap())
+                join_dedot(
+                    base_path.to_owned(),
+                    path.strip_prefix(prefix_path.to_string()).unwrap(),
+                )
             }
             Err(_) => {
                 // No corresponding path prefix, return the path as-is
@@ -128,4 +139,57 @@ pub trait HasVfs {
 
     // Get mutable access to the underlying virtual file system
     fn get_vfs_mut(&mut self) -> &mut Vfs;
+}
+
+/// Joins two paths together, applying `ParentDir` and `CurrentDir` components
+///
+/// `append` must be a relative path
+fn join_dedot(mut path: PathBuf, append: &Path) -> PathBuf {
+    assert!(append.is_relative());
+
+    for comp in append.components() {
+        match comp {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                // go up
+                path.pop();
+            }
+            Component::Normal(comp) => {
+                // append component
+                path.push(comp);
+            }
+            // absolute components
+            // should never be reachable since we check for absolute expanded paths
+            Component::Prefix(_) | Component::RootDir => unreachable!(),
+        }
+    }
+
+    path
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn resolve_dedots_expansion() {
+        let mut vfs = Vfs::new();
+
+        vfs.set_prefix_expansion(BuiltinPrefix::Oot, "/path/to/oot");
+        let help = vfs.intern_path("/path/to/some/help".into());
+
+        let resolve = vfs.resolve_path(None, "%oot/../other/.././oot/../some/help");
+        assert_eq!(resolve, PathResolution::Interned(help));
+    }
+
+    #[test]
+    fn resolve_dedots_relative() {
+        let mut vfs = Vfs::new();
+
+        let child = vfs.intern_path("/src/subdir/child".into());
+        let main = vfs.intern_path("/src/main.t".into());
+
+        let resolve = vfs.resolve_path(Some(child), "../././././main.t");
+        assert_eq!(resolve, PathResolution::Interned(main));
+    }
 }

--- a/compiler/toc_vfs/src/vfs.rs
+++ b/compiler/toc_vfs/src/vfs.rs
@@ -11,6 +11,7 @@ use crate::BuiltinPrefix;
 
 /// Concrete virtual filesystem interface
 ///
+// TODO: This behaviour has changed, and the `Vfs` is now just a path tree abstraction
 /// File sources are loaded into the main `Vfs` type, and file sources in
 /// the form of raw binary blobs can come from anywhere.
 /// For example, they can be generated from diffs provided from a
@@ -20,7 +21,6 @@ use crate::BuiltinPrefix;
 pub struct Vfs {
     path_interner: PathInterner,
     builtin_expansions: HashMap<BuiltinPrefix, PathBuf>,
-    pub(crate) file_store: HashMap<FileId, Option<Vec<u8>>>,
 }
 
 impl Vfs {
@@ -119,27 +119,13 @@ impl Vfs {
     pub fn lookup_path(&self, file_id: FileId) -> &std::path::Path {
         self.path_interner.lookup_path(file_id)
     }
-
-    /// Inserts a file, producing a file id
-    ///
-    /// Mainly used in tests.
-    pub fn insert_file(&mut self, path: impl AsRef<Path>, source: &str) -> FileId {
-        let id = self.intern_path(path.as_ref().to_path_buf());
-        self.file_store
-            .insert(id, Some(source.to_string().into_bytes()));
-        id
-    }
-
-    /// Replaces the file source of the given `file_id` with the `new_source`.
-    ///
-    /// [`None`] is used to indicate that a file does not exist.
-    pub fn update_file(&mut self, file_id: FileId, new_source: Option<Vec<u8>>) {
-        self.file_store.insert(file_id, new_source);
-    }
 }
 
 /// Trait providing the query system access to the virtual file system
 pub trait HasVfs {
     // Get access to the underlying virtual file system
     fn get_vfs(&self) -> &Vfs;
+
+    // Get mutable access to the underlying virtual file system
+    fn get_vfs_mut(&mut self) -> &mut Vfs;
 }

--- a/lsp-server/src/main.rs
+++ b/lsp-server/src/main.rs
@@ -12,6 +12,7 @@ use toc_ast_db::db::{SourceParser, SpanMapping};
 use toc_ast_db::SourceRoots;
 use toc_salsa::salsa;
 use toc_vfs::db::VfsDatabaseExt;
+use toc_vfs::LoadStatus;
 
 type DynError = Box<dyn Error + Sync + Send>;
 
@@ -139,8 +140,7 @@ fn check_file(uri: &lsp_types::Url, contents: &str) -> Vec<Diagnostic> {
 
     // Add the root path to the file db
     let root_file = db.vfs.intern_path(path.into());
-    db.update_file(root_file, Some(contents.into()));
-
+    db.update_file(root_file, Ok(LoadStatus::Modified(contents.into())));
     // Setup source roots
     let source_roots = SourceRoots::new(vec![root_file]);
     db.set_source_roots(source_roots);

--- a/lsp-server/src/main.rs
+++ b/lsp-server/src/main.rs
@@ -9,7 +9,7 @@ use lsp_types::{
     TextDocumentSyncCapability, TextDocumentSyncKind, VersionedTextDocumentIdentifier,
 };
 use toc_analysis::db::HirAnalysis;
-use toc_ast_db::db::{SourceParser, SpanMapping};
+use toc_ast_db::db::{AstDatabaseExt, SourceParser, SpanMapping};
 use toc_ast_db::SourceGraph;
 use toc_salsa::salsa;
 use toc_vfs::db::VfsDatabaseExt;
@@ -148,6 +148,7 @@ fn check_file(uri: &lsp_types::Url, contents: &str) -> Vec<Diagnostic> {
     db.set_source_graph(Arc::new(source_graph));
 
     // TODO: Recursively load in files, respecting already loaded files
+    db.invalidate_source_graph(&toc_vfs::DummyFileLoader);
 
     let analyze_res = db.analyze_libraries();
     let msgs = analyze_res.messages();

--- a/notes/TODO.md
+++ b/notes/TODO.md
@@ -92,7 +92,7 @@
     - [ ] PreprocIf stmt substitution
     - [ ] PreprocExpr evaluation
     - [ ] PreprocInclude insertion
-      - [ ] Gather include files
+      - [x] Gather include files
 - [ ] Import & dependency resolution
 - [ ] Typeck
   - [ ] Stmt
@@ -192,7 +192,13 @@
   - [ ] External functions support
 - [ ] FileDb & FileId maps
 - [x] Additional `ReportMessage` notes
-  - [ ] Integration with `annotate-snippets`
+  - [x] Integration with `ariadne`
+- [ ] Multi-file compilation
+  - [x] Select file dependencies
+  - [ ] Load in the dependent file sources
+  - [ ] Generate a test fixture VFS from a text string
+  - [ ] Include tree stuff
+  - [ ] Reasonable limit on files included
 
 ### Potential
 

--- a/notes/TODO.md
+++ b/notes/TODO.md
@@ -190,12 +190,11 @@
   - [ ] SizeOf structure size computation
 - [ ] HIR Codegen
   - [ ] External functions support
-- [ ] FileDb & FileId maps
 - [x] Additional `ReportMessage` notes
   - [x] Integration with `ariadne`
 - [ ] Multi-file compilation
   - [x] Select file dependencies
-  - [ ] Load in the dependent file sources
+  - [x] Load in the dependent file sources
   - [x] Generate a test fixture VFS from a text string
   - [ ] Include tree stuff
   - [ ] Reasonable limit on files included

--- a/notes/TODO.md
+++ b/notes/TODO.md
@@ -196,7 +196,7 @@
 - [ ] Multi-file compilation
   - [x] Select file dependencies
   - [ ] Load in the dependent file sources
-  - [ ] Generate a test fixture VFS from a text string
+  - [x] Generate a test fixture VFS from a text string
   - [ ] Include tree stuff
   - [ ] Reasonable limit on files included
 


### PR DESCRIPTION
Ingest all files accessible from all source roots into the database

Transforming ingested paths into a common cross-platform representation is an issue for another time