### PR TITLE
Support string concatenation type checking

### DIFF
--- a/compiler/toc_analysis/src/ty/rules.rs
+++ b/compiler/toc_analysis/src/ty/rules.rs
@@ -654,8 +654,11 @@ pub fn report_invalid_bin_op<'db, DB>(
     let right_ty = right_ty.in_db(db);
     // Try logical operation if either is a boolean
     let is_logical = left_ty.kind().is_boolean() || right_ty.kind().is_boolean();
+    // Try string concat operation if either is a charseq
+    let is_string_concat = left_ty.kind().is_charseq() || right_ty.kind().is_charseq();
 
     let op_name = match op {
+        expr::BinaryOp::Add if is_string_concat => "string concatenation",
         expr::BinaryOp::Add => "addition",
         expr::BinaryOp::Sub => "subtraction",
         expr::BinaryOp::Mul => "multiplication",
@@ -683,6 +686,7 @@ pub fn report_invalid_bin_op<'db, DB>(
         expr::BinaryOp::NotIn => "`not in`",
     };
     let verb_phrase = match op {
+        expr::BinaryOp::Add if is_string_concat => "concatenated to",
         expr::BinaryOp::Add => "added to",
         expr::BinaryOp::Sub => "subtracted by",
         expr::BinaryOp::Mul => "multiplied by",

--- a/compiler/toc_analysis/src/ty/rules.rs
+++ b/compiler/toc_analysis/src/ty/rules.rs
@@ -37,6 +37,14 @@ impl TypeKind {
     pub fn is_error(&self) -> bool {
         matches!(self, TypeKind::Error)
     }
+
+    /// charseq types includes `String`, `StringN`, `Char`, and `CharN` types
+    pub fn is_charseq(&self) -> bool {
+        matches!(
+            self,
+            TypeKind::String | TypeKind::StringN(_) | TypeKind::Char | TypeKind::CharN(_)
+        )
+    }
 }
 
 // Conversions of type
@@ -368,6 +376,29 @@ pub fn check_binary_op<T: ?Sized + db::TypeDatabase>(
         }
     }
 
+    fn check_charseq_operands<T: ?Sized + db::TypeDatabase>(
+        db: &T,
+        left: &TypeKind,
+        right: &TypeKind,
+    ) -> Option<TypeId> {
+        // For now, don't deal with the following special cases:
+        // - char, char
+        // - char(N), char / char, char(N)
+        // - char(N), char(M)
+        //
+        // These require building compile time expressions not from the HIR, which we don't support yet
+        // TODO: Handle special cases once we can lazy evaluate constant expressions
+        //
+        // Testing note: special cases with char(N) can go over the max char size, make sure we check for that
+
+        if left.is_charseq() && right.is_charseq() {
+            // The rest of the cases fall back on producing string
+            Some(db.mk_string())
+        } else {
+            None
+        }
+    }
+
     let left = left.in_db(db).peel_ref();
     let right = right.in_db(db).peel_ref();
     let (lhs_kind, rhs_kind) = (&*left.kind(), &*right.kind());
@@ -401,12 +432,15 @@ pub fn check_binary_op<T: ?Sized + db::TypeDatabase>(
         // Arithmetic operators
         expr::BinaryOp::Add => {
             // Operations:
-            // x String concatenation (charseq, charseq => charseq)
+            // - String concatenation (charseq, charseq => charseq)
             // x Set union (set, set => set)
             // - Addition (number, number => number)
 
             if let Some(result_ty) = check_arithmetic_operands(db, lhs_kind, rhs_kind) {
                 // Addition
+                Ok(result_ty)
+            } else if let Some(result_ty) = check_charseq_operands(db, lhs_kind, rhs_kind) {
+                // String concatenation
                 Ok(result_ty)
             } else {
                 // Type error

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__string_manip_op_concat.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__string_manip_op_concat.snap
@@ -1,0 +1,49 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+expression: "\n    var c : char\n    var c_dyn : char(*)\n    var c_sz : char(6)\n    var s : string\n    var s_dyn : string(*)\n    var s_sz : string(6)\n\n    % special cases first\n    var _t00 := c + c\n    var _t02 := c + c_sz\n    var _t20 := c_sz + c\n    var _t22 := c_sz + c_sz\n\n    % the rest of them down here (should produce string)\n    var _t01 := c + c_dyn\n    var _t03 := c + s\n    var _t04 := c + s_dyn\n    var _t05 := c + s_sz\n\n    var _t10 := c_dyn + c\n    var _t30 := s + c\n    var _t40 := s_dyn + c\n    var _t50 := s_sz + c\n\n    var _t11 := c_dyn + c_dyn\n    var _t12 := c_dyn + c_sz\n    var _t13 := c_dyn + s\n    var _t14 := c_dyn + s_dyn\n    var _t15 := c_dyn + s_sz\n\n    var _t21 := c_sz + c_dyn\n    var _t31 := s + c_dyn\n    var _t41 := s_dyn + c_dyn\n    var _t51 := s_sz + c_dyn\n\n    var _t23 := c_sz + s\n    var _t24 := c_sz + s_dyn\n    var _t25 := c_sz + s_sz\n\n    var _t32 := s + c_sz\n    var _t42 := s_dyn + c_sz\n    var _t52 := s_sz + c_sz\n\n    var _t33 := s + s\n    var _t34 := s + s_dyn\n    var _t35 := s + s_sz\n\n    var _t43 := s_dyn + s\n    var _t53 := s_sz + s\n\n    var _t44 := s_dyn + s_dyn\n    var _t45 := s_dyn + s_sz\n\n    var _t54 := s_sz + s_dyn\n\n    var _t55 := s_sz + s_sz\n    "
+
+---
+"c"@(FileId(1), 9..10) [Declared]: ref_mut char
+"c_dyn"@(FileId(1), 26..31) [Declared]: ref_mut char_n Dynamic
+"c_sz"@(FileId(1), 50..54) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
+"s"@(FileId(1), 73..74) [Declared]: ref_mut string
+"s_dyn"@(FileId(1), 92..97) [Declared]: ref_mut string_n Dynamic
+"s_sz"@(FileId(1), 118..122) [Declared]: ref_mut string_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
+"_t00"@(FileId(1), 170..174) [Declared]: ref_mut string
+"_t02"@(FileId(1), 192..196) [Declared]: ref_mut string
+"_t20"@(FileId(1), 217..221) [Declared]: ref_mut string
+"_t22"@(FileId(1), 242..246) [Declared]: ref_mut string
+"_t01"@(FileId(1), 328..332) [Declared]: ref_mut string
+"_t03"@(FileId(1), 354..358) [Declared]: ref_mut string
+"_t04"@(FileId(1), 376..380) [Declared]: ref_mut string
+"_t05"@(FileId(1), 402..406) [Declared]: ref_mut string
+"_t10"@(FileId(1), 428..432) [Declared]: ref_mut string
+"_t30"@(FileId(1), 454..458) [Declared]: ref_mut string
+"_t40"@(FileId(1), 476..480) [Declared]: ref_mut string
+"_t50"@(FileId(1), 502..506) [Declared]: ref_mut string
+"_t11"@(FileId(1), 528..532) [Declared]: ref_mut string
+"_t12"@(FileId(1), 558..562) [Declared]: ref_mut string
+"_t13"@(FileId(1), 587..591) [Declared]: ref_mut string
+"_t14"@(FileId(1), 613..617) [Declared]: ref_mut string
+"_t15"@(FileId(1), 643..647) [Declared]: ref_mut string
+"_t21"@(FileId(1), 673..677) [Declared]: ref_mut string
+"_t31"@(FileId(1), 702..706) [Declared]: ref_mut string
+"_t41"@(FileId(1), 728..732) [Declared]: ref_mut string
+"_t51"@(FileId(1), 758..762) [Declared]: ref_mut string
+"_t23"@(FileId(1), 788..792) [Declared]: ref_mut string
+"_t24"@(FileId(1), 813..817) [Declared]: ref_mut string
+"_t25"@(FileId(1), 842..846) [Declared]: ref_mut string
+"_t32"@(FileId(1), 871..875) [Declared]: ref_mut string
+"_t42"@(FileId(1), 896..900) [Declared]: ref_mut string
+"_t52"@(FileId(1), 925..929) [Declared]: ref_mut string
+"_t33"@(FileId(1), 954..958) [Declared]: ref_mut string
+"_t34"@(FileId(1), 976..980) [Declared]: ref_mut string
+"_t35"@(FileId(1), 1002..1006) [Declared]: ref_mut string
+"_t43"@(FileId(1), 1028..1032) [Declared]: ref_mut string
+"_t53"@(FileId(1), 1054..1058) [Declared]: ref_mut string
+"_t44"@(FileId(1), 1080..1084) [Declared]: ref_mut string
+"_t45"@(FileId(1), 1110..1114) [Declared]: ref_mut string
+"_t54"@(FileId(1), 1140..1144) [Declared]: ref_mut string
+"_t55"@(FileId(1), 1170..1174) [Declared]: ref_mut string
+"<root>"@(dummy) [Declared]: <error>
+

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__string_manip_op_wrong_type_concat.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__string_manip_op_wrong_type_concat.snap
@@ -1,0 +1,86 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+expression: "\n    var c : char\n    var c_dyn : char(*)\n    var c_sz : char(6)\n    var s : string\n    var s_dyn : string(*)\n    var s_sz : string(6)\n    var i : int\n\n    var _e00 := c + i\n    var _e01 := c_dyn + i\n    var _e02 := c_sz + i\n    var _e03 := s + i\n    var _e04 := s_dyn + i\n    var _e05 := s_sz + i\n\n    var _e10 := i + c\n    var _e11 := i + c_dyn\n    var _e12 := i + c_sz\n    var _e13 := i + s\n    var _e14 := i + s_dyn\n    var _e15 := i + s_sz\n\n    % TODO: Uncomment to verify incompatible types\n    /*\n    var _e20 : char(13) := c_sz + c_sz\n    var _e21 : char(8) := c_sz + c\n    var _e22 : char(8) := c + c_sz\n    var _e23 : char(3) := c + c\n    var _e24 : char := c + c\n    */\n    "
+
+---
+"c"@(FileId(1), 9..10) [Declared]: ref_mut char
+"c_dyn"@(FileId(1), 26..31) [Declared]: ref_mut char_n Dynamic
+"c_sz"@(FileId(1), 50..54) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
+"s"@(FileId(1), 73..74) [Declared]: ref_mut string
+"s_dyn"@(FileId(1), 92..97) [Declared]: ref_mut string_n Dynamic
+"s_sz"@(FileId(1), 118..122) [Declared]: ref_mut string_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
+"i"@(FileId(1), 143..144) [Declared]: ref_mut int
+"_e00"@(FileId(1), 160..164) [Declared]: ref_mut <error>
+"_e01"@(FileId(1), 182..186) [Declared]: ref_mut <error>
+"_e02"@(FileId(1), 208..212) [Declared]: ref_mut <error>
+"_e03"@(FileId(1), 233..237) [Declared]: ref_mut <error>
+"_e04"@(FileId(1), 255..259) [Declared]: ref_mut <error>
+"_e05"@(FileId(1), 281..285) [Declared]: ref_mut <error>
+"_e10"@(FileId(1), 307..311) [Declared]: ref_mut <error>
+"_e11"@(FileId(1), 329..333) [Declared]: ref_mut <error>
+"_e12"@(FileId(1), 355..359) [Declared]: ref_mut <error>
+"_e13"@(FileId(1), 380..384) [Declared]: ref_mut <error>
+"_e14"@(FileId(1), 402..406) [Declared]: ref_mut <error>
+"_e15"@(FileId(1), 428..432) [Declared]: ref_mut <error>
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 170..171: mismatched types for string concatenation
+| note in file FileId(1) for 168..169: this is of type `char`
+| note in file FileId(1) for 172..173: this is of type `int`
+| error in file FileId(1) for 170..171: `char` cannot be concatenated to `int`
+| info: operands must both be numbers, strings, or sets
+error in file FileId(1) at 196..197: mismatched types for string concatenation
+| note in file FileId(1) for 190..195: this is of type `char(*)`
+| note in file FileId(1) for 198..199: this is of type `int`
+| error in file FileId(1) for 196..197: `char(*)` cannot be concatenated to `int`
+| info: operands must both be numbers, strings, or sets
+error in file FileId(1) at 221..222: mismatched types for string concatenation
+| note in file FileId(1) for 216..220: this is of type `char(6)`
+| note in file FileId(1) for 223..224: this is of type `int`
+| error in file FileId(1) for 221..222: `char(6)` cannot be concatenated to `int`
+| info: operands must both be numbers, strings, or sets
+error in file FileId(1) at 243..244: mismatched types for string concatenation
+| note in file FileId(1) for 241..242: this is of type `string`
+| note in file FileId(1) for 245..246: this is of type `int`
+| error in file FileId(1) for 243..244: `string` cannot be concatenated to `int`
+| info: operands must both be numbers, strings, or sets
+error in file FileId(1) at 269..270: mismatched types for string concatenation
+| note in file FileId(1) for 263..268: this is of type `string(*)`
+| note in file FileId(1) for 271..272: this is of type `int`
+| error in file FileId(1) for 269..270: `string(*)` cannot be concatenated to `int`
+| info: operands must both be numbers, strings, or sets
+error in file FileId(1) at 294..295: mismatched types for string concatenation
+| note in file FileId(1) for 289..293: this is of type `string(6)`
+| note in file FileId(1) for 296..297: this is of type `int`
+| error in file FileId(1) for 294..295: `string(6)` cannot be concatenated to `int`
+| info: operands must both be numbers, strings, or sets
+error in file FileId(1) at 317..318: mismatched types for string concatenation
+| note in file FileId(1) for 315..316: this is of type `int`
+| note in file FileId(1) for 319..320: this is of type `char`
+| error in file FileId(1) for 317..318: `int` cannot be concatenated to `char`
+| info: operands must both be numbers, strings, or sets
+error in file FileId(1) at 339..340: mismatched types for string concatenation
+| note in file FileId(1) for 337..338: this is of type `int`
+| note in file FileId(1) for 341..346: this is of type `char(*)`
+| error in file FileId(1) for 339..340: `int` cannot be concatenated to `char(*)`
+| info: operands must both be numbers, strings, or sets
+error in file FileId(1) at 365..366: mismatched types for string concatenation
+| note in file FileId(1) for 363..364: this is of type `int`
+| note in file FileId(1) for 367..371: this is of type `char(6)`
+| error in file FileId(1) for 365..366: `int` cannot be concatenated to `char(6)`
+| info: operands must both be numbers, strings, or sets
+error in file FileId(1) at 390..391: mismatched types for string concatenation
+| note in file FileId(1) for 388..389: this is of type `int`
+| note in file FileId(1) for 392..393: this is of type `string`
+| error in file FileId(1) for 390..391: `int` cannot be concatenated to `string`
+| info: operands must both be numbers, strings, or sets
+error in file FileId(1) at 412..413: mismatched types for string concatenation
+| note in file FileId(1) for 410..411: this is of type `int`
+| note in file FileId(1) for 414..419: this is of type `string(*)`
+| error in file FileId(1) for 412..413: `int` cannot be concatenated to `string(*)`
+| info: operands must both be numbers, strings, or sets
+error in file FileId(1) at 438..439: mismatched types for string concatenation
+| note in file FileId(1) for 436..437: this is of type `int`
+| note in file FileId(1) for 440..444: this is of type `string(6)`
+| error in file FileId(1) for 438..439: `int` cannot be concatenated to `string(6)`
+| info: operands must both be numbers, strings, or sets

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typecheck_error_prop.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typecheck_error_prop.snap
@@ -9,8 +9,8 @@ expression: "var a : int\nvar b : string\nvar c := a + b\nvar j := c + a\n"
 "j"@(FileId(1), 46..47) [Declared]: ref_mut <error>
 "<root>"@(dummy) [Declared]: <error>
 
-error in file FileId(1) at 38..39: mismatched types for addition
+error in file FileId(1) at 38..39: mismatched types for string concatenation
 | note in file FileId(1) for 36..37: this is of type `int`
 | note in file FileId(1) for 40..41: this is of type `string`
-| error in file FileId(1) for 38..39: `int` cannot be added to `string`
+| error in file FileId(1) for 38..39: `int` cannot be concatenated to `string`
 | info: operands must both be numbers, strings, or sets

--- a/compiler/toc_analysis/src/typeck/test.rs
+++ b/compiler/toc_analysis/src/typeck/test.rs
@@ -301,6 +301,104 @@ test_for_each_op! { logical_op_wrong_type,
     // unary `not` also covered in `bitwise_op_wrong_type`
 }
 
+test_for_each_op! { string_manip_op,
+    [("+", concat)] =>
+    // over all 30 permutations + 6 same-arg permutations
+    r#"
+    var c : char
+    var c_dyn : char(*)
+    var c_sz : char(6)
+    var s : string
+    var s_dyn : string(*)
+    var s_sz : string(6)
+
+    % special cases first
+    var _t00 := c {0} c
+    var _t02 := c {0} c_sz
+    var _t20 := c_sz {0} c
+    var _t22 := c_sz {0} c_sz
+
+    % the rest of them down here (should produce string)
+    var _t01 := c {0} c_dyn
+    var _t03 := c {0} s
+    var _t04 := c {0} s_dyn
+    var _t05 := c {0} s_sz
+
+    var _t10 := c_dyn {0} c
+    var _t30 := s {0} c
+    var _t40 := s_dyn {0} c
+    var _t50 := s_sz {0} c
+
+    var _t11 := c_dyn {0} c_dyn
+    var _t12 := c_dyn {0} c_sz
+    var _t13 := c_dyn {0} s
+    var _t14 := c_dyn {0} s_dyn
+    var _t15 := c_dyn {0} s_sz
+
+    var _t21 := c_sz {0} c_dyn
+    var _t31 := s {0} c_dyn
+    var _t41 := s_dyn {0} c_dyn
+    var _t51 := s_sz {0} c_dyn
+
+    var _t23 := c_sz {0} s
+    var _t24 := c_sz {0} s_dyn
+    var _t25 := c_sz {0} s_sz
+
+    var _t32 := s {0} c_sz
+    var _t42 := s_dyn {0} c_sz
+    var _t52 := s_sz {0} c_sz
+
+    var _t33 := s {0} s
+    var _t34 := s {0} s_dyn
+    var _t35 := s {0} s_sz
+
+    var _t43 := s_dyn {0} s
+    var _t53 := s_sz {0} s
+
+    var _t44 := s_dyn {0} s_dyn
+    var _t45 := s_dyn {0} s_sz
+
+    var _t54 := s_sz {0} s_dyn
+
+    var _t55 := s_sz {0} s_sz
+    "#
+}
+
+test_for_each_op! { string_manip_op_wrong_type,
+    [("+", concat)] => r#"
+    var c : char
+    var c_dyn : char(*)
+    var c_sz : char(6)
+    var s : string
+    var s_dyn : string(*)
+    var s_sz : string(6)
+    var i : int
+
+    var _e00 := c {0} i
+    var _e01 := c_dyn {0} i
+    var _e02 := c_sz {0} i
+    var _e03 := s {0} i
+    var _e04 := s_dyn {0} i
+    var _e05 := s_sz {0} i
+
+    var _e10 := i {0} c
+    var _e11 := i {0} c_dyn
+    var _e12 := i {0} c_sz
+    var _e13 := i {0} s
+    var _e14 := i {0} s_dyn
+    var _e15 := i {0} s_sz
+
+    % TODO: Uncomment to verify incompatible types
+    /*
+    var _e20 : char(13) := c_sz {0} c_sz
+    var _e21 : char(8) := c_sz {0} c
+    var _e22 : char(8) := c {0} c_sz
+    var _e23 : char(3) := c {0} c
+    var _e24 : char := c {0} c
+    */
+    "#
+}
+
 // Test integer inference for all compatible operators
 test_for_each_op! { integer_inference,
     [


### PR DESCRIPTION
We should be closed over the current set of types with the current set of supported ops.
It's not supported yet in constant evaluation, but we don't have to worry about that yet...