### PR TITLE
Lower Partial HIR nodes

### DIFF
--- a/compiler/toc_analysis/src/const_eval/query.rs
+++ b/compiler/toc_analysis/src/const_eval/query.rs
@@ -125,7 +125,7 @@ pub(crate) fn evaluate_const(
                                 toc_hir::item::ItemKind::ConstVar(cv)
                                     if matches!(cv.mutability, Mutability::Const) =>
                                 {
-                                    cv.tail.init_expr()
+                                    cv.init_expr
                                 }
                                 _ => None,
                             }

--- a/compiler/toc_analysis/src/const_eval/test.rs
+++ b/compiler/toc_analysis/src/const_eval/test.rs
@@ -52,7 +52,7 @@ fn do_const_eval(source: &str) -> String {
     impl toc_hir::visitor::HirVisitor for ConstEvaluator<'_> {
         fn visit_constvar(&self, id: toc_hir::item::ItemId, item: &toc_hir::item::ConstVar) {
             let def_id = self.library.item(id).def_id;
-            let body = if let Some(body) = item.tail.init_expr() {
+            let body = if let Some(body) = item.init_expr {
                 body
             } else {
                 return;

--- a/compiler/toc_analysis/src/typeck.rs
+++ b/compiler/toc_analysis/src/typeck.rs
@@ -145,8 +145,8 @@ impl toc_hir::visitor::HirVisitor for TypeCheck<'_> {
 impl TypeCheck<'_> {
     fn typeck_constvar(&self, id: item::ItemId, item: &item::ConstVar) {
         // Check the initializer expression
-        let (ty_spec, init) = if let item::ConstVarTail::Both(ty_spec, initializer) = item.tail {
-            (ty_spec, initializer)
+        let (ty_spec, init) = if let Some(bundle) = item.type_spec.zip(item.init_expr) {
+            bundle
         } else {
             // Inferred or already specified
             return;

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__bare_var_decl-2.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__bare_var_decl-2.snap
@@ -1,0 +1,10 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+expression: "const k k := 3"
+
+---
+"k"@(FileId(1), 6..7) [Declared]: ref <error>
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 10..12: cannot assign into expression
+| note in file FileId(1) for 8..9: not a reference to a variable

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__bare_var_decl.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__bare_var_decl.snap
@@ -1,7 +1,8 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-expression: var k
+expression: "var k k := 3"
 
 ---
+"k"@(FileId(1), 4..5) [Declared]: ref_mut <error>
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_assignment_lhs_not_mut_missing_rhs.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_assignment_lhs_not_mut_missing_rhs.snap
@@ -1,0 +1,10 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+expression: "const j : int := 1\nj := \n"
+
+---
+"j"@(FileId(1), 6..7) [Declared]: ref int
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 21..23: cannot assign into expression
+| note in file FileId(1) for 19..20: not a reference to a variable

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_get_stmt_wrong_type_only_stream.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_get_stmt_wrong_type_only_stream.snap
@@ -1,0 +1,10 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+expression: "get : 1.0"
+
+---
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 6..9: mismatched types
+| note in file FileId(1) for 6..9: this is of type `real`
+| info: `real` is not an integer type

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_put_stmt_wrong_type_only_steam.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_put_stmt_wrong_type_only_steam.snap
@@ -1,0 +1,10 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+expression: "put : 1.0"
+
+---
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 6..9: mismatched types
+| note in file FileId(1) for 6..9: this is of type `real`
+| info: `real` is not an integer type

--- a/compiler/toc_analysis/src/typeck/test.rs
+++ b/compiler/toc_analysis/src/typeck/test.rs
@@ -96,9 +96,9 @@ fn var_decl_init_typecheck() {
 
 #[test]
 fn bare_var_decl() {
-    // Invariant, to be covered by the parser & hir stage
-    // Should not amount to anything
-    assert_typecheck("var k");
+    assert_typecheck("var k k := 3");
+    // should yell about this
+    assert_typecheck("const k k := 3");
 }
 
 #[test]

--- a/compiler/toc_analysis/src/typeck/test.rs
+++ b/compiler/toc_analysis/src/typeck/test.rs
@@ -732,6 +732,10 @@ test_named_group! { typeck_assignment,
             var lhs : int
             lhs := 1 + 1.0
         "#,
+        lhs_not_mut_missing_rhs => r#"
+            const j : int := 1
+            j := 
+        "#
     ]
 }
 
@@ -1127,6 +1131,7 @@ test_named_group! { typeck_put_stmt,
         var e : real
         put 1 : 0 : 0 : e
         "#,
+        wrong_type_only_steam => r#"put : 1.0"#
         // TODO: Add test for non-put-able items once non-primitive types are lowered
     ]
 }
@@ -1173,6 +1178,7 @@ test_named_group! { typeck_get_stmt,
         wrong_ref_literal => r#"
         get 1
         "#,
+        wrong_type_only_stream => r#"get : 1.0"#
         // TODO: Add test for non-get-able items once non-primitive types are lowered
     ]
 }

--- a/compiler/toc_hir/src/item.rs
+++ b/compiler/toc_hir/src/item.rs
@@ -68,7 +68,8 @@ pub struct ConstVar {
     pub is_register: bool,
     pub mutability: Mutability,
     pub def_id: symbol::LocalDefId,
-    pub tail: ConstVarTail,
+    pub type_spec: Option<ty::TypeId>,
+    pub init_expr: Option<body::BodyId>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/compiler/toc_hir/src/visitor.rs
+++ b/compiler/toc_hir/src/visitor.rs
@@ -275,11 +275,11 @@ impl<'hir> Walker<'hir> {
     }
 
     fn walk_constvar(&mut self, node: &item::ConstVar) {
-        if let Some(ty) = node.tail.type_spec() {
+        if let Some(ty) = node.type_spec {
             self.enter_type(ty, self.lib.lookup_type(ty));
         }
 
-        if let Some(id) = node.tail.init_expr() {
+        if let Some(id) = node.init_expr {
             self.enter_body(id, self.lib.body(id));
         }
     }

--- a/compiler/toc_hir_lowering/tests/lowering.rs
+++ b/compiler/toc_hir_lowering/tests/lowering.rs
@@ -137,6 +137,8 @@ fn lower_simple_assignment() {
     assert_lower("var a, b : int a := b");
     // non-reference lhs
     assert_lower("1 := 2");
+    // no rhs
+    assert_lower("1 := ");
 }
 
 #[test]
@@ -497,6 +499,11 @@ fn lower_put_stmt() {
     assert_lower("put 1 : 1 :  : 1");
     assert_lower("put 1 : 1 :  : ");
     assert_lower("put 1 :  :  : ");
+
+    // stream expr
+    assert_lower("put : a");
+    // no items, but there's a stream expr
+    assert_lower("put : 1");
 }
 
 #[test]
@@ -509,6 +516,11 @@ fn lower_get_stmt() {
     assert_lower("get");
     // not a reference
     assert_lower("get a*a");
+
+    // stream expr
+    assert_lower("get a : a*a");
+    // no items, but there's a stream expr
+    assert_lower("get : 1");
 }
 
 #[test]

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_get_stmt-5.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_get_stmt-5.snap
@@ -1,0 +1,17 @@
+---
+source: compiler/toc_hir_lowering/tests/lowering.rs
+expression: "get a : a*a"
+
+---
+Library@(dummy)
+  Root@(dummy): FileId(1) -> ItemId(0)
+    Module@(FileId(1), 0..11): "<root>"@(dummy)
+      StmtBody@(FileId(1), 0..11): []
+        Get@(FileId(1), 0..11)
+          Name@(FileId(1), 4..5): "a"@(FileId(1), 4..5), undeclared
+          Binary@(FileId(1), 8..11): Mul
+            Name@(FileId(1), 8..9): "a"@(FileId(1), 4..5), undeclared
+            Name@(FileId(1), 10..11): "a"@(FileId(1), 4..5), undeclared
+error in file FileId(1) at 4..5: `a` is undeclared
+| error in file FileId(1) for 4..5: no definitions of `a` are in scope
+

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_get_stmt-6.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_get_stmt-6.snap
@@ -1,0 +1,14 @@
+---
+source: compiler/toc_hir_lowering/tests/lowering.rs
+expression: "get : 1"
+
+---
+Library@(dummy)
+  Root@(dummy): FileId(1) -> ItemId(0)
+    Module@(FileId(1), 0..7): "<root>"@(dummy)
+      StmtBody@(FileId(1), 0..7): []
+        Get@(FileId(1), 0..7)
+          Literal@(FileId(1), 6..7): Integer(1)
+error in file FileId(1) at 6..7: unexpected end of file
+| error in file FileId(1) for 6..7: expected ‘,’ after here
+

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_put_stmt-7.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_put_stmt-7.snap
@@ -1,0 +1,14 @@
+---
+source: compiler/toc_hir_lowering/tests/lowering.rs
+expression: "put : a"
+
+---
+Library@(dummy)
+  Root@(dummy): FileId(1) -> ItemId(0)
+    Module@(FileId(1), 0..7): "<root>"@(dummy)
+      StmtBody@(FileId(1), 0..7): []
+        Put@(FileId(1), 0..7): newline
+          Name@(FileId(1), 6..7): "a"@(FileId(1), 6..7), undeclared
+error in file FileId(1) at 6..7: `a` is undeclared
+| error in file FileId(1) for 6..7: no definitions of `a` are in scope
+

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_put_stmt-8.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_put_stmt-8.snap
@@ -1,0 +1,14 @@
+---
+source: compiler/toc_hir_lowering/tests/lowering.rs
+expression: "put : 1"
+
+---
+Library@(dummy)
+  Root@(dummy): FileId(1) -> ItemId(0)
+    Module@(FileId(1), 0..7): "<root>"@(dummy)
+      StmtBody@(FileId(1), 0..7): []
+        Put@(FileId(1), 0..7): newline
+          Literal@(FileId(1), 6..7): Integer(1)
+error in file FileId(1) at 6..7: unexpected end of file
+| error in file FileId(1) for 6..7: expected ‘,’ after here
+

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_simple_assignment-3.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_simple_assignment-3.snap
@@ -1,0 +1,14 @@
+---
+source: compiler/toc_hir_lowering/tests/lowering.rs
+expression: "1 := "
+
+---
+Library@(dummy)
+  Root@(dummy): FileId(1) -> ItemId(0)
+    Module@(FileId(1), 0..5): "<root>"@(dummy)
+      StmtBody@(FileId(1), 0..4): []
+        Assign@(FileId(1), 0..4)
+          Literal@(FileId(1), 0..1): Integer(1)
+error in file FileId(1) at 2..4: unexpected end of file
+| error in file FileId(1) for 2..4: expected expression after here
+

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_var_def-5.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_var_def-5.snap
@@ -4,9 +4,11 @@ expression: var a
 
 ---
 Library@(dummy)
-  Root@(dummy): FileId(1) -> ItemId(0)
+  Root@(dummy): FileId(1) -> ItemId(1)
     Module@(FileId(1), 0..5): "<root>"@(dummy)
       StmtBody@(FileId(1), 0..5): []
+        StmtItem@(FileId(1), 0..5): ItemId(0)
+          ConstVar@(FileId(1), 0..5): var "a"@(FileId(1), 4..5)
 error in file FileId(1) at 4..5: unexpected end of file
 | error in file FileId(1) for 4..5: expected ‘,’, ‘:’ or ‘:=’ after here
 


### PR DESCRIPTION
These are partially filled HIR nodes that represent invalid-but-analyzable code.