### PR TITLE
Don't panic if trying to cover with a dummy span

### DIFF
--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_for_missing_left_bound.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_for_missing_left_bound.snap
@@ -1,0 +1,7 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+expression: "for : 1 .. end for"
+
+---
+"<root>"@(dummy) [Declared]: <error>
+

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_for_missing_right_bound.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_for_missing_right_bound.snap
@@ -1,0 +1,7 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+expression: "for : 1 .. end for"
+
+---
+"<root>"@(dummy) [Declared]: <error>
+

--- a/compiler/toc_analysis/src/typeck/test.rs
+++ b/compiler/toc_analysis/src/typeck/test.rs
@@ -1238,7 +1238,11 @@ test_named_group! {
 
         immut_counter => r#"for i : false .. true i := false end for"#,
 
-        unsupported_implicit_bounds => r#"var implied : int for : implied end for"#
+        unsupported_implicit_bounds => r#"var implied : int for : implied end for"#,
+
+        // Be resilient against missing bounds
+        missing_left_bound => "for : 1 .. end for",
+        missing_right_bound => "for : 1 .. end for",
     ]
 }
 

--- a/compiler/toc_span/src/lib.rs
+++ b/compiler/toc_span/src/lib.rs
@@ -52,19 +52,21 @@ impl Span {
     }
 
     /// Makes a new span covering both text ranges.
+    /// If either span is a dummy span, then `None` is returned.
     ///
     /// # Panics
     /// Panics if both spans aren't in the same file.
-    pub fn cover(self, other: Self) -> Self {
+    pub fn cover(self, other: Self) -> Option<Self> {
+        let (this_file, other_file) = self.file.zip(other.file)?;
         assert_eq!(
-            self.file, other.file,
+            this_file, other_file,
             "trying to cover spans in different files"
         );
 
-        Span {
+        Some(Span {
             range: self.range.cover(other.range),
             ..self
-        }
+        })
     }
 }
 


### PR DESCRIPTION
Trying to join two spans where one is a dummy span isn't possible, but it is still a valid case.
Therefore, `Span::cover` should be a fallible function.