### PR TITLE
Support Type Aliases

### DIFF
--- a/compiler/toc_analysis/src/ty.rs
+++ b/compiler/toc_analysis/src/ty.rs
@@ -370,6 +370,16 @@ where
     }
 }
 
+impl<'db, DB: ?Sized + 'db> Clone for TyRef<'db, DB> {
+    fn clone(&self) -> Self {
+        Self {
+            db: self.db,
+            id: self.id,
+            data: self.data.clone(),
+        }
+    }
+}
+
 /// Aligns `size` up to the next `align` boundary.
 /// `align` must be a power of two.
 pub fn align_up_to(size: usize, align: usize) -> usize {

--- a/compiler/toc_analysis/src/ty.rs
+++ b/compiler/toc_analysis/src/ty.rs
@@ -3,6 +3,7 @@
 use std::fmt::Debug;
 use std::sync::Arc;
 
+use toc_hir::symbol::DefId;
 use toc_span::Span;
 
 use crate::const_eval::{Const, ConstError, ConstInt};
@@ -65,6 +66,12 @@ pub enum TypeKind {
     CharN(SeqSize),
     /// Fixed-size string type.
     StringN(SeqSize),
+    /// Named alias to another type, pointing to the base (un-aliased) type
+    Alias(DefId, TypeId),
+    /// Forward declaration of a type.
+    /// This is used to prevent cyclic type declarations, which we can't detect
+    /// yet.
+    Forward,
     /// Reference type.
     ///
     /// This type does not appear in syntax (except for parameter binding),
@@ -218,6 +225,9 @@ where
             TypeKind::String => 1,
             TypeKind::CharN(_) => 1,
             TypeKind::StringN(_) => 1,
+            // Defer to the aliased type
+            TypeKind::Alias(_, base_ty) => return base_ty.in_db(self.db).align_of(),
+            TypeKind::Forward => return None,
             TypeKind::Ref(_, _) => return None,
         };
 
@@ -255,7 +265,11 @@ where
                     align_up_to(length_of, 2)
                 }
             }
-            TypeKind::Integer | TypeKind::Ref(_, _) | TypeKind::Error => return None,
+            // Defer to the aliased type
+            TypeKind::Alias(_, base_ty) => return base_ty.in_db(self.db).align_of(),
+            TypeKind::Integer | TypeKind::Ref(_, _) | TypeKind::Forward | TypeKind::Error => {
+                return None
+            }
         };
 
         Some(size_of)

--- a/compiler/toc_analysis/src/ty/db.rs
+++ b/compiler/toc_analysis/src/ty/db.rs
@@ -26,16 +26,8 @@ pub trait TypeDatabase: TypeIntern + TypeInternExt {
     fn from_hir_type(&self, type_id: InLibrary<HirTypeId>) -> ty::TypeId;
 
     /// Gets the type of the given type source.
-    ///
-    /// This automatically pokes through aliases.
     #[salsa::invoke(ty::query::type_of)]
     fn type_of(&self, source: TypeSource) -> ty::TypeId;
-
-    /// Gets the type of the given type source, preserving alias types.
-    ///
-    /// This is primarily used for displaying the type without any transformations.
-    #[salsa::invoke(ty::query::aliased_type_of)]
-    fn aliased_type_of(&self, source: TypeSource) -> ty::TypeId;
 }
 
 /// Helpers for working with the type interner

--- a/compiler/toc_analysis/src/ty/db.rs
+++ b/compiler/toc_analysis/src/ty/db.rs
@@ -43,6 +43,8 @@ pub trait TypeInternExt {
     fn mk_string(&self) -> ty::TypeId;
     fn mk_char_n(&self, seq_size: ty::SeqSize) -> ty::TypeId;
     fn mk_string_n(&self, seq_size: ty::SeqSize) -> ty::TypeId;
+    fn mk_alias(&self, def_id: DefId, base_ty: ty::TypeId) -> ty::TypeId;
+    fn mk_forward(&self) -> ty::TypeId;
     fn mk_ref(&self, mutability: ty::Mutability, to: ty::TypeId) -> ty::TypeId;
 }
 

--- a/compiler/toc_analysis/src/ty/db.rs
+++ b/compiler/toc_analysis/src/ty/db.rs
@@ -26,8 +26,16 @@ pub trait TypeDatabase: TypeIntern + TypeInternExt {
     fn from_hir_type(&self, type_id: InLibrary<HirTypeId>) -> ty::TypeId;
 
     /// Gets the type of the given type source.
+    ///
+    /// This automatically pokes through aliases.
     #[salsa::invoke(ty::query::type_of)]
     fn type_of(&self, source: TypeSource) -> ty::TypeId;
+
+    /// Gets the type of the given type source, preserving alias types.
+    ///
+    /// This is primarily used for displaying the type without any transformations.
+    #[salsa::invoke(ty::query::aliased_type_of)]
+    fn aliased_type_of(&self, source: TypeSource) -> ty::TypeId;
 }
 
 /// Helpers for working with the type interner

--- a/compiler/toc_analysis/src/ty/lower.rs
+++ b/compiler/toc_analysis/src/ty/lower.rs
@@ -136,6 +136,8 @@ fn type_def_ty(
     item_id: InLibrary<item::ItemId>,
     item: &item::Type,
 ) -> TypeId {
+    let def_id = DefId(item_id.0, item.def_id);
+
     match &item.type_def {
         item::DefinedType::Alias(to_ty) => {
             // Peel any aliases that are encountered
@@ -152,7 +154,7 @@ fn type_def_ty(
                 _ => db.mk_alias(def_id, base_ty.id()),
             }
         }
-        item::DefinedType::Forward(_) => db.mk_forward(),
+        item::DefinedType::Forward(_) => db.mk_alias(def_id, db.mk_forward()),
     }
 }
 

--- a/compiler/toc_analysis/src/ty/lower.rs
+++ b/compiler/toc_analysis/src/ty/lower.rs
@@ -1,4 +1,4 @@
-//! Lowering HIR entities into anaylsis types
+//! Lowering HIR entities into analysis types
 
 use std::convert::TryInto;
 
@@ -19,7 +19,7 @@ pub(crate) fn ty_from_hir_ty(db: &dyn TypeDatabase, hir_id: InLibrary<hir_ty::Ty
     match &hir_ty.kind {
         hir_ty::TypeKind::Missing => db.mk_error(),
         hir_ty::TypeKind::Primitive(ty) => primitive_ty(db, hir_id, ty),
-        hir_ty::TypeKind::Alias(_) => todo!(),
+        hir_ty::TypeKind::Alias(ty) => alias_ty(db, hir_id, ty),
     }
 }
 
@@ -57,13 +57,22 @@ fn lower_seq_len(library: LibraryId, seq_len: hir_ty::SeqLength) -> SeqSize {
     }
 }
 
+fn alias_ty(
+    db: &dyn TypeDatabase,
+    hir_id: InLibrary<hir_ty::TypeId>,
+    ty: &hir_ty::Alias,
+) -> TypeId {
+    // Defer to the type's definition
+    db.type_of(DefId(hir_id.0, ty.0).into())
+}
+
 pub(crate) fn ty_from_item(db: &dyn TypeDatabase, item_id: InLibrary<item::ItemId>) -> TypeId {
     let library = db.library(item_id.0);
     let item = library.item(item_id.1);
 
     match &item.kind {
         item::ItemKind::ConstVar(item) => constvar_ty(db, item_id, item),
-        item::ItemKind::Type(_item) => todo!(),
+        item::ItemKind::Type(item) => type_def_ty(db, item_id, item),
         item::ItemKind::Module(_) => db.mk_error(), // TODO: lower module items into tys
     }
 }
@@ -120,6 +129,31 @@ fn constvar_ty(
     };
 
     db.mk_ref(mutability, item_ty)
+}
+
+fn type_def_ty(
+    db: &dyn TypeDatabase,
+    item_id: InLibrary<item::ItemId>,
+    item: &item::Type,
+) -> TypeId {
+    match &item.type_def {
+        item::DefinedType::Alias(to_ty) => {
+            // Peel any aliases that are encountered
+            let base_ty = db
+                .from_hir_type((*to_ty).in_library(item_id.0))
+                .in_db(db)
+                .peel_aliases();
+            let def_id = DefId(item_id.0, item.def_id);
+
+            // Specialize based on the kind
+            match base_ty.kind() {
+                // Forward base types get propagated as errors
+                ty::TypeKind::Forward => db.mk_error(),
+                _ => db.mk_alias(def_id, base_ty.id()),
+            }
+        }
+        item::DefinedType::Forward(_) => db.mk_forward(),
+    }
 }
 
 fn for_counter_ty(

--- a/compiler/toc_analysis/src/ty/lower.rs
+++ b/compiler/toc_analysis/src/ty/lower.rs
@@ -63,7 +63,7 @@ fn alias_ty(
     ty: &hir_ty::Alias,
 ) -> TypeId {
     // Defer to the type's definition
-    db.type_of(DefId(hir_id.0, ty.0).into())
+    db.aliased_type_of(DefId(hir_id.0, ty.0).into())
 }
 
 pub(crate) fn ty_from_item(db: &dyn TypeDatabase, item_id: InLibrary<item::ItemId>) -> TypeId {
@@ -106,7 +106,9 @@ fn constvar_ty(
         (_, Some(body)) => {
             // From inferred init expr
             // Peel any refs
-            db.type_of((item_id.0, body).into()).in_db(db).peel_ref()
+            db.aliased_type_of((item_id.0, body).into())
+                .in_db(db)
+                .peel_ref()
         }
         (None, None) => {
             // No place to infer from, make an error
@@ -145,7 +147,6 @@ fn type_def_ty(
                 .from_hir_type((*to_ty).in_library(item_id.0))
                 .in_db(db)
                 .peel_aliases();
-            let def_id = DefId(item_id.0, item.def_id);
 
             // Specialize based on the kind
             match base_ty.kind() {

--- a/compiler/toc_analysis/src/ty/lower.rs
+++ b/compiler/toc_analysis/src/ty/lower.rs
@@ -119,7 +119,7 @@ fn constvar_ty(
         // Integer decomposes into a normal `int`
         db.mk_int(IntSize::Int)
     } else {
-        item_ty.id()
+        require_resolved_type(db, item_ty.id())
     };
 
     // Use the appropriate reference mutability
@@ -147,6 +147,7 @@ fn type_def_ty(
                 .peel_aliases();
 
             // Specialize based on the kind
+            // TODO: Specialize type when it's a record or union
             match base_ty.kind() {
                 // Forward base types get propagated as errors
                 ty::TypeKind::Forward => db.mk_error(),
@@ -263,5 +264,15 @@ fn name_ty(db: &dyn TypeDatabase, body: InLibrary<&body::Body>, expr: &expr::Nam
         expr::Name::Self_ => {
             todo!()
         }
+    }
+}
+
+/// Requires that a type is resolved at this point, otherwise produces
+/// a type error
+fn require_resolved_type(db: &dyn TypeDatabase, ty: TypeId) -> TypeId {
+    if ty.in_db(db).peel_aliases().kind().is_forward() {
+        db.mk_error()
+    } else {
+        ty
     }
 }

--- a/compiler/toc_analysis/src/ty/lower.rs
+++ b/compiler/toc_analysis/src/ty/lower.rs
@@ -19,6 +19,7 @@ pub(crate) fn ty_from_hir_ty(db: &dyn TypeDatabase, hir_id: InLibrary<hir_ty::Ty
     match &hir_ty.kind {
         hir_ty::TypeKind::Missing => db.mk_error(),
         hir_ty::TypeKind::Primitive(ty) => primitive_ty(db, hir_id, ty),
+        hir_ty::TypeKind::Alias(_) => todo!(),
     }
 }
 

--- a/compiler/toc_analysis/src/ty/lower.rs
+++ b/compiler/toc_analysis/src/ty/lower.rs
@@ -63,7 +63,7 @@ fn alias_ty(
     ty: &hir_ty::Alias,
 ) -> TypeId {
     // Defer to the type's definition
-    db.aliased_type_of(DefId(hir_id.0, ty.0).into())
+    db.type_of(DefId(hir_id.0, ty.0).into())
 }
 
 pub(crate) fn ty_from_item(db: &dyn TypeDatabase, item_id: InLibrary<item::ItemId>) -> TypeId {
@@ -106,9 +106,7 @@ fn constvar_ty(
         (_, Some(body)) => {
             // From inferred init expr
             // Peel any refs
-            db.aliased_type_of((item_id.0, body).into())
-                .in_db(db)
-                .peel_ref()
+            db.type_of((item_id.0, body).into()).in_db(db).peel_ref()
         }
         (None, None) => {
             // No place to infer from, make an error

--- a/compiler/toc_analysis/src/ty/lower.rs
+++ b/compiler/toc_analysis/src/ty/lower.rs
@@ -62,6 +62,7 @@ pub(crate) fn ty_from_item(db: &dyn TypeDatabase, item_id: InLibrary<item::ItemI
 
     match &item.kind {
         item::ItemKind::ConstVar(item) => constvar_ty(db, item_id, item),
+        item::ItemKind::Type(_item) => todo!(),
         item::ItemKind::Module(_) => db.mk_error(), // TODO: lower module items into tys
     }
 }

--- a/compiler/toc_analysis/src/ty/query.rs
+++ b/compiler/toc_analysis/src/ty/query.rs
@@ -155,6 +155,24 @@ where
         )
     }
 
+    fn mk_alias(&self, def_id: DefId, base_ty: TypeId) -> TypeId {
+        self.intern_type(
+            Type {
+                kind: TypeKind::Alias(def_id, base_ty),
+            }
+            .into(),
+        )
+    }
+
+    fn mk_forward(&self) -> TypeId {
+        self.intern_type(
+            Type {
+                kind: TypeKind::Forward,
+            }
+            .into(),
+        )
+    }
+
     fn mk_ref(&self, mutability: Mutability, to: TypeId) -> TypeId {
         self.intern_type(
             Type {

--- a/compiler/toc_analysis/src/ty/query.rs
+++ b/compiler/toc_analysis/src/ty/query.rs
@@ -18,18 +18,6 @@ pub(crate) fn from_hir_type(db: &dyn db::TypeDatabase, type_id: InLibrary<HirTyp
 }
 
 pub(crate) fn type_of(db: &dyn db::TypeDatabase, source: db::TypeSource) -> TypeId {
-    let ty = db.aliased_type_of(source).in_db(db);
-
-    // punch through any aliases
-    if let TypeKind::Ref(mutability, real_ty) = ty.kind() {
-        // Carry the ref through
-        db.mk_ref(*mutability, real_ty.in_db(db).peel_aliases().id())
-    } else {
-        ty.peel_aliases().id()
-    }
-}
-
-pub(crate) fn aliased_type_of(db: &dyn db::TypeDatabase, source: db::TypeSource) -> TypeId {
     match source {
         db::TypeSource::Def(def_id) => ty_of_def(db, def_id),
         db::TypeSource::BodyExpr(id, expr) => ty_of_expr(db, InLibrary(id, expr)),

--- a/compiler/toc_analysis/src/typeck.rs
+++ b/compiler/toc_analysis/src/typeck.rs
@@ -453,7 +453,7 @@ impl TypeCheck<'_> {
 
     fn is_text_io_item(&self, ty: ty::TypeId) -> bool {
         let db = self.db;
-        let ty_dat = ty.in_db(db).peel_ref().peel_aliases();
+        let ty_dat = ty.in_db(db).peel_ref();
 
         // Must be a valid put/get type
         // Can be one of the following:

--- a/compiler/toc_analysis/src/typeck.rs
+++ b/compiler/toc_analysis/src/typeck.rs
@@ -424,7 +424,7 @@ impl TypeCheck<'_> {
 
     fn is_text_io_item(&self, ty: ty::TypeId) -> bool {
         let db = self.db;
-        let ty_dat = ty.in_db(db).peel_ref();
+        let ty_dat = ty.in_db(db).peel_ref().peel_aliases();
 
         // Must be a valid put/get type
         // Can be one of the following:
@@ -441,6 +441,7 @@ impl TypeCheck<'_> {
         // For now, all lowered types satisfy this condition
         match ty_dat.kind() {
             ty::TypeKind::Error
+            | ty::TypeKind::Forward // accept since it's like error
             | ty::TypeKind::Boolean
             | ty::TypeKind::Int(_)
             | ty::TypeKind::Nat(_)
@@ -452,6 +453,8 @@ impl TypeCheck<'_> {
             | ty::TypeKind::StringN(_) => true,
             // Already deref'd
             ty::TypeKind::Ref(_, _) => unreachable!(),
+            // Already de-aliased
+            ty::TypeKind::Alias(_, _) => unreachable!(),
         }
     }
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__arithmetic_op_wrong_type_add.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__arithmetic_op_wrong_type_add.snap
@@ -1,5 +1,6 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "\n    var b : boolean\n    var r : real\n    var i : int\n    var n : nat\n    var _br := b + r\n    var _bi := b + i\n    var _bn := b + n\n    var _rb := r + b\n    var _ib := i + b\n    var _nb := n + b\n    var _bb := b + b\n"
 
 ---
@@ -17,37 +18,37 @@ expression: "\n    var b : boolean\n    var r : real\n    var i : int\n    var n
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 87..88: mismatched types for addition
-| note in file FileId(1) for 85..86: this is of type `boolean`
 | note in file FileId(1) for 89..90: this is of type `real`
+| note in file FileId(1) for 85..86: this is of type `boolean`
 | error in file FileId(1) for 87..88: `boolean` cannot be added to `real`
 | info: operands must both be numbers, strings, or sets
 error in file FileId(1) at 108..109: mismatched types for addition
-| note in file FileId(1) for 106..107: this is of type `boolean`
 | note in file FileId(1) for 110..111: this is of type `int`
+| note in file FileId(1) for 106..107: this is of type `boolean`
 | error in file FileId(1) for 108..109: `boolean` cannot be added to `int`
 | info: operands must both be numbers, strings, or sets
 error in file FileId(1) at 129..130: mismatched types for addition
-| note in file FileId(1) for 127..128: this is of type `boolean`
 | note in file FileId(1) for 131..132: this is of type `nat`
+| note in file FileId(1) for 127..128: this is of type `boolean`
 | error in file FileId(1) for 129..130: `boolean` cannot be added to `nat`
 | info: operands must both be numbers, strings, or sets
 error in file FileId(1) at 150..151: mismatched types for addition
-| note in file FileId(1) for 148..149: this is of type `real`
 | note in file FileId(1) for 152..153: this is of type `boolean`
+| note in file FileId(1) for 148..149: this is of type `real`
 | error in file FileId(1) for 150..151: `real` cannot be added to `boolean`
 | info: operands must both be numbers, strings, or sets
 error in file FileId(1) at 171..172: mismatched types for addition
-| note in file FileId(1) for 169..170: this is of type `int`
 | note in file FileId(1) for 173..174: this is of type `boolean`
+| note in file FileId(1) for 169..170: this is of type `int`
 | error in file FileId(1) for 171..172: `int` cannot be added to `boolean`
 | info: operands must both be numbers, strings, or sets
 error in file FileId(1) at 192..193: mismatched types for addition
-| note in file FileId(1) for 190..191: this is of type `nat`
 | note in file FileId(1) for 194..195: this is of type `boolean`
+| note in file FileId(1) for 190..191: this is of type `nat`
 | error in file FileId(1) for 192..193: `nat` cannot be added to `boolean`
 | info: operands must both be numbers, strings, or sets
 error in file FileId(1) at 213..214: mismatched types for addition
-| note in file FileId(1) for 211..212: this is of type `boolean`
 | note in file FileId(1) for 215..216: this is of type `boolean`
+| note in file FileId(1) for 211..212: this is of type `boolean`
 | error in file FileId(1) for 213..214: `boolean` cannot be added to `boolean`
 | info: operands must both be numbers, strings, or sets

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__arithmetic_op_wrong_type_exp.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__arithmetic_op_wrong_type_exp.snap
@@ -1,5 +1,6 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "\n    var b : boolean\n    var r : real\n    var i : int\n    var n : nat\n    var _br := b ** r\n    var _bi := b ** i\n    var _bn := b ** n\n    var _rb := r ** b\n    var _ib := i ** b\n    var _nb := n ** b\n    var _bb := b ** b\n"
 
 ---
@@ -17,37 +18,37 @@ expression: "\n    var b : boolean\n    var r : real\n    var i : int\n    var n
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 87..89: mismatched types for exponentiation
-| note in file FileId(1) for 85..86: this is of type `boolean`
 | note in file FileId(1) for 90..91: this is of type `real`
+| note in file FileId(1) for 85..86: this is of type `boolean`
 | error in file FileId(1) for 87..89: `boolean` cannot be exponentiated by `real`
 | info: operands must both be numbers
 error in file FileId(1) at 109..111: mismatched types for exponentiation
-| note in file FileId(1) for 107..108: this is of type `boolean`
 | note in file FileId(1) for 112..113: this is of type `int`
+| note in file FileId(1) for 107..108: this is of type `boolean`
 | error in file FileId(1) for 109..111: `boolean` cannot be exponentiated by `int`
 | info: operands must both be numbers
 error in file FileId(1) at 131..133: mismatched types for exponentiation
-| note in file FileId(1) for 129..130: this is of type `boolean`
 | note in file FileId(1) for 134..135: this is of type `nat`
+| note in file FileId(1) for 129..130: this is of type `boolean`
 | error in file FileId(1) for 131..133: `boolean` cannot be exponentiated by `nat`
 | info: operands must both be numbers
 error in file FileId(1) at 153..155: mismatched types for exponentiation
-| note in file FileId(1) for 151..152: this is of type `real`
 | note in file FileId(1) for 156..157: this is of type `boolean`
+| note in file FileId(1) for 151..152: this is of type `real`
 | error in file FileId(1) for 153..155: `real` cannot be exponentiated by `boolean`
 | info: operands must both be numbers
 error in file FileId(1) at 175..177: mismatched types for exponentiation
-| note in file FileId(1) for 173..174: this is of type `int`
 | note in file FileId(1) for 178..179: this is of type `boolean`
+| note in file FileId(1) for 173..174: this is of type `int`
 | error in file FileId(1) for 175..177: `int` cannot be exponentiated by `boolean`
 | info: operands must both be numbers
 error in file FileId(1) at 197..199: mismatched types for exponentiation
-| note in file FileId(1) for 195..196: this is of type `nat`
 | note in file FileId(1) for 200..201: this is of type `boolean`
+| note in file FileId(1) for 195..196: this is of type `nat`
 | error in file FileId(1) for 197..199: `nat` cannot be exponentiated by `boolean`
 | info: operands must both be numbers
 error in file FileId(1) at 219..221: mismatched types for exponentiation
-| note in file FileId(1) for 217..218: this is of type `boolean`
 | note in file FileId(1) for 222..223: this is of type `boolean`
+| note in file FileId(1) for 217..218: this is of type `boolean`
 | error in file FileId(1) for 219..221: `boolean` cannot be exponentiated by `boolean`
 | info: operands must both be numbers

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__arithmetic_op_wrong_type_idiv.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__arithmetic_op_wrong_type_idiv.snap
@@ -1,5 +1,6 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "\n    var b : boolean\n    var r : real\n    var i : int\n    var n : nat\n    var _br := b div r\n    var _bi := b div i\n    var _bn := b div n\n    var _rb := r div b\n    var _ib := i div b\n    var _nb := n div b\n    var _bb := b div b\n"
 
 ---
@@ -17,37 +18,37 @@ expression: "\n    var b : boolean\n    var r : real\n    var i : int\n    var n
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 87..90: mismatched types for integer division
-| note in file FileId(1) for 85..86: this is of type `boolean`
 | note in file FileId(1) for 91..92: this is of type `real`
+| note in file FileId(1) for 85..86: this is of type `boolean`
 | error in file FileId(1) for 87..90: `boolean` cannot be divided by `real`
 | info: operands must both be numbers
 error in file FileId(1) at 110..113: mismatched types for integer division
-| note in file FileId(1) for 108..109: this is of type `boolean`
 | note in file FileId(1) for 114..115: this is of type `int`
+| note in file FileId(1) for 108..109: this is of type `boolean`
 | error in file FileId(1) for 110..113: `boolean` cannot be divided by `int`
 | info: operands must both be numbers
 error in file FileId(1) at 133..136: mismatched types for integer division
-| note in file FileId(1) for 131..132: this is of type `boolean`
 | note in file FileId(1) for 137..138: this is of type `nat`
+| note in file FileId(1) for 131..132: this is of type `boolean`
 | error in file FileId(1) for 133..136: `boolean` cannot be divided by `nat`
 | info: operands must both be numbers
 error in file FileId(1) at 156..159: mismatched types for integer division
-| note in file FileId(1) for 154..155: this is of type `real`
 | note in file FileId(1) for 160..161: this is of type `boolean`
+| note in file FileId(1) for 154..155: this is of type `real`
 | error in file FileId(1) for 156..159: `real` cannot be divided by `boolean`
 | info: operands must both be numbers
 error in file FileId(1) at 179..182: mismatched types for integer division
-| note in file FileId(1) for 177..178: this is of type `int`
 | note in file FileId(1) for 183..184: this is of type `boolean`
+| note in file FileId(1) for 177..178: this is of type `int`
 | error in file FileId(1) for 179..182: `int` cannot be divided by `boolean`
 | info: operands must both be numbers
 error in file FileId(1) at 202..205: mismatched types for integer division
-| note in file FileId(1) for 200..201: this is of type `nat`
 | note in file FileId(1) for 206..207: this is of type `boolean`
+| note in file FileId(1) for 200..201: this is of type `nat`
 | error in file FileId(1) for 202..205: `nat` cannot be divided by `boolean`
 | info: operands must both be numbers
 error in file FileId(1) at 225..228: mismatched types for integer division
-| note in file FileId(1) for 223..224: this is of type `boolean`
 | note in file FileId(1) for 229..230: this is of type `boolean`
+| note in file FileId(1) for 223..224: this is of type `boolean`
 | error in file FileId(1) for 225..228: `boolean` cannot be divided by `boolean`
 | info: operands must both be numbers

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__arithmetic_op_wrong_type_mod.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__arithmetic_op_wrong_type_mod.snap
@@ -1,5 +1,6 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "\n    var b : boolean\n    var r : real\n    var i : int\n    var n : nat\n    var _br := b mod r\n    var _bi := b mod i\n    var _bn := b mod n\n    var _rb := r mod b\n    var _ib := i mod b\n    var _nb := n mod b\n    var _bb := b mod b\n"
 
 ---
@@ -17,37 +18,37 @@ expression: "\n    var b : boolean\n    var r : real\n    var i : int\n    var n
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 87..90: mismatched types for modulus
-| note in file FileId(1) for 85..86: this is of type `boolean`
 | note in file FileId(1) for 91..92: this is of type `real`
+| note in file FileId(1) for 85..86: this is of type `boolean`
 | error in file FileId(1) for 87..90: `boolean` cannot be `mod`'d by `real`
 | info: operands must both be numbers
 error in file FileId(1) at 110..113: mismatched types for modulus
-| note in file FileId(1) for 108..109: this is of type `boolean`
 | note in file FileId(1) for 114..115: this is of type `int`
+| note in file FileId(1) for 108..109: this is of type `boolean`
 | error in file FileId(1) for 110..113: `boolean` cannot be `mod`'d by `int`
 | info: operands must both be numbers
 error in file FileId(1) at 133..136: mismatched types for modulus
-| note in file FileId(1) for 131..132: this is of type `boolean`
 | note in file FileId(1) for 137..138: this is of type `nat`
+| note in file FileId(1) for 131..132: this is of type `boolean`
 | error in file FileId(1) for 133..136: `boolean` cannot be `mod`'d by `nat`
 | info: operands must both be numbers
 error in file FileId(1) at 156..159: mismatched types for modulus
-| note in file FileId(1) for 154..155: this is of type `real`
 | note in file FileId(1) for 160..161: this is of type `boolean`
+| note in file FileId(1) for 154..155: this is of type `real`
 | error in file FileId(1) for 156..159: `real` cannot be `mod`'d by `boolean`
 | info: operands must both be numbers
 error in file FileId(1) at 179..182: mismatched types for modulus
-| note in file FileId(1) for 177..178: this is of type `int`
 | note in file FileId(1) for 183..184: this is of type `boolean`
+| note in file FileId(1) for 177..178: this is of type `int`
 | error in file FileId(1) for 179..182: `int` cannot be `mod`'d by `boolean`
 | info: operands must both be numbers
 error in file FileId(1) at 202..205: mismatched types for modulus
-| note in file FileId(1) for 200..201: this is of type `nat`
 | note in file FileId(1) for 206..207: this is of type `boolean`
+| note in file FileId(1) for 200..201: this is of type `nat`
 | error in file FileId(1) for 202..205: `nat` cannot be `mod`'d by `boolean`
 | info: operands must both be numbers
 error in file FileId(1) at 225..228: mismatched types for modulus
-| note in file FileId(1) for 223..224: this is of type `boolean`
 | note in file FileId(1) for 229..230: this is of type `boolean`
+| note in file FileId(1) for 223..224: this is of type `boolean`
 | error in file FileId(1) for 225..228: `boolean` cannot be `mod`'d by `boolean`
 | info: operands must both be numbers

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__arithmetic_op_wrong_type_mul.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__arithmetic_op_wrong_type_mul.snap
@@ -1,5 +1,6 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "\n    var b : boolean\n    var r : real\n    var i : int\n    var n : nat\n    var _br := b * r\n    var _bi := b * i\n    var _bn := b * n\n    var _rb := r * b\n    var _ib := i * b\n    var _nb := n * b\n    var _bb := b * b\n"
 
 ---
@@ -17,37 +18,37 @@ expression: "\n    var b : boolean\n    var r : real\n    var i : int\n    var n
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 87..88: mismatched types for multiplication
-| note in file FileId(1) for 85..86: this is of type `boolean`
 | note in file FileId(1) for 89..90: this is of type `real`
+| note in file FileId(1) for 85..86: this is of type `boolean`
 | error in file FileId(1) for 87..88: `boolean` cannot be multiplied by `real`
 | info: operands must both be numbers or sets
 error in file FileId(1) at 108..109: mismatched types for multiplication
-| note in file FileId(1) for 106..107: this is of type `boolean`
 | note in file FileId(1) for 110..111: this is of type `int`
+| note in file FileId(1) for 106..107: this is of type `boolean`
 | error in file FileId(1) for 108..109: `boolean` cannot be multiplied by `int`
 | info: operands must both be numbers or sets
 error in file FileId(1) at 129..130: mismatched types for multiplication
-| note in file FileId(1) for 127..128: this is of type `boolean`
 | note in file FileId(1) for 131..132: this is of type `nat`
+| note in file FileId(1) for 127..128: this is of type `boolean`
 | error in file FileId(1) for 129..130: `boolean` cannot be multiplied by `nat`
 | info: operands must both be numbers or sets
 error in file FileId(1) at 150..151: mismatched types for multiplication
-| note in file FileId(1) for 148..149: this is of type `real`
 | note in file FileId(1) for 152..153: this is of type `boolean`
+| note in file FileId(1) for 148..149: this is of type `real`
 | error in file FileId(1) for 150..151: `real` cannot be multiplied by `boolean`
 | info: operands must both be numbers or sets
 error in file FileId(1) at 171..172: mismatched types for multiplication
-| note in file FileId(1) for 169..170: this is of type `int`
 | note in file FileId(1) for 173..174: this is of type `boolean`
+| note in file FileId(1) for 169..170: this is of type `int`
 | error in file FileId(1) for 171..172: `int` cannot be multiplied by `boolean`
 | info: operands must both be numbers or sets
 error in file FileId(1) at 192..193: mismatched types for multiplication
-| note in file FileId(1) for 190..191: this is of type `nat`
 | note in file FileId(1) for 194..195: this is of type `boolean`
+| note in file FileId(1) for 190..191: this is of type `nat`
 | error in file FileId(1) for 192..193: `nat` cannot be multiplied by `boolean`
 | info: operands must both be numbers or sets
 error in file FileId(1) at 213..214: mismatched types for multiplication
-| note in file FileId(1) for 211..212: this is of type `boolean`
 | note in file FileId(1) for 215..216: this is of type `boolean`
+| note in file FileId(1) for 211..212: this is of type `boolean`
 | error in file FileId(1) for 213..214: `boolean` cannot be multiplied by `boolean`
 | info: operands must both be numbers or sets

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__arithmetic_op_wrong_type_rdiv.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__arithmetic_op_wrong_type_rdiv.snap
@@ -1,5 +1,6 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "\n    var b : boolean\n    var r : real\n    var i : int\n    var n : nat\n    var _br := b / r\n    var _bi := b / i\n    var _bn := b / n\n    var _rb := r / b\n    var _ib := i / b\n    var _nb := n / b\n    var _bb := b / b\n"
 
 ---
@@ -17,37 +18,37 @@ expression: "\n    var b : boolean\n    var r : real\n    var i : int\n    var n
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 87..88: mismatched types for real division
-| note in file FileId(1) for 85..86: this is of type `boolean`
 | note in file FileId(1) for 89..90: this is of type `real`
+| note in file FileId(1) for 85..86: this is of type `boolean`
 | error in file FileId(1) for 87..88: `boolean` cannot be divided by `real`
 | info: operands must both be numbers
 error in file FileId(1) at 108..109: mismatched types for real division
-| note in file FileId(1) for 106..107: this is of type `boolean`
 | note in file FileId(1) for 110..111: this is of type `int`
+| note in file FileId(1) for 106..107: this is of type `boolean`
 | error in file FileId(1) for 108..109: `boolean` cannot be divided by `int`
 | info: operands must both be numbers
 error in file FileId(1) at 129..130: mismatched types for real division
-| note in file FileId(1) for 127..128: this is of type `boolean`
 | note in file FileId(1) for 131..132: this is of type `nat`
+| note in file FileId(1) for 127..128: this is of type `boolean`
 | error in file FileId(1) for 129..130: `boolean` cannot be divided by `nat`
 | info: operands must both be numbers
 error in file FileId(1) at 150..151: mismatched types for real division
-| note in file FileId(1) for 148..149: this is of type `real`
 | note in file FileId(1) for 152..153: this is of type `boolean`
+| note in file FileId(1) for 148..149: this is of type `real`
 | error in file FileId(1) for 150..151: `real` cannot be divided by `boolean`
 | info: operands must both be numbers
 error in file FileId(1) at 171..172: mismatched types for real division
-| note in file FileId(1) for 169..170: this is of type `int`
 | note in file FileId(1) for 173..174: this is of type `boolean`
+| note in file FileId(1) for 169..170: this is of type `int`
 | error in file FileId(1) for 171..172: `int` cannot be divided by `boolean`
 | info: operands must both be numbers
 error in file FileId(1) at 192..193: mismatched types for real division
-| note in file FileId(1) for 190..191: this is of type `nat`
 | note in file FileId(1) for 194..195: this is of type `boolean`
+| note in file FileId(1) for 190..191: this is of type `nat`
 | error in file FileId(1) for 192..193: `nat` cannot be divided by `boolean`
 | info: operands must both be numbers
 error in file FileId(1) at 213..214: mismatched types for real division
-| note in file FileId(1) for 211..212: this is of type `boolean`
 | note in file FileId(1) for 215..216: this is of type `boolean`
+| note in file FileId(1) for 211..212: this is of type `boolean`
 | error in file FileId(1) for 213..214: `boolean` cannot be divided by `boolean`
 | info: operands must both be numbers

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__arithmetic_op_wrong_type_rem.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__arithmetic_op_wrong_type_rem.snap
@@ -1,5 +1,6 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "\n    var b : boolean\n    var r : real\n    var i : int\n    var n : nat\n    var _br := b rem r\n    var _bi := b rem i\n    var _bn := b rem n\n    var _rb := r rem b\n    var _ib := i rem b\n    var _nb := n rem b\n    var _bb := b rem b\n"
 
 ---
@@ -17,37 +18,37 @@ expression: "\n    var b : boolean\n    var r : real\n    var i : int\n    var n
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 87..90: mismatched types for remainder
-| note in file FileId(1) for 85..86: this is of type `boolean`
 | note in file FileId(1) for 91..92: this is of type `real`
+| note in file FileId(1) for 85..86: this is of type `boolean`
 | error in file FileId(1) for 87..90: `boolean` cannot be `rem`'d by `real`
 | info: operands must both be numbers
 error in file FileId(1) at 110..113: mismatched types for remainder
-| note in file FileId(1) for 108..109: this is of type `boolean`
 | note in file FileId(1) for 114..115: this is of type `int`
+| note in file FileId(1) for 108..109: this is of type `boolean`
 | error in file FileId(1) for 110..113: `boolean` cannot be `rem`'d by `int`
 | info: operands must both be numbers
 error in file FileId(1) at 133..136: mismatched types for remainder
-| note in file FileId(1) for 131..132: this is of type `boolean`
 | note in file FileId(1) for 137..138: this is of type `nat`
+| note in file FileId(1) for 131..132: this is of type `boolean`
 | error in file FileId(1) for 133..136: `boolean` cannot be `rem`'d by `nat`
 | info: operands must both be numbers
 error in file FileId(1) at 156..159: mismatched types for remainder
-| note in file FileId(1) for 154..155: this is of type `real`
 | note in file FileId(1) for 160..161: this is of type `boolean`
+| note in file FileId(1) for 154..155: this is of type `real`
 | error in file FileId(1) for 156..159: `real` cannot be `rem`'d by `boolean`
 | info: operands must both be numbers
 error in file FileId(1) at 179..182: mismatched types for remainder
-| note in file FileId(1) for 177..178: this is of type `int`
 | note in file FileId(1) for 183..184: this is of type `boolean`
+| note in file FileId(1) for 177..178: this is of type `int`
 | error in file FileId(1) for 179..182: `int` cannot be `rem`'d by `boolean`
 | info: operands must both be numbers
 error in file FileId(1) at 202..205: mismatched types for remainder
-| note in file FileId(1) for 200..201: this is of type `nat`
 | note in file FileId(1) for 206..207: this is of type `boolean`
+| note in file FileId(1) for 200..201: this is of type `nat`
 | error in file FileId(1) for 202..205: `nat` cannot be `rem`'d by `boolean`
 | info: operands must both be numbers
 error in file FileId(1) at 225..228: mismatched types for remainder
-| note in file FileId(1) for 223..224: this is of type `boolean`
 | note in file FileId(1) for 229..230: this is of type `boolean`
+| note in file FileId(1) for 223..224: this is of type `boolean`
 | error in file FileId(1) for 225..228: `boolean` cannot be `rem`'d by `boolean`
 | info: operands must both be numbers

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__arithmetic_op_wrong_type_sub.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__arithmetic_op_wrong_type_sub.snap
@@ -1,5 +1,6 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "\n    var b : boolean\n    var r : real\n    var i : int\n    var n : nat\n    var _br := b - r\n    var _bi := b - i\n    var _bn := b - n\n    var _rb := r - b\n    var _ib := i - b\n    var _nb := n - b\n    var _bb := b - b\n"
 
 ---
@@ -17,37 +18,37 @@ expression: "\n    var b : boolean\n    var r : real\n    var i : int\n    var n
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 87..88: mismatched types for subtraction
-| note in file FileId(1) for 85..86: this is of type `boolean`
 | note in file FileId(1) for 89..90: this is of type `real`
+| note in file FileId(1) for 85..86: this is of type `boolean`
 | error in file FileId(1) for 87..88: `boolean` cannot be subtracted by `real`
 | info: operands must both be numbers or sets
 error in file FileId(1) at 108..109: mismatched types for subtraction
-| note in file FileId(1) for 106..107: this is of type `boolean`
 | note in file FileId(1) for 110..111: this is of type `int`
+| note in file FileId(1) for 106..107: this is of type `boolean`
 | error in file FileId(1) for 108..109: `boolean` cannot be subtracted by `int`
 | info: operands must both be numbers or sets
 error in file FileId(1) at 129..130: mismatched types for subtraction
-| note in file FileId(1) for 127..128: this is of type `boolean`
 | note in file FileId(1) for 131..132: this is of type `nat`
+| note in file FileId(1) for 127..128: this is of type `boolean`
 | error in file FileId(1) for 129..130: `boolean` cannot be subtracted by `nat`
 | info: operands must both be numbers or sets
 error in file FileId(1) at 150..151: mismatched types for subtraction
-| note in file FileId(1) for 148..149: this is of type `real`
 | note in file FileId(1) for 152..153: this is of type `boolean`
+| note in file FileId(1) for 148..149: this is of type `real`
 | error in file FileId(1) for 150..151: `real` cannot be subtracted by `boolean`
 | info: operands must both be numbers or sets
 error in file FileId(1) at 171..172: mismatched types for subtraction
-| note in file FileId(1) for 169..170: this is of type `int`
 | note in file FileId(1) for 173..174: this is of type `boolean`
+| note in file FileId(1) for 169..170: this is of type `int`
 | error in file FileId(1) for 171..172: `int` cannot be subtracted by `boolean`
 | info: operands must both be numbers or sets
 error in file FileId(1) at 192..193: mismatched types for subtraction
-| note in file FileId(1) for 190..191: this is of type `nat`
 | note in file FileId(1) for 194..195: this is of type `boolean`
+| note in file FileId(1) for 190..191: this is of type `nat`
 | error in file FileId(1) for 192..193: `nat` cannot be subtracted by `boolean`
 | info: operands must both be numbers or sets
 error in file FileId(1) at 213..214: mismatched types for subtraction
-| note in file FileId(1) for 211..212: this is of type `boolean`
 | note in file FileId(1) for 215..216: this is of type `boolean`
+| note in file FileId(1) for 211..212: this is of type `boolean`
 | error in file FileId(1) for 213..214: `boolean` cannot be subtracted by `boolean`
 | info: operands must both be numbers or sets

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__bitwise_op_wrong_type_and.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__bitwise_op_wrong_type_and.snap
@@ -1,5 +1,6 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "\n    var b : boolean\n    var r : real\n    var i : int\n    var n : nat\n    var _bi := b and i\n    var _bn := b and n\n    var _ib := i and b\n    var _nb := n and b\n    var _ri := r and i\n    var _rn := r and n\n    var _ir := i and r\n    var _nr := n and r\n"
 
 ---
@@ -18,42 +19,42 @@ expression: "\n    var b : boolean\n    var r : real\n    var i : int\n    var n
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 87..90: mismatched types for logical `and`
-| note in file FileId(1) for 85..86: this is of type `boolean`
 | note in file FileId(1) for 91..92: this is of type `int`
+| note in file FileId(1) for 85..86: this is of type `boolean`
 | error in file FileId(1) for 87..90: `boolean` cannot be `and`ed logically by `int`
 | info: operands must both be integers or booleans
 error in file FileId(1) at 110..113: mismatched types for logical `and`
-| note in file FileId(1) for 108..109: this is of type `boolean`
 | note in file FileId(1) for 114..115: this is of type `nat`
+| note in file FileId(1) for 108..109: this is of type `boolean`
 | error in file FileId(1) for 110..113: `boolean` cannot be `and`ed logically by `nat`
 | info: operands must both be integers or booleans
 error in file FileId(1) at 133..136: mismatched types for logical `and`
-| note in file FileId(1) for 131..132: this is of type `int`
 | note in file FileId(1) for 137..138: this is of type `boolean`
+| note in file FileId(1) for 131..132: this is of type `int`
 | error in file FileId(1) for 133..136: `int` cannot be `and`ed logically by `boolean`
 | info: operands must both be integers or booleans
 error in file FileId(1) at 156..159: mismatched types for logical `and`
-| note in file FileId(1) for 154..155: this is of type `nat`
 | note in file FileId(1) for 160..161: this is of type `boolean`
+| note in file FileId(1) for 154..155: this is of type `nat`
 | error in file FileId(1) for 156..159: `nat` cannot be `and`ed logically by `boolean`
 | info: operands must both be integers or booleans
 error in file FileId(1) at 179..182: mismatched types for bitwise `and`
-| note in file FileId(1) for 177..178: this is of type `real`
 | note in file FileId(1) for 183..184: this is of type `int`
+| note in file FileId(1) for 177..178: this is of type `real`
 | error in file FileId(1) for 179..182: `real` cannot be `and`ed bitwise by `int`
 | info: operands must both be integers or booleans
 error in file FileId(1) at 202..205: mismatched types for bitwise `and`
-| note in file FileId(1) for 200..201: this is of type `real`
 | note in file FileId(1) for 206..207: this is of type `nat`
+| note in file FileId(1) for 200..201: this is of type `real`
 | error in file FileId(1) for 202..205: `real` cannot be `and`ed bitwise by `nat`
 | info: operands must both be integers or booleans
 error in file FileId(1) at 225..228: mismatched types for bitwise `and`
-| note in file FileId(1) for 223..224: this is of type `int`
 | note in file FileId(1) for 229..230: this is of type `real`
+| note in file FileId(1) for 223..224: this is of type `int`
 | error in file FileId(1) for 225..228: `int` cannot be `and`ed bitwise by `real`
 | info: operands must both be integers or booleans
 error in file FileId(1) at 248..251: mismatched types for bitwise `and`
-| note in file FileId(1) for 246..247: this is of type `nat`
 | note in file FileId(1) for 252..253: this is of type `real`
+| note in file FileId(1) for 246..247: this is of type `nat`
 | error in file FileId(1) for 248..251: `nat` cannot be `and`ed bitwise by `real`
 | info: operands must both be integers or booleans

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__bitwise_op_wrong_type_or.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__bitwise_op_wrong_type_or.snap
@@ -1,5 +1,6 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "\n    var b : boolean\n    var r : real\n    var i : int\n    var n : nat\n    var _bi := b or i\n    var _bn := b or n\n    var _ib := i or b\n    var _nb := n or b\n    var _ri := r or i\n    var _rn := r or n\n    var _ir := i or r\n    var _nr := n or r\n"
 
 ---
@@ -18,42 +19,42 @@ expression: "\n    var b : boolean\n    var r : real\n    var i : int\n    var n
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 87..89: mismatched types for logical `or`
-| note in file FileId(1) for 85..86: this is of type `boolean`
 | note in file FileId(1) for 90..91: this is of type `int`
+| note in file FileId(1) for 85..86: this is of type `boolean`
 | error in file FileId(1) for 87..89: `boolean` cannot be `or`ed by `int`
 | info: operands must both be integers or booleans
 error in file FileId(1) at 109..111: mismatched types for logical `or`
-| note in file FileId(1) for 107..108: this is of type `boolean`
 | note in file FileId(1) for 112..113: this is of type `nat`
+| note in file FileId(1) for 107..108: this is of type `boolean`
 | error in file FileId(1) for 109..111: `boolean` cannot be `or`ed by `nat`
 | info: operands must both be integers or booleans
 error in file FileId(1) at 131..133: mismatched types for logical `or`
-| note in file FileId(1) for 129..130: this is of type `int`
 | note in file FileId(1) for 134..135: this is of type `boolean`
+| note in file FileId(1) for 129..130: this is of type `int`
 | error in file FileId(1) for 131..133: `int` cannot be `or`ed by `boolean`
 | info: operands must both be integers or booleans
 error in file FileId(1) at 153..155: mismatched types for logical `or`
-| note in file FileId(1) for 151..152: this is of type `nat`
 | note in file FileId(1) for 156..157: this is of type `boolean`
+| note in file FileId(1) for 151..152: this is of type `nat`
 | error in file FileId(1) for 153..155: `nat` cannot be `or`ed by `boolean`
 | info: operands must both be integers or booleans
 error in file FileId(1) at 175..177: mismatched types for bitwise `or`
-| note in file FileId(1) for 173..174: this is of type `real`
 | note in file FileId(1) for 178..179: this is of type `int`
+| note in file FileId(1) for 173..174: this is of type `real`
 | error in file FileId(1) for 175..177: `real` cannot be `or`ed bitwise by `int`
 | info: operands must both be integers or booleans
 error in file FileId(1) at 197..199: mismatched types for bitwise `or`
-| note in file FileId(1) for 195..196: this is of type `real`
 | note in file FileId(1) for 200..201: this is of type `nat`
+| note in file FileId(1) for 195..196: this is of type `real`
 | error in file FileId(1) for 197..199: `real` cannot be `or`ed bitwise by `nat`
 | info: operands must both be integers or booleans
 error in file FileId(1) at 219..221: mismatched types for bitwise `or`
-| note in file FileId(1) for 217..218: this is of type `int`
 | note in file FileId(1) for 222..223: this is of type `real`
+| note in file FileId(1) for 217..218: this is of type `int`
 | error in file FileId(1) for 219..221: `int` cannot be `or`ed bitwise by `real`
 | info: operands must both be integers or booleans
 error in file FileId(1) at 241..243: mismatched types for bitwise `or`
-| note in file FileId(1) for 239..240: this is of type `nat`
 | note in file FileId(1) for 244..245: this is of type `real`
+| note in file FileId(1) for 239..240: this is of type `nat`
 | error in file FileId(1) for 241..243: `nat` cannot be `or`ed bitwise by `real`
 | info: operands must both be integers or booleans

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__bitwise_op_wrong_type_shl.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__bitwise_op_wrong_type_shl.snap
@@ -1,5 +1,6 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "\n    var b : boolean\n    var r : real\n    var i : int\n    var n : nat\n    var _bi := b shl i\n    var _bn := b shl n\n    var _ib := i shl b\n    var _nb := n shl b\n    var _ri := r shl i\n    var _rn := r shl n\n    var _ir := i shl r\n    var _nr := n shl r\n"
 
 ---
@@ -18,42 +19,42 @@ expression: "\n    var b : boolean\n    var r : real\n    var i : int\n    var n
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 87..90: mismatched types for `shl`
-| note in file FileId(1) for 85..86: this is of type `boolean`
 | note in file FileId(1) for 91..92: this is of type `int`
+| note in file FileId(1) for 85..86: this is of type `boolean`
 | error in file FileId(1) for 87..90: `boolean` cannot be shifted left by `int`
 | info: operands must both be integers
 error in file FileId(1) at 110..113: mismatched types for `shl`
-| note in file FileId(1) for 108..109: this is of type `boolean`
 | note in file FileId(1) for 114..115: this is of type `nat`
+| note in file FileId(1) for 108..109: this is of type `boolean`
 | error in file FileId(1) for 110..113: `boolean` cannot be shifted left by `nat`
 | info: operands must both be integers
 error in file FileId(1) at 133..136: mismatched types for `shl`
-| note in file FileId(1) for 131..132: this is of type `int`
 | note in file FileId(1) for 137..138: this is of type `boolean`
+| note in file FileId(1) for 131..132: this is of type `int`
 | error in file FileId(1) for 133..136: `int` cannot be shifted left by `boolean`
 | info: operands must both be integers
 error in file FileId(1) at 156..159: mismatched types for `shl`
-| note in file FileId(1) for 154..155: this is of type `nat`
 | note in file FileId(1) for 160..161: this is of type `boolean`
+| note in file FileId(1) for 154..155: this is of type `nat`
 | error in file FileId(1) for 156..159: `nat` cannot be shifted left by `boolean`
 | info: operands must both be integers
 error in file FileId(1) at 179..182: mismatched types for `shl`
-| note in file FileId(1) for 177..178: this is of type `real`
 | note in file FileId(1) for 183..184: this is of type `int`
+| note in file FileId(1) for 177..178: this is of type `real`
 | error in file FileId(1) for 179..182: `real` cannot be shifted left by `int`
 | info: operands must both be integers
 error in file FileId(1) at 202..205: mismatched types for `shl`
-| note in file FileId(1) for 200..201: this is of type `real`
 | note in file FileId(1) for 206..207: this is of type `nat`
+| note in file FileId(1) for 200..201: this is of type `real`
 | error in file FileId(1) for 202..205: `real` cannot be shifted left by `nat`
 | info: operands must both be integers
 error in file FileId(1) at 225..228: mismatched types for `shl`
-| note in file FileId(1) for 223..224: this is of type `int`
 | note in file FileId(1) for 229..230: this is of type `real`
+| note in file FileId(1) for 223..224: this is of type `int`
 | error in file FileId(1) for 225..228: `int` cannot be shifted left by `real`
 | info: operands must both be integers
 error in file FileId(1) at 248..251: mismatched types for `shl`
-| note in file FileId(1) for 246..247: this is of type `nat`
 | note in file FileId(1) for 252..253: this is of type `real`
+| note in file FileId(1) for 246..247: this is of type `nat`
 | error in file FileId(1) for 248..251: `nat` cannot be shifted left by `real`
 | info: operands must both be integers

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__bitwise_op_wrong_type_shr.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__bitwise_op_wrong_type_shr.snap
@@ -1,5 +1,6 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "\n    var b : boolean\n    var r : real\n    var i : int\n    var n : nat\n    var _bi := b shr i\n    var _bn := b shr n\n    var _ib := i shr b\n    var _nb := n shr b\n    var _ri := r shr i\n    var _rn := r shr n\n    var _ir := i shr r\n    var _nr := n shr r\n"
 
 ---
@@ -18,42 +19,42 @@ expression: "\n    var b : boolean\n    var r : real\n    var i : int\n    var n
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 87..90: mismatched types for `shr`
-| note in file FileId(1) for 85..86: this is of type `boolean`
 | note in file FileId(1) for 91..92: this is of type `int`
+| note in file FileId(1) for 85..86: this is of type `boolean`
 | error in file FileId(1) for 87..90: `boolean` cannot be shifted right by `int`
 | info: operands must both be integers
 error in file FileId(1) at 110..113: mismatched types for `shr`
-| note in file FileId(1) for 108..109: this is of type `boolean`
 | note in file FileId(1) for 114..115: this is of type `nat`
+| note in file FileId(1) for 108..109: this is of type `boolean`
 | error in file FileId(1) for 110..113: `boolean` cannot be shifted right by `nat`
 | info: operands must both be integers
 error in file FileId(1) at 133..136: mismatched types for `shr`
-| note in file FileId(1) for 131..132: this is of type `int`
 | note in file FileId(1) for 137..138: this is of type `boolean`
+| note in file FileId(1) for 131..132: this is of type `int`
 | error in file FileId(1) for 133..136: `int` cannot be shifted right by `boolean`
 | info: operands must both be integers
 error in file FileId(1) at 156..159: mismatched types for `shr`
-| note in file FileId(1) for 154..155: this is of type `nat`
 | note in file FileId(1) for 160..161: this is of type `boolean`
+| note in file FileId(1) for 154..155: this is of type `nat`
 | error in file FileId(1) for 156..159: `nat` cannot be shifted right by `boolean`
 | info: operands must both be integers
 error in file FileId(1) at 179..182: mismatched types for `shr`
-| note in file FileId(1) for 177..178: this is of type `real`
 | note in file FileId(1) for 183..184: this is of type `int`
+| note in file FileId(1) for 177..178: this is of type `real`
 | error in file FileId(1) for 179..182: `real` cannot be shifted right by `int`
 | info: operands must both be integers
 error in file FileId(1) at 202..205: mismatched types for `shr`
-| note in file FileId(1) for 200..201: this is of type `real`
 | note in file FileId(1) for 206..207: this is of type `nat`
+| note in file FileId(1) for 200..201: this is of type `real`
 | error in file FileId(1) for 202..205: `real` cannot be shifted right by `nat`
 | info: operands must both be integers
 error in file FileId(1) at 225..228: mismatched types for `shr`
-| note in file FileId(1) for 223..224: this is of type `int`
 | note in file FileId(1) for 229..230: this is of type `real`
+| note in file FileId(1) for 223..224: this is of type `int`
 | error in file FileId(1) for 225..228: `int` cannot be shifted right by `real`
 | info: operands must both be integers
 error in file FileId(1) at 248..251: mismatched types for `shr`
-| note in file FileId(1) for 246..247: this is of type `nat`
 | note in file FileId(1) for 252..253: this is of type `real`
+| note in file FileId(1) for 246..247: this is of type `nat`
 | error in file FileId(1) for 248..251: `nat` cannot be shifted right by `real`
 | info: operands must both be integers

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__bitwise_op_wrong_type_xor.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__bitwise_op_wrong_type_xor.snap
@@ -1,5 +1,6 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "\n    var b : boolean\n    var r : real\n    var i : int\n    var n : nat\n    var _bi := b xor i\n    var _bn := b xor n\n    var _ib := i xor b\n    var _nb := n xor b\n    var _ri := r xor i\n    var _rn := r xor n\n    var _ir := i xor r\n    var _nr := n xor r\n"
 
 ---
@@ -18,42 +19,42 @@ expression: "\n    var b : boolean\n    var r : real\n    var i : int\n    var n
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 87..90: mismatched types for logical `xor`
-| note in file FileId(1) for 85..86: this is of type `boolean`
 | note in file FileId(1) for 91..92: this is of type `int`
+| note in file FileId(1) for 85..86: this is of type `boolean`
 | error in file FileId(1) for 87..90: `boolean` cannot be `xor`ed logically by `int`
 | info: operands must both be integers or booleans
 error in file FileId(1) at 110..113: mismatched types for logical `xor`
-| note in file FileId(1) for 108..109: this is of type `boolean`
 | note in file FileId(1) for 114..115: this is of type `nat`
+| note in file FileId(1) for 108..109: this is of type `boolean`
 | error in file FileId(1) for 110..113: `boolean` cannot be `xor`ed logically by `nat`
 | info: operands must both be integers or booleans
 error in file FileId(1) at 133..136: mismatched types for logical `xor`
-| note in file FileId(1) for 131..132: this is of type `int`
 | note in file FileId(1) for 137..138: this is of type `boolean`
+| note in file FileId(1) for 131..132: this is of type `int`
 | error in file FileId(1) for 133..136: `int` cannot be `xor`ed logically by `boolean`
 | info: operands must both be integers or booleans
 error in file FileId(1) at 156..159: mismatched types for logical `xor`
-| note in file FileId(1) for 154..155: this is of type `nat`
 | note in file FileId(1) for 160..161: this is of type `boolean`
+| note in file FileId(1) for 154..155: this is of type `nat`
 | error in file FileId(1) for 156..159: `nat` cannot be `xor`ed logically by `boolean`
 | info: operands must both be integers or booleans
 error in file FileId(1) at 179..182: mismatched types for bitwise `xor`
-| note in file FileId(1) for 177..178: this is of type `real`
 | note in file FileId(1) for 183..184: this is of type `int`
+| note in file FileId(1) for 177..178: this is of type `real`
 | error in file FileId(1) for 179..182: `real` cannot be `xor`ed bitwise by `int`
 | info: operands must both be integers or booleans
 error in file FileId(1) at 202..205: mismatched types for bitwise `xor`
-| note in file FileId(1) for 200..201: this is of type `real`
 | note in file FileId(1) for 206..207: this is of type `nat`
+| note in file FileId(1) for 200..201: this is of type `real`
 | error in file FileId(1) for 202..205: `real` cannot be `xor`ed bitwise by `nat`
 | info: operands must both be integers or booleans
 error in file FileId(1) at 225..228: mismatched types for bitwise `xor`
-| note in file FileId(1) for 223..224: this is of type `int`
 | note in file FileId(1) for 229..230: this is of type `real`
+| note in file FileId(1) for 223..224: this is of type `int`
 | error in file FileId(1) for 225..228: `int` cannot be `xor`ed bitwise by `real`
 | info: operands must both be integers or booleans
 error in file FileId(1) at 248..251: mismatched types for bitwise `xor`
-| note in file FileId(1) for 246..247: this is of type `nat`
 | note in file FileId(1) for 252..253: this is of type `real`
+| note in file FileId(1) for 246..247: this is of type `nat`
 | error in file FileId(1) for 248..251: `nat` cannot be `xor`ed bitwise by `real`
 | info: operands must both be integers or booleans

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_equal.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_equal.snap
@@ -1,5 +1,6 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "\n    % Numerics\n    var r : real\n    var i : int\n    var n : nat\n\n    % Other scalars\n    var b : boolean\n\n    % Sized charseqs\n    var c : char\n    var c_sz : char(6)\n    var s : string\n    var s_sz : string(6)\n\n    % should all produce boolean anyway\n    var _v_res : boolean\n\n    _v_res := r = b\n    _v_res := r = c\n    _v_res := r = c_sz\n    _v_res := r = s\n    _v_res := r = s_sz\n\n    _v_res := i = b\n    _v_res := i = c\n    _v_res := i = c_sz\n    _v_res := i = s\n    _v_res := i = s_sz\n\n    _v_res := n = b\n    _v_res := n = c\n    _v_res := n = c_sz\n    _v_res := n = s\n    _v_res := n = s_sz\n\n    _v_res := b = r\n    _v_res := b = i\n    _v_res := b = n\n    _v_res := b = c\n    _v_res := b = c_sz\n    _v_res := b = s\n    _v_res := b = s_sz\n\n    _v_res := c = r\n    _v_res := c = i\n    _v_res := c = n\n    _v_res := c = b\n\n    _v_res := c_sz = r\n    _v_res := c_sz = i\n    _v_res := c_sz = n\n    _v_res := c_sz = b\n\n    _v_res := s = r\n    _v_res := s = i\n    _v_res := s = n\n    _v_res := s = b\n\n    _v_res := s_sz = r\n    _v_res := s_sz = i\n    _v_res := s_sz = n\n    _v_res := s_sz = b\n    "
 
 ---
@@ -15,192 +16,192 @@ expression: "\n    % Numerics\n    var r : real\n    var i : int\n    var n : na
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 295..296: mismatched types for `=`
-| note in file FileId(1) for 293..294: this is of type `real`
 | note in file FileId(1) for 297..298: this is of type `boolean`
+| note in file FileId(1) for 293..294: this is of type `real`
 | error in file FileId(1) for 295..296: `real` cannot be compared to `boolean`
 | info: operands must both be the same type
 error in file FileId(1) at 315..316: mismatched types for `=`
-| note in file FileId(1) for 313..314: this is of type `real`
 | note in file FileId(1) for 317..318: this is of type `char`
+| note in file FileId(1) for 313..314: this is of type `real`
 | error in file FileId(1) for 315..316: `real` cannot be compared to `char`
 | info: operands must both be the same type
 error in file FileId(1) at 335..336: mismatched types for `=`
-| note in file FileId(1) for 333..334: this is of type `real`
 | note in file FileId(1) for 337..341: this is of type `char(6)`
+| note in file FileId(1) for 333..334: this is of type `real`
 | error in file FileId(1) for 335..336: `real` cannot be compared to `char(6)`
 | info: operands must both be the same type
 error in file FileId(1) at 358..359: mismatched types for `=`
-| note in file FileId(1) for 356..357: this is of type `real`
 | note in file FileId(1) for 360..361: this is of type `string`
+| note in file FileId(1) for 356..357: this is of type `real`
 | error in file FileId(1) for 358..359: `real` cannot be compared to `string`
 | info: operands must both be the same type
 error in file FileId(1) at 378..379: mismatched types for `=`
-| note in file FileId(1) for 376..377: this is of type `real`
 | note in file FileId(1) for 380..384: this is of type `string(6)`
+| note in file FileId(1) for 376..377: this is of type `real`
 | error in file FileId(1) for 378..379: `real` cannot be compared to `string(6)`
 | info: operands must both be the same type
 error in file FileId(1) at 402..403: mismatched types for `=`
-| note in file FileId(1) for 400..401: this is of type `int`
 | note in file FileId(1) for 404..405: this is of type `boolean`
+| note in file FileId(1) for 400..401: this is of type `int`
 | error in file FileId(1) for 402..403: `int` cannot be compared to `boolean`
 | info: operands must both be the same type
 error in file FileId(1) at 422..423: mismatched types for `=`
-| note in file FileId(1) for 420..421: this is of type `int`
 | note in file FileId(1) for 424..425: this is of type `char`
+| note in file FileId(1) for 420..421: this is of type `int`
 | error in file FileId(1) for 422..423: `int` cannot be compared to `char`
 | info: operands must both be the same type
 error in file FileId(1) at 442..443: mismatched types for `=`
-| note in file FileId(1) for 440..441: this is of type `int`
 | note in file FileId(1) for 444..448: this is of type `char(6)`
+| note in file FileId(1) for 440..441: this is of type `int`
 | error in file FileId(1) for 442..443: `int` cannot be compared to `char(6)`
 | info: operands must both be the same type
 error in file FileId(1) at 465..466: mismatched types for `=`
-| note in file FileId(1) for 463..464: this is of type `int`
 | note in file FileId(1) for 467..468: this is of type `string`
+| note in file FileId(1) for 463..464: this is of type `int`
 | error in file FileId(1) for 465..466: `int` cannot be compared to `string`
 | info: operands must both be the same type
 error in file FileId(1) at 485..486: mismatched types for `=`
-| note in file FileId(1) for 483..484: this is of type `int`
 | note in file FileId(1) for 487..491: this is of type `string(6)`
+| note in file FileId(1) for 483..484: this is of type `int`
 | error in file FileId(1) for 485..486: `int` cannot be compared to `string(6)`
 | info: operands must both be the same type
 error in file FileId(1) at 509..510: mismatched types for `=`
-| note in file FileId(1) for 507..508: this is of type `nat`
 | note in file FileId(1) for 511..512: this is of type `boolean`
+| note in file FileId(1) for 507..508: this is of type `nat`
 | error in file FileId(1) for 509..510: `nat` cannot be compared to `boolean`
 | info: operands must both be the same type
 error in file FileId(1) at 529..530: mismatched types for `=`
-| note in file FileId(1) for 527..528: this is of type `nat`
 | note in file FileId(1) for 531..532: this is of type `char`
+| note in file FileId(1) for 527..528: this is of type `nat`
 | error in file FileId(1) for 529..530: `nat` cannot be compared to `char`
 | info: operands must both be the same type
 error in file FileId(1) at 549..550: mismatched types for `=`
-| note in file FileId(1) for 547..548: this is of type `nat`
 | note in file FileId(1) for 551..555: this is of type `char(6)`
+| note in file FileId(1) for 547..548: this is of type `nat`
 | error in file FileId(1) for 549..550: `nat` cannot be compared to `char(6)`
 | info: operands must both be the same type
 error in file FileId(1) at 572..573: mismatched types for `=`
-| note in file FileId(1) for 570..571: this is of type `nat`
 | note in file FileId(1) for 574..575: this is of type `string`
+| note in file FileId(1) for 570..571: this is of type `nat`
 | error in file FileId(1) for 572..573: `nat` cannot be compared to `string`
 | info: operands must both be the same type
 error in file FileId(1) at 592..593: mismatched types for `=`
-| note in file FileId(1) for 590..591: this is of type `nat`
 | note in file FileId(1) for 594..598: this is of type `string(6)`
+| note in file FileId(1) for 590..591: this is of type `nat`
 | error in file FileId(1) for 592..593: `nat` cannot be compared to `string(6)`
 | info: operands must both be the same type
 error in file FileId(1) at 616..617: mismatched types for `=`
-| note in file FileId(1) for 614..615: this is of type `boolean`
 | note in file FileId(1) for 618..619: this is of type `real`
+| note in file FileId(1) for 614..615: this is of type `boolean`
 | error in file FileId(1) for 616..617: `boolean` cannot be compared to `real`
 | info: operands must both be the same type
 error in file FileId(1) at 636..637: mismatched types for `=`
-| note in file FileId(1) for 634..635: this is of type `boolean`
 | note in file FileId(1) for 638..639: this is of type `int`
+| note in file FileId(1) for 634..635: this is of type `boolean`
 | error in file FileId(1) for 636..637: `boolean` cannot be compared to `int`
 | info: operands must both be the same type
 error in file FileId(1) at 656..657: mismatched types for `=`
-| note in file FileId(1) for 654..655: this is of type `boolean`
 | note in file FileId(1) for 658..659: this is of type `nat`
+| note in file FileId(1) for 654..655: this is of type `boolean`
 | error in file FileId(1) for 656..657: `boolean` cannot be compared to `nat`
 | info: operands must both be the same type
 error in file FileId(1) at 676..677: mismatched types for `=`
-| note in file FileId(1) for 674..675: this is of type `boolean`
 | note in file FileId(1) for 678..679: this is of type `char`
+| note in file FileId(1) for 674..675: this is of type `boolean`
 | error in file FileId(1) for 676..677: `boolean` cannot be compared to `char`
 | info: operands must both be the same type
 error in file FileId(1) at 696..697: mismatched types for `=`
-| note in file FileId(1) for 694..695: this is of type `boolean`
 | note in file FileId(1) for 698..702: this is of type `char(6)`
+| note in file FileId(1) for 694..695: this is of type `boolean`
 | error in file FileId(1) for 696..697: `boolean` cannot be compared to `char(6)`
 | info: operands must both be the same type
 error in file FileId(1) at 719..720: mismatched types for `=`
-| note in file FileId(1) for 717..718: this is of type `boolean`
 | note in file FileId(1) for 721..722: this is of type `string`
+| note in file FileId(1) for 717..718: this is of type `boolean`
 | error in file FileId(1) for 719..720: `boolean` cannot be compared to `string`
 | info: operands must both be the same type
 error in file FileId(1) at 739..740: mismatched types for `=`
-| note in file FileId(1) for 737..738: this is of type `boolean`
 | note in file FileId(1) for 741..745: this is of type `string(6)`
+| note in file FileId(1) for 737..738: this is of type `boolean`
 | error in file FileId(1) for 739..740: `boolean` cannot be compared to `string(6)`
 | info: operands must both be the same type
 error in file FileId(1) at 763..764: mismatched types for `=`
-| note in file FileId(1) for 761..762: this is of type `char`
 | note in file FileId(1) for 765..766: this is of type `real`
+| note in file FileId(1) for 761..762: this is of type `char`
 | error in file FileId(1) for 763..764: `char` cannot be compared to `real`
 | info: operands must both be the same type
 error in file FileId(1) at 783..784: mismatched types for `=`
-| note in file FileId(1) for 781..782: this is of type `char`
 | note in file FileId(1) for 785..786: this is of type `int`
+| note in file FileId(1) for 781..782: this is of type `char`
 | error in file FileId(1) for 783..784: `char` cannot be compared to `int`
 | info: operands must both be the same type
 error in file FileId(1) at 803..804: mismatched types for `=`
-| note in file FileId(1) for 801..802: this is of type `char`
 | note in file FileId(1) for 805..806: this is of type `nat`
+| note in file FileId(1) for 801..802: this is of type `char`
 | error in file FileId(1) for 803..804: `char` cannot be compared to `nat`
 | info: operands must both be the same type
 error in file FileId(1) at 823..824: mismatched types for `=`
-| note in file FileId(1) for 821..822: this is of type `char`
 | note in file FileId(1) for 825..826: this is of type `boolean`
+| note in file FileId(1) for 821..822: this is of type `char`
 | error in file FileId(1) for 823..824: `char` cannot be compared to `boolean`
 | info: operands must both be the same type
 error in file FileId(1) at 847..848: mismatched types for `=`
-| note in file FileId(1) for 842..846: this is of type `char(6)`
 | note in file FileId(1) for 849..850: this is of type `real`
+| note in file FileId(1) for 842..846: this is of type `char(6)`
 | error in file FileId(1) for 847..848: `char(6)` cannot be compared to `real`
 | info: operands must both be the same type
 error in file FileId(1) at 870..871: mismatched types for `=`
-| note in file FileId(1) for 865..869: this is of type `char(6)`
 | note in file FileId(1) for 872..873: this is of type `int`
+| note in file FileId(1) for 865..869: this is of type `char(6)`
 | error in file FileId(1) for 870..871: `char(6)` cannot be compared to `int`
 | info: operands must both be the same type
 error in file FileId(1) at 893..894: mismatched types for `=`
-| note in file FileId(1) for 888..892: this is of type `char(6)`
 | note in file FileId(1) for 895..896: this is of type `nat`
+| note in file FileId(1) for 888..892: this is of type `char(6)`
 | error in file FileId(1) for 893..894: `char(6)` cannot be compared to `nat`
 | info: operands must both be the same type
 error in file FileId(1) at 916..917: mismatched types for `=`
-| note in file FileId(1) for 911..915: this is of type `char(6)`
 | note in file FileId(1) for 918..919: this is of type `boolean`
+| note in file FileId(1) for 911..915: this is of type `char(6)`
 | error in file FileId(1) for 916..917: `char(6)` cannot be compared to `boolean`
 | info: operands must both be the same type
 error in file FileId(1) at 937..938: mismatched types for `=`
-| note in file FileId(1) for 935..936: this is of type `string`
 | note in file FileId(1) for 939..940: this is of type `real`
+| note in file FileId(1) for 935..936: this is of type `string`
 | error in file FileId(1) for 937..938: `string` cannot be compared to `real`
 | info: operands must both be the same type
 error in file FileId(1) at 957..958: mismatched types for `=`
-| note in file FileId(1) for 955..956: this is of type `string`
 | note in file FileId(1) for 959..960: this is of type `int`
+| note in file FileId(1) for 955..956: this is of type `string`
 | error in file FileId(1) for 957..958: `string` cannot be compared to `int`
 | info: operands must both be the same type
 error in file FileId(1) at 977..978: mismatched types for `=`
-| note in file FileId(1) for 975..976: this is of type `string`
 | note in file FileId(1) for 979..980: this is of type `nat`
+| note in file FileId(1) for 975..976: this is of type `string`
 | error in file FileId(1) for 977..978: `string` cannot be compared to `nat`
 | info: operands must both be the same type
 error in file FileId(1) at 997..998: mismatched types for `=`
-| note in file FileId(1) for 995..996: this is of type `string`
 | note in file FileId(1) for 999..1000: this is of type `boolean`
+| note in file FileId(1) for 995..996: this is of type `string`
 | error in file FileId(1) for 997..998: `string` cannot be compared to `boolean`
 | info: operands must both be the same type
 error in file FileId(1) at 1021..1022: mismatched types for `=`
-| note in file FileId(1) for 1016..1020: this is of type `string(6)`
 | note in file FileId(1) for 1023..1024: this is of type `real`
+| note in file FileId(1) for 1016..1020: this is of type `string(6)`
 | error in file FileId(1) for 1021..1022: `string(6)` cannot be compared to `real`
 | info: operands must both be the same type
 error in file FileId(1) at 1044..1045: mismatched types for `=`
-| note in file FileId(1) for 1039..1043: this is of type `string(6)`
 | note in file FileId(1) for 1046..1047: this is of type `int`
+| note in file FileId(1) for 1039..1043: this is of type `string(6)`
 | error in file FileId(1) for 1044..1045: `string(6)` cannot be compared to `int`
 | info: operands must both be the same type
 error in file FileId(1) at 1067..1068: mismatched types for `=`
-| note in file FileId(1) for 1062..1066: this is of type `string(6)`
 | note in file FileId(1) for 1069..1070: this is of type `nat`
+| note in file FileId(1) for 1062..1066: this is of type `string(6)`
 | error in file FileId(1) for 1067..1068: `string(6)` cannot be compared to `nat`
 | info: operands must both be the same type
 error in file FileId(1) at 1090..1091: mismatched types for `=`
-| note in file FileId(1) for 1085..1089: this is of type `string(6)`
 | note in file FileId(1) for 1092..1093: this is of type `boolean`
+| note in file FileId(1) for 1085..1089: this is of type `string(6)`
 | error in file FileId(1) for 1090..1091: `string(6)` cannot be compared to `boolean`
 | info: operands must both be the same type

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_greater.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_greater.snap
@@ -1,5 +1,6 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "\n    % Numerics\n    var r : real\n    var i : int\n    var n : nat\n\n    % Other scalars\n    var b : boolean\n\n    % Sized charseqs\n    var c : char\n    var c_sz : char(6)\n    var s : string\n    var s_sz : string(6)\n\n    % should all produce boolean anyway\n    var _v_res : boolean\n\n    _v_res := r > b\n    _v_res := r > c\n    _v_res := r > c_sz\n    _v_res := r > s\n    _v_res := r > s_sz\n\n    _v_res := i > b\n    _v_res := i > c\n    _v_res := i > c_sz\n    _v_res := i > s\n    _v_res := i > s_sz\n\n    _v_res := n > b\n    _v_res := n > c\n    _v_res := n > c_sz\n    _v_res := n > s\n    _v_res := n > s_sz\n\n    _v_res := b > r\n    _v_res := b > i\n    _v_res := b > n\n    _v_res := b > c\n    _v_res := b > c_sz\n    _v_res := b > s\n    _v_res := b > s_sz\n\n    _v_res := c > r\n    _v_res := c > i\n    _v_res := c > n\n    _v_res := c > b\n\n    _v_res := c_sz > r\n    _v_res := c_sz > i\n    _v_res := c_sz > n\n    _v_res := c_sz > b\n\n    _v_res := s > r\n    _v_res := s > i\n    _v_res := s > n\n    _v_res := s > b\n\n    _v_res := s_sz > r\n    _v_res := s_sz > i\n    _v_res := s_sz > n\n    _v_res := s_sz > b\n    "
 
 ---
@@ -15,192 +16,192 @@ expression: "\n    % Numerics\n    var r : real\n    var i : int\n    var n : na
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 295..296: mismatched types for `>`
-| note in file FileId(1) for 293..294: this is of type `real`
 | note in file FileId(1) for 297..298: this is of type `boolean`
+| note in file FileId(1) for 293..294: this is of type `real`
 | error in file FileId(1) for 295..296: `real` cannot be compared to `boolean`
 | info: operands must both be the same type
 error in file FileId(1) at 315..316: mismatched types for `>`
-| note in file FileId(1) for 313..314: this is of type `real`
 | note in file FileId(1) for 317..318: this is of type `char`
+| note in file FileId(1) for 313..314: this is of type `real`
 | error in file FileId(1) for 315..316: `real` cannot be compared to `char`
 | info: operands must both be the same type
 error in file FileId(1) at 335..336: mismatched types for `>`
-| note in file FileId(1) for 333..334: this is of type `real`
 | note in file FileId(1) for 337..341: this is of type `char(6)`
+| note in file FileId(1) for 333..334: this is of type `real`
 | error in file FileId(1) for 335..336: `real` cannot be compared to `char(6)`
 | info: operands must both be the same type
 error in file FileId(1) at 358..359: mismatched types for `>`
-| note in file FileId(1) for 356..357: this is of type `real`
 | note in file FileId(1) for 360..361: this is of type `string`
+| note in file FileId(1) for 356..357: this is of type `real`
 | error in file FileId(1) for 358..359: `real` cannot be compared to `string`
 | info: operands must both be the same type
 error in file FileId(1) at 378..379: mismatched types for `>`
-| note in file FileId(1) for 376..377: this is of type `real`
 | note in file FileId(1) for 380..384: this is of type `string(6)`
+| note in file FileId(1) for 376..377: this is of type `real`
 | error in file FileId(1) for 378..379: `real` cannot be compared to `string(6)`
 | info: operands must both be the same type
 error in file FileId(1) at 402..403: mismatched types for `>`
-| note in file FileId(1) for 400..401: this is of type `int`
 | note in file FileId(1) for 404..405: this is of type `boolean`
+| note in file FileId(1) for 400..401: this is of type `int`
 | error in file FileId(1) for 402..403: `int` cannot be compared to `boolean`
 | info: operands must both be the same type
 error in file FileId(1) at 422..423: mismatched types for `>`
-| note in file FileId(1) for 420..421: this is of type `int`
 | note in file FileId(1) for 424..425: this is of type `char`
+| note in file FileId(1) for 420..421: this is of type `int`
 | error in file FileId(1) for 422..423: `int` cannot be compared to `char`
 | info: operands must both be the same type
 error in file FileId(1) at 442..443: mismatched types for `>`
-| note in file FileId(1) for 440..441: this is of type `int`
 | note in file FileId(1) for 444..448: this is of type `char(6)`
+| note in file FileId(1) for 440..441: this is of type `int`
 | error in file FileId(1) for 442..443: `int` cannot be compared to `char(6)`
 | info: operands must both be the same type
 error in file FileId(1) at 465..466: mismatched types for `>`
-| note in file FileId(1) for 463..464: this is of type `int`
 | note in file FileId(1) for 467..468: this is of type `string`
+| note in file FileId(1) for 463..464: this is of type `int`
 | error in file FileId(1) for 465..466: `int` cannot be compared to `string`
 | info: operands must both be the same type
 error in file FileId(1) at 485..486: mismatched types for `>`
-| note in file FileId(1) for 483..484: this is of type `int`
 | note in file FileId(1) for 487..491: this is of type `string(6)`
+| note in file FileId(1) for 483..484: this is of type `int`
 | error in file FileId(1) for 485..486: `int` cannot be compared to `string(6)`
 | info: operands must both be the same type
 error in file FileId(1) at 509..510: mismatched types for `>`
-| note in file FileId(1) for 507..508: this is of type `nat`
 | note in file FileId(1) for 511..512: this is of type `boolean`
+| note in file FileId(1) for 507..508: this is of type `nat`
 | error in file FileId(1) for 509..510: `nat` cannot be compared to `boolean`
 | info: operands must both be the same type
 error in file FileId(1) at 529..530: mismatched types for `>`
-| note in file FileId(1) for 527..528: this is of type `nat`
 | note in file FileId(1) for 531..532: this is of type `char`
+| note in file FileId(1) for 527..528: this is of type `nat`
 | error in file FileId(1) for 529..530: `nat` cannot be compared to `char`
 | info: operands must both be the same type
 error in file FileId(1) at 549..550: mismatched types for `>`
-| note in file FileId(1) for 547..548: this is of type `nat`
 | note in file FileId(1) for 551..555: this is of type `char(6)`
+| note in file FileId(1) for 547..548: this is of type `nat`
 | error in file FileId(1) for 549..550: `nat` cannot be compared to `char(6)`
 | info: operands must both be the same type
 error in file FileId(1) at 572..573: mismatched types for `>`
-| note in file FileId(1) for 570..571: this is of type `nat`
 | note in file FileId(1) for 574..575: this is of type `string`
+| note in file FileId(1) for 570..571: this is of type `nat`
 | error in file FileId(1) for 572..573: `nat` cannot be compared to `string`
 | info: operands must both be the same type
 error in file FileId(1) at 592..593: mismatched types for `>`
-| note in file FileId(1) for 590..591: this is of type `nat`
 | note in file FileId(1) for 594..598: this is of type `string(6)`
+| note in file FileId(1) for 590..591: this is of type `nat`
 | error in file FileId(1) for 592..593: `nat` cannot be compared to `string(6)`
 | info: operands must both be the same type
 error in file FileId(1) at 616..617: mismatched types for `>`
-| note in file FileId(1) for 614..615: this is of type `boolean`
 | note in file FileId(1) for 618..619: this is of type `real`
+| note in file FileId(1) for 614..615: this is of type `boolean`
 | error in file FileId(1) for 616..617: `boolean` cannot be compared to `real`
 | info: operands must both be the same type
 error in file FileId(1) at 636..637: mismatched types for `>`
-| note in file FileId(1) for 634..635: this is of type `boolean`
 | note in file FileId(1) for 638..639: this is of type `int`
+| note in file FileId(1) for 634..635: this is of type `boolean`
 | error in file FileId(1) for 636..637: `boolean` cannot be compared to `int`
 | info: operands must both be the same type
 error in file FileId(1) at 656..657: mismatched types for `>`
-| note in file FileId(1) for 654..655: this is of type `boolean`
 | note in file FileId(1) for 658..659: this is of type `nat`
+| note in file FileId(1) for 654..655: this is of type `boolean`
 | error in file FileId(1) for 656..657: `boolean` cannot be compared to `nat`
 | info: operands must both be the same type
 error in file FileId(1) at 676..677: mismatched types for `>`
-| note in file FileId(1) for 674..675: this is of type `boolean`
 | note in file FileId(1) for 678..679: this is of type `char`
+| note in file FileId(1) for 674..675: this is of type `boolean`
 | error in file FileId(1) for 676..677: `boolean` cannot be compared to `char`
 | info: operands must both be the same type
 error in file FileId(1) at 696..697: mismatched types for `>`
-| note in file FileId(1) for 694..695: this is of type `boolean`
 | note in file FileId(1) for 698..702: this is of type `char(6)`
+| note in file FileId(1) for 694..695: this is of type `boolean`
 | error in file FileId(1) for 696..697: `boolean` cannot be compared to `char(6)`
 | info: operands must both be the same type
 error in file FileId(1) at 719..720: mismatched types for `>`
-| note in file FileId(1) for 717..718: this is of type `boolean`
 | note in file FileId(1) for 721..722: this is of type `string`
+| note in file FileId(1) for 717..718: this is of type `boolean`
 | error in file FileId(1) for 719..720: `boolean` cannot be compared to `string`
 | info: operands must both be the same type
 error in file FileId(1) at 739..740: mismatched types for `>`
-| note in file FileId(1) for 737..738: this is of type `boolean`
 | note in file FileId(1) for 741..745: this is of type `string(6)`
+| note in file FileId(1) for 737..738: this is of type `boolean`
 | error in file FileId(1) for 739..740: `boolean` cannot be compared to `string(6)`
 | info: operands must both be the same type
 error in file FileId(1) at 763..764: mismatched types for `>`
-| note in file FileId(1) for 761..762: this is of type `char`
 | note in file FileId(1) for 765..766: this is of type `real`
+| note in file FileId(1) for 761..762: this is of type `char`
 | error in file FileId(1) for 763..764: `char` cannot be compared to `real`
 | info: operands must both be the same type
 error in file FileId(1) at 783..784: mismatched types for `>`
-| note in file FileId(1) for 781..782: this is of type `char`
 | note in file FileId(1) for 785..786: this is of type `int`
+| note in file FileId(1) for 781..782: this is of type `char`
 | error in file FileId(1) for 783..784: `char` cannot be compared to `int`
 | info: operands must both be the same type
 error in file FileId(1) at 803..804: mismatched types for `>`
-| note in file FileId(1) for 801..802: this is of type `char`
 | note in file FileId(1) for 805..806: this is of type `nat`
+| note in file FileId(1) for 801..802: this is of type `char`
 | error in file FileId(1) for 803..804: `char` cannot be compared to `nat`
 | info: operands must both be the same type
 error in file FileId(1) at 823..824: mismatched types for `>`
-| note in file FileId(1) for 821..822: this is of type `char`
 | note in file FileId(1) for 825..826: this is of type `boolean`
+| note in file FileId(1) for 821..822: this is of type `char`
 | error in file FileId(1) for 823..824: `char` cannot be compared to `boolean`
 | info: operands must both be the same type
 error in file FileId(1) at 847..848: mismatched types for `>`
-| note in file FileId(1) for 842..846: this is of type `char(6)`
 | note in file FileId(1) for 849..850: this is of type `real`
+| note in file FileId(1) for 842..846: this is of type `char(6)`
 | error in file FileId(1) for 847..848: `char(6)` cannot be compared to `real`
 | info: operands must both be the same type
 error in file FileId(1) at 870..871: mismatched types for `>`
-| note in file FileId(1) for 865..869: this is of type `char(6)`
 | note in file FileId(1) for 872..873: this is of type `int`
+| note in file FileId(1) for 865..869: this is of type `char(6)`
 | error in file FileId(1) for 870..871: `char(6)` cannot be compared to `int`
 | info: operands must both be the same type
 error in file FileId(1) at 893..894: mismatched types for `>`
-| note in file FileId(1) for 888..892: this is of type `char(6)`
 | note in file FileId(1) for 895..896: this is of type `nat`
+| note in file FileId(1) for 888..892: this is of type `char(6)`
 | error in file FileId(1) for 893..894: `char(6)` cannot be compared to `nat`
 | info: operands must both be the same type
 error in file FileId(1) at 916..917: mismatched types for `>`
-| note in file FileId(1) for 911..915: this is of type `char(6)`
 | note in file FileId(1) for 918..919: this is of type `boolean`
+| note in file FileId(1) for 911..915: this is of type `char(6)`
 | error in file FileId(1) for 916..917: `char(6)` cannot be compared to `boolean`
 | info: operands must both be the same type
 error in file FileId(1) at 937..938: mismatched types for `>`
-| note in file FileId(1) for 935..936: this is of type `string`
 | note in file FileId(1) for 939..940: this is of type `real`
+| note in file FileId(1) for 935..936: this is of type `string`
 | error in file FileId(1) for 937..938: `string` cannot be compared to `real`
 | info: operands must both be the same type
 error in file FileId(1) at 957..958: mismatched types for `>`
-| note in file FileId(1) for 955..956: this is of type `string`
 | note in file FileId(1) for 959..960: this is of type `int`
+| note in file FileId(1) for 955..956: this is of type `string`
 | error in file FileId(1) for 957..958: `string` cannot be compared to `int`
 | info: operands must both be the same type
 error in file FileId(1) at 977..978: mismatched types for `>`
-| note in file FileId(1) for 975..976: this is of type `string`
 | note in file FileId(1) for 979..980: this is of type `nat`
+| note in file FileId(1) for 975..976: this is of type `string`
 | error in file FileId(1) for 977..978: `string` cannot be compared to `nat`
 | info: operands must both be the same type
 error in file FileId(1) at 997..998: mismatched types for `>`
-| note in file FileId(1) for 995..996: this is of type `string`
 | note in file FileId(1) for 999..1000: this is of type `boolean`
+| note in file FileId(1) for 995..996: this is of type `string`
 | error in file FileId(1) for 997..998: `string` cannot be compared to `boolean`
 | info: operands must both be the same type
 error in file FileId(1) at 1021..1022: mismatched types for `>`
-| note in file FileId(1) for 1016..1020: this is of type `string(6)`
 | note in file FileId(1) for 1023..1024: this is of type `real`
+| note in file FileId(1) for 1016..1020: this is of type `string(6)`
 | error in file FileId(1) for 1021..1022: `string(6)` cannot be compared to `real`
 | info: operands must both be the same type
 error in file FileId(1) at 1044..1045: mismatched types for `>`
-| note in file FileId(1) for 1039..1043: this is of type `string(6)`
 | note in file FileId(1) for 1046..1047: this is of type `int`
+| note in file FileId(1) for 1039..1043: this is of type `string(6)`
 | error in file FileId(1) for 1044..1045: `string(6)` cannot be compared to `int`
 | info: operands must both be the same type
 error in file FileId(1) at 1067..1068: mismatched types for `>`
-| note in file FileId(1) for 1062..1066: this is of type `string(6)`
 | note in file FileId(1) for 1069..1070: this is of type `nat`
+| note in file FileId(1) for 1062..1066: this is of type `string(6)`
 | error in file FileId(1) for 1067..1068: `string(6)` cannot be compared to `nat`
 | info: operands must both be the same type
 error in file FileId(1) at 1090..1091: mismatched types for `>`
-| note in file FileId(1) for 1085..1089: this is of type `string(6)`
 | note in file FileId(1) for 1092..1093: this is of type `boolean`
+| note in file FileId(1) for 1085..1089: this is of type `string(6)`
 | error in file FileId(1) for 1090..1091: `string(6)` cannot be compared to `boolean`
 | info: operands must both be the same type

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_greater_eq.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_greater_eq.snap
@@ -1,5 +1,6 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "\n    % Numerics\n    var r : real\n    var i : int\n    var n : nat\n\n    % Other scalars\n    var b : boolean\n\n    % Sized charseqs\n    var c : char\n    var c_sz : char(6)\n    var s : string\n    var s_sz : string(6)\n\n    % should all produce boolean anyway\n    var _v_res : boolean\n\n    _v_res := r >= b\n    _v_res := r >= c\n    _v_res := r >= c_sz\n    _v_res := r >= s\n    _v_res := r >= s_sz\n\n    _v_res := i >= b\n    _v_res := i >= c\n    _v_res := i >= c_sz\n    _v_res := i >= s\n    _v_res := i >= s_sz\n\n    _v_res := n >= b\n    _v_res := n >= c\n    _v_res := n >= c_sz\n    _v_res := n >= s\n    _v_res := n >= s_sz\n\n    _v_res := b >= r\n    _v_res := b >= i\n    _v_res := b >= n\n    _v_res := b >= c\n    _v_res := b >= c_sz\n    _v_res := b >= s\n    _v_res := b >= s_sz\n\n    _v_res := c >= r\n    _v_res := c >= i\n    _v_res := c >= n\n    _v_res := c >= b\n\n    _v_res := c_sz >= r\n    _v_res := c_sz >= i\n    _v_res := c_sz >= n\n    _v_res := c_sz >= b\n\n    _v_res := s >= r\n    _v_res := s >= i\n    _v_res := s >= n\n    _v_res := s >= b\n\n    _v_res := s_sz >= r\n    _v_res := s_sz >= i\n    _v_res := s_sz >= n\n    _v_res := s_sz >= b\n    "
 
 ---
@@ -15,192 +16,192 @@ expression: "\n    % Numerics\n    var r : real\n    var i : int\n    var n : na
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 295..297: mismatched types for `>=`
-| note in file FileId(1) for 293..294: this is of type `real`
 | note in file FileId(1) for 298..299: this is of type `boolean`
+| note in file FileId(1) for 293..294: this is of type `real`
 | error in file FileId(1) for 295..297: `real` cannot be compared to `boolean`
 | info: operands must both be the same type
 error in file FileId(1) at 316..318: mismatched types for `>=`
-| note in file FileId(1) for 314..315: this is of type `real`
 | note in file FileId(1) for 319..320: this is of type `char`
+| note in file FileId(1) for 314..315: this is of type `real`
 | error in file FileId(1) for 316..318: `real` cannot be compared to `char`
 | info: operands must both be the same type
 error in file FileId(1) at 337..339: mismatched types for `>=`
-| note in file FileId(1) for 335..336: this is of type `real`
 | note in file FileId(1) for 340..344: this is of type `char(6)`
+| note in file FileId(1) for 335..336: this is of type `real`
 | error in file FileId(1) for 337..339: `real` cannot be compared to `char(6)`
 | info: operands must both be the same type
 error in file FileId(1) at 361..363: mismatched types for `>=`
-| note in file FileId(1) for 359..360: this is of type `real`
 | note in file FileId(1) for 364..365: this is of type `string`
+| note in file FileId(1) for 359..360: this is of type `real`
 | error in file FileId(1) for 361..363: `real` cannot be compared to `string`
 | info: operands must both be the same type
 error in file FileId(1) at 382..384: mismatched types for `>=`
-| note in file FileId(1) for 380..381: this is of type `real`
 | note in file FileId(1) for 385..389: this is of type `string(6)`
+| note in file FileId(1) for 380..381: this is of type `real`
 | error in file FileId(1) for 382..384: `real` cannot be compared to `string(6)`
 | info: operands must both be the same type
 error in file FileId(1) at 407..409: mismatched types for `>=`
-| note in file FileId(1) for 405..406: this is of type `int`
 | note in file FileId(1) for 410..411: this is of type `boolean`
+| note in file FileId(1) for 405..406: this is of type `int`
 | error in file FileId(1) for 407..409: `int` cannot be compared to `boolean`
 | info: operands must both be the same type
 error in file FileId(1) at 428..430: mismatched types for `>=`
-| note in file FileId(1) for 426..427: this is of type `int`
 | note in file FileId(1) for 431..432: this is of type `char`
+| note in file FileId(1) for 426..427: this is of type `int`
 | error in file FileId(1) for 428..430: `int` cannot be compared to `char`
 | info: operands must both be the same type
 error in file FileId(1) at 449..451: mismatched types for `>=`
-| note in file FileId(1) for 447..448: this is of type `int`
 | note in file FileId(1) for 452..456: this is of type `char(6)`
+| note in file FileId(1) for 447..448: this is of type `int`
 | error in file FileId(1) for 449..451: `int` cannot be compared to `char(6)`
 | info: operands must both be the same type
 error in file FileId(1) at 473..475: mismatched types for `>=`
-| note in file FileId(1) for 471..472: this is of type `int`
 | note in file FileId(1) for 476..477: this is of type `string`
+| note in file FileId(1) for 471..472: this is of type `int`
 | error in file FileId(1) for 473..475: `int` cannot be compared to `string`
 | info: operands must both be the same type
 error in file FileId(1) at 494..496: mismatched types for `>=`
-| note in file FileId(1) for 492..493: this is of type `int`
 | note in file FileId(1) for 497..501: this is of type `string(6)`
+| note in file FileId(1) for 492..493: this is of type `int`
 | error in file FileId(1) for 494..496: `int` cannot be compared to `string(6)`
 | info: operands must both be the same type
 error in file FileId(1) at 519..521: mismatched types for `>=`
-| note in file FileId(1) for 517..518: this is of type `nat`
 | note in file FileId(1) for 522..523: this is of type `boolean`
+| note in file FileId(1) for 517..518: this is of type `nat`
 | error in file FileId(1) for 519..521: `nat` cannot be compared to `boolean`
 | info: operands must both be the same type
 error in file FileId(1) at 540..542: mismatched types for `>=`
-| note in file FileId(1) for 538..539: this is of type `nat`
 | note in file FileId(1) for 543..544: this is of type `char`
+| note in file FileId(1) for 538..539: this is of type `nat`
 | error in file FileId(1) for 540..542: `nat` cannot be compared to `char`
 | info: operands must both be the same type
 error in file FileId(1) at 561..563: mismatched types for `>=`
-| note in file FileId(1) for 559..560: this is of type `nat`
 | note in file FileId(1) for 564..568: this is of type `char(6)`
+| note in file FileId(1) for 559..560: this is of type `nat`
 | error in file FileId(1) for 561..563: `nat` cannot be compared to `char(6)`
 | info: operands must both be the same type
 error in file FileId(1) at 585..587: mismatched types for `>=`
-| note in file FileId(1) for 583..584: this is of type `nat`
 | note in file FileId(1) for 588..589: this is of type `string`
+| note in file FileId(1) for 583..584: this is of type `nat`
 | error in file FileId(1) for 585..587: `nat` cannot be compared to `string`
 | info: operands must both be the same type
 error in file FileId(1) at 606..608: mismatched types for `>=`
-| note in file FileId(1) for 604..605: this is of type `nat`
 | note in file FileId(1) for 609..613: this is of type `string(6)`
+| note in file FileId(1) for 604..605: this is of type `nat`
 | error in file FileId(1) for 606..608: `nat` cannot be compared to `string(6)`
 | info: operands must both be the same type
 error in file FileId(1) at 631..633: mismatched types for `>=`
-| note in file FileId(1) for 629..630: this is of type `boolean`
 | note in file FileId(1) for 634..635: this is of type `real`
+| note in file FileId(1) for 629..630: this is of type `boolean`
 | error in file FileId(1) for 631..633: `boolean` cannot be compared to `real`
 | info: operands must both be the same type
 error in file FileId(1) at 652..654: mismatched types for `>=`
-| note in file FileId(1) for 650..651: this is of type `boolean`
 | note in file FileId(1) for 655..656: this is of type `int`
+| note in file FileId(1) for 650..651: this is of type `boolean`
 | error in file FileId(1) for 652..654: `boolean` cannot be compared to `int`
 | info: operands must both be the same type
 error in file FileId(1) at 673..675: mismatched types for `>=`
-| note in file FileId(1) for 671..672: this is of type `boolean`
 | note in file FileId(1) for 676..677: this is of type `nat`
+| note in file FileId(1) for 671..672: this is of type `boolean`
 | error in file FileId(1) for 673..675: `boolean` cannot be compared to `nat`
 | info: operands must both be the same type
 error in file FileId(1) at 694..696: mismatched types for `>=`
-| note in file FileId(1) for 692..693: this is of type `boolean`
 | note in file FileId(1) for 697..698: this is of type `char`
+| note in file FileId(1) for 692..693: this is of type `boolean`
 | error in file FileId(1) for 694..696: `boolean` cannot be compared to `char`
 | info: operands must both be the same type
 error in file FileId(1) at 715..717: mismatched types for `>=`
-| note in file FileId(1) for 713..714: this is of type `boolean`
 | note in file FileId(1) for 718..722: this is of type `char(6)`
+| note in file FileId(1) for 713..714: this is of type `boolean`
 | error in file FileId(1) for 715..717: `boolean` cannot be compared to `char(6)`
 | info: operands must both be the same type
 error in file FileId(1) at 739..741: mismatched types for `>=`
-| note in file FileId(1) for 737..738: this is of type `boolean`
 | note in file FileId(1) for 742..743: this is of type `string`
+| note in file FileId(1) for 737..738: this is of type `boolean`
 | error in file FileId(1) for 739..741: `boolean` cannot be compared to `string`
 | info: operands must both be the same type
 error in file FileId(1) at 760..762: mismatched types for `>=`
-| note in file FileId(1) for 758..759: this is of type `boolean`
 | note in file FileId(1) for 763..767: this is of type `string(6)`
+| note in file FileId(1) for 758..759: this is of type `boolean`
 | error in file FileId(1) for 760..762: `boolean` cannot be compared to `string(6)`
 | info: operands must both be the same type
 error in file FileId(1) at 785..787: mismatched types for `>=`
-| note in file FileId(1) for 783..784: this is of type `char`
 | note in file FileId(1) for 788..789: this is of type `real`
+| note in file FileId(1) for 783..784: this is of type `char`
 | error in file FileId(1) for 785..787: `char` cannot be compared to `real`
 | info: operands must both be the same type
 error in file FileId(1) at 806..808: mismatched types for `>=`
-| note in file FileId(1) for 804..805: this is of type `char`
 | note in file FileId(1) for 809..810: this is of type `int`
+| note in file FileId(1) for 804..805: this is of type `char`
 | error in file FileId(1) for 806..808: `char` cannot be compared to `int`
 | info: operands must both be the same type
 error in file FileId(1) at 827..829: mismatched types for `>=`
-| note in file FileId(1) for 825..826: this is of type `char`
 | note in file FileId(1) for 830..831: this is of type `nat`
+| note in file FileId(1) for 825..826: this is of type `char`
 | error in file FileId(1) for 827..829: `char` cannot be compared to `nat`
 | info: operands must both be the same type
 error in file FileId(1) at 848..850: mismatched types for `>=`
-| note in file FileId(1) for 846..847: this is of type `char`
 | note in file FileId(1) for 851..852: this is of type `boolean`
+| note in file FileId(1) for 846..847: this is of type `char`
 | error in file FileId(1) for 848..850: `char` cannot be compared to `boolean`
 | info: operands must both be the same type
 error in file FileId(1) at 873..875: mismatched types for `>=`
-| note in file FileId(1) for 868..872: this is of type `char(6)`
 | note in file FileId(1) for 876..877: this is of type `real`
+| note in file FileId(1) for 868..872: this is of type `char(6)`
 | error in file FileId(1) for 873..875: `char(6)` cannot be compared to `real`
 | info: operands must both be the same type
 error in file FileId(1) at 897..899: mismatched types for `>=`
-| note in file FileId(1) for 892..896: this is of type `char(6)`
 | note in file FileId(1) for 900..901: this is of type `int`
+| note in file FileId(1) for 892..896: this is of type `char(6)`
 | error in file FileId(1) for 897..899: `char(6)` cannot be compared to `int`
 | info: operands must both be the same type
 error in file FileId(1) at 921..923: mismatched types for `>=`
-| note in file FileId(1) for 916..920: this is of type `char(6)`
 | note in file FileId(1) for 924..925: this is of type `nat`
+| note in file FileId(1) for 916..920: this is of type `char(6)`
 | error in file FileId(1) for 921..923: `char(6)` cannot be compared to `nat`
 | info: operands must both be the same type
 error in file FileId(1) at 945..947: mismatched types for `>=`
-| note in file FileId(1) for 940..944: this is of type `char(6)`
 | note in file FileId(1) for 948..949: this is of type `boolean`
+| note in file FileId(1) for 940..944: this is of type `char(6)`
 | error in file FileId(1) for 945..947: `char(6)` cannot be compared to `boolean`
 | info: operands must both be the same type
 error in file FileId(1) at 967..969: mismatched types for `>=`
-| note in file FileId(1) for 965..966: this is of type `string`
 | note in file FileId(1) for 970..971: this is of type `real`
+| note in file FileId(1) for 965..966: this is of type `string`
 | error in file FileId(1) for 967..969: `string` cannot be compared to `real`
 | info: operands must both be the same type
 error in file FileId(1) at 988..990: mismatched types for `>=`
-| note in file FileId(1) for 986..987: this is of type `string`
 | note in file FileId(1) for 991..992: this is of type `int`
+| note in file FileId(1) for 986..987: this is of type `string`
 | error in file FileId(1) for 988..990: `string` cannot be compared to `int`
 | info: operands must both be the same type
 error in file FileId(1) at 1009..1011: mismatched types for `>=`
-| note in file FileId(1) for 1007..1008: this is of type `string`
 | note in file FileId(1) for 1012..1013: this is of type `nat`
+| note in file FileId(1) for 1007..1008: this is of type `string`
 | error in file FileId(1) for 1009..1011: `string` cannot be compared to `nat`
 | info: operands must both be the same type
 error in file FileId(1) at 1030..1032: mismatched types for `>=`
-| note in file FileId(1) for 1028..1029: this is of type `string`
 | note in file FileId(1) for 1033..1034: this is of type `boolean`
+| note in file FileId(1) for 1028..1029: this is of type `string`
 | error in file FileId(1) for 1030..1032: `string` cannot be compared to `boolean`
 | info: operands must both be the same type
 error in file FileId(1) at 1055..1057: mismatched types for `>=`
-| note in file FileId(1) for 1050..1054: this is of type `string(6)`
 | note in file FileId(1) for 1058..1059: this is of type `real`
+| note in file FileId(1) for 1050..1054: this is of type `string(6)`
 | error in file FileId(1) for 1055..1057: `string(6)` cannot be compared to `real`
 | info: operands must both be the same type
 error in file FileId(1) at 1079..1081: mismatched types for `>=`
-| note in file FileId(1) for 1074..1078: this is of type `string(6)`
 | note in file FileId(1) for 1082..1083: this is of type `int`
+| note in file FileId(1) for 1074..1078: this is of type `string(6)`
 | error in file FileId(1) for 1079..1081: `string(6)` cannot be compared to `int`
 | info: operands must both be the same type
 error in file FileId(1) at 1103..1105: mismatched types for `>=`
-| note in file FileId(1) for 1098..1102: this is of type `string(6)`
 | note in file FileId(1) for 1106..1107: this is of type `nat`
+| note in file FileId(1) for 1098..1102: this is of type `string(6)`
 | error in file FileId(1) for 1103..1105: `string(6)` cannot be compared to `nat`
 | info: operands must both be the same type
 error in file FileId(1) at 1127..1129: mismatched types for `>=`
-| note in file FileId(1) for 1122..1126: this is of type `string(6)`
 | note in file FileId(1) for 1130..1131: this is of type `boolean`
+| note in file FileId(1) for 1122..1126: this is of type `string(6)`
 | error in file FileId(1) for 1127..1129: `string(6)` cannot be compared to `boolean`
 | info: operands must both be the same type

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_less.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_less.snap
@@ -1,5 +1,6 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "\n    % Numerics\n    var r : real\n    var i : int\n    var n : nat\n\n    % Other scalars\n    var b : boolean\n\n    % Sized charseqs\n    var c : char\n    var c_sz : char(6)\n    var s : string\n    var s_sz : string(6)\n\n    % should all produce boolean anyway\n    var _v_res : boolean\n\n    _v_res := r < b\n    _v_res := r < c\n    _v_res := r < c_sz\n    _v_res := r < s\n    _v_res := r < s_sz\n\n    _v_res := i < b\n    _v_res := i < c\n    _v_res := i < c_sz\n    _v_res := i < s\n    _v_res := i < s_sz\n\n    _v_res := n < b\n    _v_res := n < c\n    _v_res := n < c_sz\n    _v_res := n < s\n    _v_res := n < s_sz\n\n    _v_res := b < r\n    _v_res := b < i\n    _v_res := b < n\n    _v_res := b < c\n    _v_res := b < c_sz\n    _v_res := b < s\n    _v_res := b < s_sz\n\n    _v_res := c < r\n    _v_res := c < i\n    _v_res := c < n\n    _v_res := c < b\n\n    _v_res := c_sz < r\n    _v_res := c_sz < i\n    _v_res := c_sz < n\n    _v_res := c_sz < b\n\n    _v_res := s < r\n    _v_res := s < i\n    _v_res := s < n\n    _v_res := s < b\n\n    _v_res := s_sz < r\n    _v_res := s_sz < i\n    _v_res := s_sz < n\n    _v_res := s_sz < b\n    "
 
 ---
@@ -15,192 +16,192 @@ expression: "\n    % Numerics\n    var r : real\n    var i : int\n    var n : na
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 295..296: mismatched types for `<`
-| note in file FileId(1) for 293..294: this is of type `real`
 | note in file FileId(1) for 297..298: this is of type `boolean`
+| note in file FileId(1) for 293..294: this is of type `real`
 | error in file FileId(1) for 295..296: `real` cannot be compared to `boolean`
 | info: operands must both be the same type
 error in file FileId(1) at 315..316: mismatched types for `<`
-| note in file FileId(1) for 313..314: this is of type `real`
 | note in file FileId(1) for 317..318: this is of type `char`
+| note in file FileId(1) for 313..314: this is of type `real`
 | error in file FileId(1) for 315..316: `real` cannot be compared to `char`
 | info: operands must both be the same type
 error in file FileId(1) at 335..336: mismatched types for `<`
-| note in file FileId(1) for 333..334: this is of type `real`
 | note in file FileId(1) for 337..341: this is of type `char(6)`
+| note in file FileId(1) for 333..334: this is of type `real`
 | error in file FileId(1) for 335..336: `real` cannot be compared to `char(6)`
 | info: operands must both be the same type
 error in file FileId(1) at 358..359: mismatched types for `<`
-| note in file FileId(1) for 356..357: this is of type `real`
 | note in file FileId(1) for 360..361: this is of type `string`
+| note in file FileId(1) for 356..357: this is of type `real`
 | error in file FileId(1) for 358..359: `real` cannot be compared to `string`
 | info: operands must both be the same type
 error in file FileId(1) at 378..379: mismatched types for `<`
-| note in file FileId(1) for 376..377: this is of type `real`
 | note in file FileId(1) for 380..384: this is of type `string(6)`
+| note in file FileId(1) for 376..377: this is of type `real`
 | error in file FileId(1) for 378..379: `real` cannot be compared to `string(6)`
 | info: operands must both be the same type
 error in file FileId(1) at 402..403: mismatched types for `<`
-| note in file FileId(1) for 400..401: this is of type `int`
 | note in file FileId(1) for 404..405: this is of type `boolean`
+| note in file FileId(1) for 400..401: this is of type `int`
 | error in file FileId(1) for 402..403: `int` cannot be compared to `boolean`
 | info: operands must both be the same type
 error in file FileId(1) at 422..423: mismatched types for `<`
-| note in file FileId(1) for 420..421: this is of type `int`
 | note in file FileId(1) for 424..425: this is of type `char`
+| note in file FileId(1) for 420..421: this is of type `int`
 | error in file FileId(1) for 422..423: `int` cannot be compared to `char`
 | info: operands must both be the same type
 error in file FileId(1) at 442..443: mismatched types for `<`
-| note in file FileId(1) for 440..441: this is of type `int`
 | note in file FileId(1) for 444..448: this is of type `char(6)`
+| note in file FileId(1) for 440..441: this is of type `int`
 | error in file FileId(1) for 442..443: `int` cannot be compared to `char(6)`
 | info: operands must both be the same type
 error in file FileId(1) at 465..466: mismatched types for `<`
-| note in file FileId(1) for 463..464: this is of type `int`
 | note in file FileId(1) for 467..468: this is of type `string`
+| note in file FileId(1) for 463..464: this is of type `int`
 | error in file FileId(1) for 465..466: `int` cannot be compared to `string`
 | info: operands must both be the same type
 error in file FileId(1) at 485..486: mismatched types for `<`
-| note in file FileId(1) for 483..484: this is of type `int`
 | note in file FileId(1) for 487..491: this is of type `string(6)`
+| note in file FileId(1) for 483..484: this is of type `int`
 | error in file FileId(1) for 485..486: `int` cannot be compared to `string(6)`
 | info: operands must both be the same type
 error in file FileId(1) at 509..510: mismatched types for `<`
-| note in file FileId(1) for 507..508: this is of type `nat`
 | note in file FileId(1) for 511..512: this is of type `boolean`
+| note in file FileId(1) for 507..508: this is of type `nat`
 | error in file FileId(1) for 509..510: `nat` cannot be compared to `boolean`
 | info: operands must both be the same type
 error in file FileId(1) at 529..530: mismatched types for `<`
-| note in file FileId(1) for 527..528: this is of type `nat`
 | note in file FileId(1) for 531..532: this is of type `char`
+| note in file FileId(1) for 527..528: this is of type `nat`
 | error in file FileId(1) for 529..530: `nat` cannot be compared to `char`
 | info: operands must both be the same type
 error in file FileId(1) at 549..550: mismatched types for `<`
-| note in file FileId(1) for 547..548: this is of type `nat`
 | note in file FileId(1) for 551..555: this is of type `char(6)`
+| note in file FileId(1) for 547..548: this is of type `nat`
 | error in file FileId(1) for 549..550: `nat` cannot be compared to `char(6)`
 | info: operands must both be the same type
 error in file FileId(1) at 572..573: mismatched types for `<`
-| note in file FileId(1) for 570..571: this is of type `nat`
 | note in file FileId(1) for 574..575: this is of type `string`
+| note in file FileId(1) for 570..571: this is of type `nat`
 | error in file FileId(1) for 572..573: `nat` cannot be compared to `string`
 | info: operands must both be the same type
 error in file FileId(1) at 592..593: mismatched types for `<`
-| note in file FileId(1) for 590..591: this is of type `nat`
 | note in file FileId(1) for 594..598: this is of type `string(6)`
+| note in file FileId(1) for 590..591: this is of type `nat`
 | error in file FileId(1) for 592..593: `nat` cannot be compared to `string(6)`
 | info: operands must both be the same type
 error in file FileId(1) at 616..617: mismatched types for `<`
-| note in file FileId(1) for 614..615: this is of type `boolean`
 | note in file FileId(1) for 618..619: this is of type `real`
+| note in file FileId(1) for 614..615: this is of type `boolean`
 | error in file FileId(1) for 616..617: `boolean` cannot be compared to `real`
 | info: operands must both be the same type
 error in file FileId(1) at 636..637: mismatched types for `<`
-| note in file FileId(1) for 634..635: this is of type `boolean`
 | note in file FileId(1) for 638..639: this is of type `int`
+| note in file FileId(1) for 634..635: this is of type `boolean`
 | error in file FileId(1) for 636..637: `boolean` cannot be compared to `int`
 | info: operands must both be the same type
 error in file FileId(1) at 656..657: mismatched types for `<`
-| note in file FileId(1) for 654..655: this is of type `boolean`
 | note in file FileId(1) for 658..659: this is of type `nat`
+| note in file FileId(1) for 654..655: this is of type `boolean`
 | error in file FileId(1) for 656..657: `boolean` cannot be compared to `nat`
 | info: operands must both be the same type
 error in file FileId(1) at 676..677: mismatched types for `<`
-| note in file FileId(1) for 674..675: this is of type `boolean`
 | note in file FileId(1) for 678..679: this is of type `char`
+| note in file FileId(1) for 674..675: this is of type `boolean`
 | error in file FileId(1) for 676..677: `boolean` cannot be compared to `char`
 | info: operands must both be the same type
 error in file FileId(1) at 696..697: mismatched types for `<`
-| note in file FileId(1) for 694..695: this is of type `boolean`
 | note in file FileId(1) for 698..702: this is of type `char(6)`
+| note in file FileId(1) for 694..695: this is of type `boolean`
 | error in file FileId(1) for 696..697: `boolean` cannot be compared to `char(6)`
 | info: operands must both be the same type
 error in file FileId(1) at 719..720: mismatched types for `<`
-| note in file FileId(1) for 717..718: this is of type `boolean`
 | note in file FileId(1) for 721..722: this is of type `string`
+| note in file FileId(1) for 717..718: this is of type `boolean`
 | error in file FileId(1) for 719..720: `boolean` cannot be compared to `string`
 | info: operands must both be the same type
 error in file FileId(1) at 739..740: mismatched types for `<`
-| note in file FileId(1) for 737..738: this is of type `boolean`
 | note in file FileId(1) for 741..745: this is of type `string(6)`
+| note in file FileId(1) for 737..738: this is of type `boolean`
 | error in file FileId(1) for 739..740: `boolean` cannot be compared to `string(6)`
 | info: operands must both be the same type
 error in file FileId(1) at 763..764: mismatched types for `<`
-| note in file FileId(1) for 761..762: this is of type `char`
 | note in file FileId(1) for 765..766: this is of type `real`
+| note in file FileId(1) for 761..762: this is of type `char`
 | error in file FileId(1) for 763..764: `char` cannot be compared to `real`
 | info: operands must both be the same type
 error in file FileId(1) at 783..784: mismatched types for `<`
-| note in file FileId(1) for 781..782: this is of type `char`
 | note in file FileId(1) for 785..786: this is of type `int`
+| note in file FileId(1) for 781..782: this is of type `char`
 | error in file FileId(1) for 783..784: `char` cannot be compared to `int`
 | info: operands must both be the same type
 error in file FileId(1) at 803..804: mismatched types for `<`
-| note in file FileId(1) for 801..802: this is of type `char`
 | note in file FileId(1) for 805..806: this is of type `nat`
+| note in file FileId(1) for 801..802: this is of type `char`
 | error in file FileId(1) for 803..804: `char` cannot be compared to `nat`
 | info: operands must both be the same type
 error in file FileId(1) at 823..824: mismatched types for `<`
-| note in file FileId(1) for 821..822: this is of type `char`
 | note in file FileId(1) for 825..826: this is of type `boolean`
+| note in file FileId(1) for 821..822: this is of type `char`
 | error in file FileId(1) for 823..824: `char` cannot be compared to `boolean`
 | info: operands must both be the same type
 error in file FileId(1) at 847..848: mismatched types for `<`
-| note in file FileId(1) for 842..846: this is of type `char(6)`
 | note in file FileId(1) for 849..850: this is of type `real`
+| note in file FileId(1) for 842..846: this is of type `char(6)`
 | error in file FileId(1) for 847..848: `char(6)` cannot be compared to `real`
 | info: operands must both be the same type
 error in file FileId(1) at 870..871: mismatched types for `<`
-| note in file FileId(1) for 865..869: this is of type `char(6)`
 | note in file FileId(1) for 872..873: this is of type `int`
+| note in file FileId(1) for 865..869: this is of type `char(6)`
 | error in file FileId(1) for 870..871: `char(6)` cannot be compared to `int`
 | info: operands must both be the same type
 error in file FileId(1) at 893..894: mismatched types for `<`
-| note in file FileId(1) for 888..892: this is of type `char(6)`
 | note in file FileId(1) for 895..896: this is of type `nat`
+| note in file FileId(1) for 888..892: this is of type `char(6)`
 | error in file FileId(1) for 893..894: `char(6)` cannot be compared to `nat`
 | info: operands must both be the same type
 error in file FileId(1) at 916..917: mismatched types for `<`
-| note in file FileId(1) for 911..915: this is of type `char(6)`
 | note in file FileId(1) for 918..919: this is of type `boolean`
+| note in file FileId(1) for 911..915: this is of type `char(6)`
 | error in file FileId(1) for 916..917: `char(6)` cannot be compared to `boolean`
 | info: operands must both be the same type
 error in file FileId(1) at 937..938: mismatched types for `<`
-| note in file FileId(1) for 935..936: this is of type `string`
 | note in file FileId(1) for 939..940: this is of type `real`
+| note in file FileId(1) for 935..936: this is of type `string`
 | error in file FileId(1) for 937..938: `string` cannot be compared to `real`
 | info: operands must both be the same type
 error in file FileId(1) at 957..958: mismatched types for `<`
-| note in file FileId(1) for 955..956: this is of type `string`
 | note in file FileId(1) for 959..960: this is of type `int`
+| note in file FileId(1) for 955..956: this is of type `string`
 | error in file FileId(1) for 957..958: `string` cannot be compared to `int`
 | info: operands must both be the same type
 error in file FileId(1) at 977..978: mismatched types for `<`
-| note in file FileId(1) for 975..976: this is of type `string`
 | note in file FileId(1) for 979..980: this is of type `nat`
+| note in file FileId(1) for 975..976: this is of type `string`
 | error in file FileId(1) for 977..978: `string` cannot be compared to `nat`
 | info: operands must both be the same type
 error in file FileId(1) at 997..998: mismatched types for `<`
-| note in file FileId(1) for 995..996: this is of type `string`
 | note in file FileId(1) for 999..1000: this is of type `boolean`
+| note in file FileId(1) for 995..996: this is of type `string`
 | error in file FileId(1) for 997..998: `string` cannot be compared to `boolean`
 | info: operands must both be the same type
 error in file FileId(1) at 1021..1022: mismatched types for `<`
-| note in file FileId(1) for 1016..1020: this is of type `string(6)`
 | note in file FileId(1) for 1023..1024: this is of type `real`
+| note in file FileId(1) for 1016..1020: this is of type `string(6)`
 | error in file FileId(1) for 1021..1022: `string(6)` cannot be compared to `real`
 | info: operands must both be the same type
 error in file FileId(1) at 1044..1045: mismatched types for `<`
-| note in file FileId(1) for 1039..1043: this is of type `string(6)`
 | note in file FileId(1) for 1046..1047: this is of type `int`
+| note in file FileId(1) for 1039..1043: this is of type `string(6)`
 | error in file FileId(1) for 1044..1045: `string(6)` cannot be compared to `int`
 | info: operands must both be the same type
 error in file FileId(1) at 1067..1068: mismatched types for `<`
-| note in file FileId(1) for 1062..1066: this is of type `string(6)`
 | note in file FileId(1) for 1069..1070: this is of type `nat`
+| note in file FileId(1) for 1062..1066: this is of type `string(6)`
 | error in file FileId(1) for 1067..1068: `string(6)` cannot be compared to `nat`
 | info: operands must both be the same type
 error in file FileId(1) at 1090..1091: mismatched types for `<`
-| note in file FileId(1) for 1085..1089: this is of type `string(6)`
 | note in file FileId(1) for 1092..1093: this is of type `boolean`
+| note in file FileId(1) for 1085..1089: this is of type `string(6)`
 | error in file FileId(1) for 1090..1091: `string(6)` cannot be compared to `boolean`
 | info: operands must both be the same type

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_less_eq.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_less_eq.snap
@@ -1,5 +1,6 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "\n    % Numerics\n    var r : real\n    var i : int\n    var n : nat\n\n    % Other scalars\n    var b : boolean\n\n    % Sized charseqs\n    var c : char\n    var c_sz : char(6)\n    var s : string\n    var s_sz : string(6)\n\n    % should all produce boolean anyway\n    var _v_res : boolean\n\n    _v_res := r <= b\n    _v_res := r <= c\n    _v_res := r <= c_sz\n    _v_res := r <= s\n    _v_res := r <= s_sz\n\n    _v_res := i <= b\n    _v_res := i <= c\n    _v_res := i <= c_sz\n    _v_res := i <= s\n    _v_res := i <= s_sz\n\n    _v_res := n <= b\n    _v_res := n <= c\n    _v_res := n <= c_sz\n    _v_res := n <= s\n    _v_res := n <= s_sz\n\n    _v_res := b <= r\n    _v_res := b <= i\n    _v_res := b <= n\n    _v_res := b <= c\n    _v_res := b <= c_sz\n    _v_res := b <= s\n    _v_res := b <= s_sz\n\n    _v_res := c <= r\n    _v_res := c <= i\n    _v_res := c <= n\n    _v_res := c <= b\n\n    _v_res := c_sz <= r\n    _v_res := c_sz <= i\n    _v_res := c_sz <= n\n    _v_res := c_sz <= b\n\n    _v_res := s <= r\n    _v_res := s <= i\n    _v_res := s <= n\n    _v_res := s <= b\n\n    _v_res := s_sz <= r\n    _v_res := s_sz <= i\n    _v_res := s_sz <= n\n    _v_res := s_sz <= b\n    "
 
 ---
@@ -15,192 +16,192 @@ expression: "\n    % Numerics\n    var r : real\n    var i : int\n    var n : na
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 295..297: mismatched types for `<=`
-| note in file FileId(1) for 293..294: this is of type `real`
 | note in file FileId(1) for 298..299: this is of type `boolean`
+| note in file FileId(1) for 293..294: this is of type `real`
 | error in file FileId(1) for 295..297: `real` cannot be compared to `boolean`
 | info: operands must both be the same type
 error in file FileId(1) at 316..318: mismatched types for `<=`
-| note in file FileId(1) for 314..315: this is of type `real`
 | note in file FileId(1) for 319..320: this is of type `char`
+| note in file FileId(1) for 314..315: this is of type `real`
 | error in file FileId(1) for 316..318: `real` cannot be compared to `char`
 | info: operands must both be the same type
 error in file FileId(1) at 337..339: mismatched types for `<=`
-| note in file FileId(1) for 335..336: this is of type `real`
 | note in file FileId(1) for 340..344: this is of type `char(6)`
+| note in file FileId(1) for 335..336: this is of type `real`
 | error in file FileId(1) for 337..339: `real` cannot be compared to `char(6)`
 | info: operands must both be the same type
 error in file FileId(1) at 361..363: mismatched types for `<=`
-| note in file FileId(1) for 359..360: this is of type `real`
 | note in file FileId(1) for 364..365: this is of type `string`
+| note in file FileId(1) for 359..360: this is of type `real`
 | error in file FileId(1) for 361..363: `real` cannot be compared to `string`
 | info: operands must both be the same type
 error in file FileId(1) at 382..384: mismatched types for `<=`
-| note in file FileId(1) for 380..381: this is of type `real`
 | note in file FileId(1) for 385..389: this is of type `string(6)`
+| note in file FileId(1) for 380..381: this is of type `real`
 | error in file FileId(1) for 382..384: `real` cannot be compared to `string(6)`
 | info: operands must both be the same type
 error in file FileId(1) at 407..409: mismatched types for `<=`
-| note in file FileId(1) for 405..406: this is of type `int`
 | note in file FileId(1) for 410..411: this is of type `boolean`
+| note in file FileId(1) for 405..406: this is of type `int`
 | error in file FileId(1) for 407..409: `int` cannot be compared to `boolean`
 | info: operands must both be the same type
 error in file FileId(1) at 428..430: mismatched types for `<=`
-| note in file FileId(1) for 426..427: this is of type `int`
 | note in file FileId(1) for 431..432: this is of type `char`
+| note in file FileId(1) for 426..427: this is of type `int`
 | error in file FileId(1) for 428..430: `int` cannot be compared to `char`
 | info: operands must both be the same type
 error in file FileId(1) at 449..451: mismatched types for `<=`
-| note in file FileId(1) for 447..448: this is of type `int`
 | note in file FileId(1) for 452..456: this is of type `char(6)`
+| note in file FileId(1) for 447..448: this is of type `int`
 | error in file FileId(1) for 449..451: `int` cannot be compared to `char(6)`
 | info: operands must both be the same type
 error in file FileId(1) at 473..475: mismatched types for `<=`
-| note in file FileId(1) for 471..472: this is of type `int`
 | note in file FileId(1) for 476..477: this is of type `string`
+| note in file FileId(1) for 471..472: this is of type `int`
 | error in file FileId(1) for 473..475: `int` cannot be compared to `string`
 | info: operands must both be the same type
 error in file FileId(1) at 494..496: mismatched types for `<=`
-| note in file FileId(1) for 492..493: this is of type `int`
 | note in file FileId(1) for 497..501: this is of type `string(6)`
+| note in file FileId(1) for 492..493: this is of type `int`
 | error in file FileId(1) for 494..496: `int` cannot be compared to `string(6)`
 | info: operands must both be the same type
 error in file FileId(1) at 519..521: mismatched types for `<=`
-| note in file FileId(1) for 517..518: this is of type `nat`
 | note in file FileId(1) for 522..523: this is of type `boolean`
+| note in file FileId(1) for 517..518: this is of type `nat`
 | error in file FileId(1) for 519..521: `nat` cannot be compared to `boolean`
 | info: operands must both be the same type
 error in file FileId(1) at 540..542: mismatched types for `<=`
-| note in file FileId(1) for 538..539: this is of type `nat`
 | note in file FileId(1) for 543..544: this is of type `char`
+| note in file FileId(1) for 538..539: this is of type `nat`
 | error in file FileId(1) for 540..542: `nat` cannot be compared to `char`
 | info: operands must both be the same type
 error in file FileId(1) at 561..563: mismatched types for `<=`
-| note in file FileId(1) for 559..560: this is of type `nat`
 | note in file FileId(1) for 564..568: this is of type `char(6)`
+| note in file FileId(1) for 559..560: this is of type `nat`
 | error in file FileId(1) for 561..563: `nat` cannot be compared to `char(6)`
 | info: operands must both be the same type
 error in file FileId(1) at 585..587: mismatched types for `<=`
-| note in file FileId(1) for 583..584: this is of type `nat`
 | note in file FileId(1) for 588..589: this is of type `string`
+| note in file FileId(1) for 583..584: this is of type `nat`
 | error in file FileId(1) for 585..587: `nat` cannot be compared to `string`
 | info: operands must both be the same type
 error in file FileId(1) at 606..608: mismatched types for `<=`
-| note in file FileId(1) for 604..605: this is of type `nat`
 | note in file FileId(1) for 609..613: this is of type `string(6)`
+| note in file FileId(1) for 604..605: this is of type `nat`
 | error in file FileId(1) for 606..608: `nat` cannot be compared to `string(6)`
 | info: operands must both be the same type
 error in file FileId(1) at 631..633: mismatched types for `<=`
-| note in file FileId(1) for 629..630: this is of type `boolean`
 | note in file FileId(1) for 634..635: this is of type `real`
+| note in file FileId(1) for 629..630: this is of type `boolean`
 | error in file FileId(1) for 631..633: `boolean` cannot be compared to `real`
 | info: operands must both be the same type
 error in file FileId(1) at 652..654: mismatched types for `<=`
-| note in file FileId(1) for 650..651: this is of type `boolean`
 | note in file FileId(1) for 655..656: this is of type `int`
+| note in file FileId(1) for 650..651: this is of type `boolean`
 | error in file FileId(1) for 652..654: `boolean` cannot be compared to `int`
 | info: operands must both be the same type
 error in file FileId(1) at 673..675: mismatched types for `<=`
-| note in file FileId(1) for 671..672: this is of type `boolean`
 | note in file FileId(1) for 676..677: this is of type `nat`
+| note in file FileId(1) for 671..672: this is of type `boolean`
 | error in file FileId(1) for 673..675: `boolean` cannot be compared to `nat`
 | info: operands must both be the same type
 error in file FileId(1) at 694..696: mismatched types for `<=`
-| note in file FileId(1) for 692..693: this is of type `boolean`
 | note in file FileId(1) for 697..698: this is of type `char`
+| note in file FileId(1) for 692..693: this is of type `boolean`
 | error in file FileId(1) for 694..696: `boolean` cannot be compared to `char`
 | info: operands must both be the same type
 error in file FileId(1) at 715..717: mismatched types for `<=`
-| note in file FileId(1) for 713..714: this is of type `boolean`
 | note in file FileId(1) for 718..722: this is of type `char(6)`
+| note in file FileId(1) for 713..714: this is of type `boolean`
 | error in file FileId(1) for 715..717: `boolean` cannot be compared to `char(6)`
 | info: operands must both be the same type
 error in file FileId(1) at 739..741: mismatched types for `<=`
-| note in file FileId(1) for 737..738: this is of type `boolean`
 | note in file FileId(1) for 742..743: this is of type `string`
+| note in file FileId(1) for 737..738: this is of type `boolean`
 | error in file FileId(1) for 739..741: `boolean` cannot be compared to `string`
 | info: operands must both be the same type
 error in file FileId(1) at 760..762: mismatched types for `<=`
-| note in file FileId(1) for 758..759: this is of type `boolean`
 | note in file FileId(1) for 763..767: this is of type `string(6)`
+| note in file FileId(1) for 758..759: this is of type `boolean`
 | error in file FileId(1) for 760..762: `boolean` cannot be compared to `string(6)`
 | info: operands must both be the same type
 error in file FileId(1) at 785..787: mismatched types for `<=`
-| note in file FileId(1) for 783..784: this is of type `char`
 | note in file FileId(1) for 788..789: this is of type `real`
+| note in file FileId(1) for 783..784: this is of type `char`
 | error in file FileId(1) for 785..787: `char` cannot be compared to `real`
 | info: operands must both be the same type
 error in file FileId(1) at 806..808: mismatched types for `<=`
-| note in file FileId(1) for 804..805: this is of type `char`
 | note in file FileId(1) for 809..810: this is of type `int`
+| note in file FileId(1) for 804..805: this is of type `char`
 | error in file FileId(1) for 806..808: `char` cannot be compared to `int`
 | info: operands must both be the same type
 error in file FileId(1) at 827..829: mismatched types for `<=`
-| note in file FileId(1) for 825..826: this is of type `char`
 | note in file FileId(1) for 830..831: this is of type `nat`
+| note in file FileId(1) for 825..826: this is of type `char`
 | error in file FileId(1) for 827..829: `char` cannot be compared to `nat`
 | info: operands must both be the same type
 error in file FileId(1) at 848..850: mismatched types for `<=`
-| note in file FileId(1) for 846..847: this is of type `char`
 | note in file FileId(1) for 851..852: this is of type `boolean`
+| note in file FileId(1) for 846..847: this is of type `char`
 | error in file FileId(1) for 848..850: `char` cannot be compared to `boolean`
 | info: operands must both be the same type
 error in file FileId(1) at 873..875: mismatched types for `<=`
-| note in file FileId(1) for 868..872: this is of type `char(6)`
 | note in file FileId(1) for 876..877: this is of type `real`
+| note in file FileId(1) for 868..872: this is of type `char(6)`
 | error in file FileId(1) for 873..875: `char(6)` cannot be compared to `real`
 | info: operands must both be the same type
 error in file FileId(1) at 897..899: mismatched types for `<=`
-| note in file FileId(1) for 892..896: this is of type `char(6)`
 | note in file FileId(1) for 900..901: this is of type `int`
+| note in file FileId(1) for 892..896: this is of type `char(6)`
 | error in file FileId(1) for 897..899: `char(6)` cannot be compared to `int`
 | info: operands must both be the same type
 error in file FileId(1) at 921..923: mismatched types for `<=`
-| note in file FileId(1) for 916..920: this is of type `char(6)`
 | note in file FileId(1) for 924..925: this is of type `nat`
+| note in file FileId(1) for 916..920: this is of type `char(6)`
 | error in file FileId(1) for 921..923: `char(6)` cannot be compared to `nat`
 | info: operands must both be the same type
 error in file FileId(1) at 945..947: mismatched types for `<=`
-| note in file FileId(1) for 940..944: this is of type `char(6)`
 | note in file FileId(1) for 948..949: this is of type `boolean`
+| note in file FileId(1) for 940..944: this is of type `char(6)`
 | error in file FileId(1) for 945..947: `char(6)` cannot be compared to `boolean`
 | info: operands must both be the same type
 error in file FileId(1) at 967..969: mismatched types for `<=`
-| note in file FileId(1) for 965..966: this is of type `string`
 | note in file FileId(1) for 970..971: this is of type `real`
+| note in file FileId(1) for 965..966: this is of type `string`
 | error in file FileId(1) for 967..969: `string` cannot be compared to `real`
 | info: operands must both be the same type
 error in file FileId(1) at 988..990: mismatched types for `<=`
-| note in file FileId(1) for 986..987: this is of type `string`
 | note in file FileId(1) for 991..992: this is of type `int`
+| note in file FileId(1) for 986..987: this is of type `string`
 | error in file FileId(1) for 988..990: `string` cannot be compared to `int`
 | info: operands must both be the same type
 error in file FileId(1) at 1009..1011: mismatched types for `<=`
-| note in file FileId(1) for 1007..1008: this is of type `string`
 | note in file FileId(1) for 1012..1013: this is of type `nat`
+| note in file FileId(1) for 1007..1008: this is of type `string`
 | error in file FileId(1) for 1009..1011: `string` cannot be compared to `nat`
 | info: operands must both be the same type
 error in file FileId(1) at 1030..1032: mismatched types for `<=`
-| note in file FileId(1) for 1028..1029: this is of type `string`
 | note in file FileId(1) for 1033..1034: this is of type `boolean`
+| note in file FileId(1) for 1028..1029: this is of type `string`
 | error in file FileId(1) for 1030..1032: `string` cannot be compared to `boolean`
 | info: operands must both be the same type
 error in file FileId(1) at 1055..1057: mismatched types for `<=`
-| note in file FileId(1) for 1050..1054: this is of type `string(6)`
 | note in file FileId(1) for 1058..1059: this is of type `real`
+| note in file FileId(1) for 1050..1054: this is of type `string(6)`
 | error in file FileId(1) for 1055..1057: `string(6)` cannot be compared to `real`
 | info: operands must both be the same type
 error in file FileId(1) at 1079..1081: mismatched types for `<=`
-| note in file FileId(1) for 1074..1078: this is of type `string(6)`
 | note in file FileId(1) for 1082..1083: this is of type `int`
+| note in file FileId(1) for 1074..1078: this is of type `string(6)`
 | error in file FileId(1) for 1079..1081: `string(6)` cannot be compared to `int`
 | info: operands must both be the same type
 error in file FileId(1) at 1103..1105: mismatched types for `<=`
-| note in file FileId(1) for 1098..1102: this is of type `string(6)`
 | note in file FileId(1) for 1106..1107: this is of type `nat`
+| note in file FileId(1) for 1098..1102: this is of type `string(6)`
 | error in file FileId(1) for 1103..1105: `string(6)` cannot be compared to `nat`
 | info: operands must both be the same type
 error in file FileId(1) at 1127..1129: mismatched types for `<=`
-| note in file FileId(1) for 1122..1126: this is of type `string(6)`
 | note in file FileId(1) for 1130..1131: this is of type `boolean`
+| note in file FileId(1) for 1122..1126: this is of type `string(6)`
 | error in file FileId(1) for 1127..1129: `string(6)` cannot be compared to `boolean`
 | info: operands must both be the same type

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_not_equal.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_not_equal.snap
@@ -1,5 +1,6 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "\n    % Numerics\n    var r : real\n    var i : int\n    var n : nat\n\n    % Other scalars\n    var b : boolean\n\n    % Sized charseqs\n    var c : char\n    var c_sz : char(6)\n    var s : string\n    var s_sz : string(6)\n\n    % should all produce boolean anyway\n    var _v_res : boolean\n\n    _v_res := r not= b\n    _v_res := r not= c\n    _v_res := r not= c_sz\n    _v_res := r not= s\n    _v_res := r not= s_sz\n\n    _v_res := i not= b\n    _v_res := i not= c\n    _v_res := i not= c_sz\n    _v_res := i not= s\n    _v_res := i not= s_sz\n\n    _v_res := n not= b\n    _v_res := n not= c\n    _v_res := n not= c_sz\n    _v_res := n not= s\n    _v_res := n not= s_sz\n\n    _v_res := b not= r\n    _v_res := b not= i\n    _v_res := b not= n\n    _v_res := b not= c\n    _v_res := b not= c_sz\n    _v_res := b not= s\n    _v_res := b not= s_sz\n\n    _v_res := c not= r\n    _v_res := c not= i\n    _v_res := c not= n\n    _v_res := c not= b\n\n    _v_res := c_sz not= r\n    _v_res := c_sz not= i\n    _v_res := c_sz not= n\n    _v_res := c_sz not= b\n\n    _v_res := s not= r\n    _v_res := s not= i\n    _v_res := s not= n\n    _v_res := s not= b\n\n    _v_res := s_sz not= r\n    _v_res := s_sz not= i\n    _v_res := s_sz not= n\n    _v_res := s_sz not= b\n    "
 
 ---
@@ -15,192 +16,192 @@ expression: "\n    % Numerics\n    var r : real\n    var i : int\n    var n : na
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 295..299: mismatched types for `not =`
-| note in file FileId(1) for 293..294: this is of type `real`
 | note in file FileId(1) for 300..301: this is of type `boolean`
+| note in file FileId(1) for 293..294: this is of type `real`
 | error in file FileId(1) for 295..299: `real` cannot be compared to `boolean`
 | info: operands must both be the same type
 error in file FileId(1) at 318..322: mismatched types for `not =`
-| note in file FileId(1) for 316..317: this is of type `real`
 | note in file FileId(1) for 323..324: this is of type `char`
+| note in file FileId(1) for 316..317: this is of type `real`
 | error in file FileId(1) for 318..322: `real` cannot be compared to `char`
 | info: operands must both be the same type
 error in file FileId(1) at 341..345: mismatched types for `not =`
-| note in file FileId(1) for 339..340: this is of type `real`
 | note in file FileId(1) for 346..350: this is of type `char(6)`
+| note in file FileId(1) for 339..340: this is of type `real`
 | error in file FileId(1) for 341..345: `real` cannot be compared to `char(6)`
 | info: operands must both be the same type
 error in file FileId(1) at 367..371: mismatched types for `not =`
-| note in file FileId(1) for 365..366: this is of type `real`
 | note in file FileId(1) for 372..373: this is of type `string`
+| note in file FileId(1) for 365..366: this is of type `real`
 | error in file FileId(1) for 367..371: `real` cannot be compared to `string`
 | info: operands must both be the same type
 error in file FileId(1) at 390..394: mismatched types for `not =`
-| note in file FileId(1) for 388..389: this is of type `real`
 | note in file FileId(1) for 395..399: this is of type `string(6)`
+| note in file FileId(1) for 388..389: this is of type `real`
 | error in file FileId(1) for 390..394: `real` cannot be compared to `string(6)`
 | info: operands must both be the same type
 error in file FileId(1) at 417..421: mismatched types for `not =`
-| note in file FileId(1) for 415..416: this is of type `int`
 | note in file FileId(1) for 422..423: this is of type `boolean`
+| note in file FileId(1) for 415..416: this is of type `int`
 | error in file FileId(1) for 417..421: `int` cannot be compared to `boolean`
 | info: operands must both be the same type
 error in file FileId(1) at 440..444: mismatched types for `not =`
-| note in file FileId(1) for 438..439: this is of type `int`
 | note in file FileId(1) for 445..446: this is of type `char`
+| note in file FileId(1) for 438..439: this is of type `int`
 | error in file FileId(1) for 440..444: `int` cannot be compared to `char`
 | info: operands must both be the same type
 error in file FileId(1) at 463..467: mismatched types for `not =`
-| note in file FileId(1) for 461..462: this is of type `int`
 | note in file FileId(1) for 468..472: this is of type `char(6)`
+| note in file FileId(1) for 461..462: this is of type `int`
 | error in file FileId(1) for 463..467: `int` cannot be compared to `char(6)`
 | info: operands must both be the same type
 error in file FileId(1) at 489..493: mismatched types for `not =`
-| note in file FileId(1) for 487..488: this is of type `int`
 | note in file FileId(1) for 494..495: this is of type `string`
+| note in file FileId(1) for 487..488: this is of type `int`
 | error in file FileId(1) for 489..493: `int` cannot be compared to `string`
 | info: operands must both be the same type
 error in file FileId(1) at 512..516: mismatched types for `not =`
-| note in file FileId(1) for 510..511: this is of type `int`
 | note in file FileId(1) for 517..521: this is of type `string(6)`
+| note in file FileId(1) for 510..511: this is of type `int`
 | error in file FileId(1) for 512..516: `int` cannot be compared to `string(6)`
 | info: operands must both be the same type
 error in file FileId(1) at 539..543: mismatched types for `not =`
-| note in file FileId(1) for 537..538: this is of type `nat`
 | note in file FileId(1) for 544..545: this is of type `boolean`
+| note in file FileId(1) for 537..538: this is of type `nat`
 | error in file FileId(1) for 539..543: `nat` cannot be compared to `boolean`
 | info: operands must both be the same type
 error in file FileId(1) at 562..566: mismatched types for `not =`
-| note in file FileId(1) for 560..561: this is of type `nat`
 | note in file FileId(1) for 567..568: this is of type `char`
+| note in file FileId(1) for 560..561: this is of type `nat`
 | error in file FileId(1) for 562..566: `nat` cannot be compared to `char`
 | info: operands must both be the same type
 error in file FileId(1) at 585..589: mismatched types for `not =`
-| note in file FileId(1) for 583..584: this is of type `nat`
 | note in file FileId(1) for 590..594: this is of type `char(6)`
+| note in file FileId(1) for 583..584: this is of type `nat`
 | error in file FileId(1) for 585..589: `nat` cannot be compared to `char(6)`
 | info: operands must both be the same type
 error in file FileId(1) at 611..615: mismatched types for `not =`
-| note in file FileId(1) for 609..610: this is of type `nat`
 | note in file FileId(1) for 616..617: this is of type `string`
+| note in file FileId(1) for 609..610: this is of type `nat`
 | error in file FileId(1) for 611..615: `nat` cannot be compared to `string`
 | info: operands must both be the same type
 error in file FileId(1) at 634..638: mismatched types for `not =`
-| note in file FileId(1) for 632..633: this is of type `nat`
 | note in file FileId(1) for 639..643: this is of type `string(6)`
+| note in file FileId(1) for 632..633: this is of type `nat`
 | error in file FileId(1) for 634..638: `nat` cannot be compared to `string(6)`
 | info: operands must both be the same type
 error in file FileId(1) at 661..665: mismatched types for `not =`
-| note in file FileId(1) for 659..660: this is of type `boolean`
 | note in file FileId(1) for 666..667: this is of type `real`
+| note in file FileId(1) for 659..660: this is of type `boolean`
 | error in file FileId(1) for 661..665: `boolean` cannot be compared to `real`
 | info: operands must both be the same type
 error in file FileId(1) at 684..688: mismatched types for `not =`
-| note in file FileId(1) for 682..683: this is of type `boolean`
 | note in file FileId(1) for 689..690: this is of type `int`
+| note in file FileId(1) for 682..683: this is of type `boolean`
 | error in file FileId(1) for 684..688: `boolean` cannot be compared to `int`
 | info: operands must both be the same type
 error in file FileId(1) at 707..711: mismatched types for `not =`
-| note in file FileId(1) for 705..706: this is of type `boolean`
 | note in file FileId(1) for 712..713: this is of type `nat`
+| note in file FileId(1) for 705..706: this is of type `boolean`
 | error in file FileId(1) for 707..711: `boolean` cannot be compared to `nat`
 | info: operands must both be the same type
 error in file FileId(1) at 730..734: mismatched types for `not =`
-| note in file FileId(1) for 728..729: this is of type `boolean`
 | note in file FileId(1) for 735..736: this is of type `char`
+| note in file FileId(1) for 728..729: this is of type `boolean`
 | error in file FileId(1) for 730..734: `boolean` cannot be compared to `char`
 | info: operands must both be the same type
 error in file FileId(1) at 753..757: mismatched types for `not =`
-| note in file FileId(1) for 751..752: this is of type `boolean`
 | note in file FileId(1) for 758..762: this is of type `char(6)`
+| note in file FileId(1) for 751..752: this is of type `boolean`
 | error in file FileId(1) for 753..757: `boolean` cannot be compared to `char(6)`
 | info: operands must both be the same type
 error in file FileId(1) at 779..783: mismatched types for `not =`
-| note in file FileId(1) for 777..778: this is of type `boolean`
 | note in file FileId(1) for 784..785: this is of type `string`
+| note in file FileId(1) for 777..778: this is of type `boolean`
 | error in file FileId(1) for 779..783: `boolean` cannot be compared to `string`
 | info: operands must both be the same type
 error in file FileId(1) at 802..806: mismatched types for `not =`
-| note in file FileId(1) for 800..801: this is of type `boolean`
 | note in file FileId(1) for 807..811: this is of type `string(6)`
+| note in file FileId(1) for 800..801: this is of type `boolean`
 | error in file FileId(1) for 802..806: `boolean` cannot be compared to `string(6)`
 | info: operands must both be the same type
 error in file FileId(1) at 829..833: mismatched types for `not =`
-| note in file FileId(1) for 827..828: this is of type `char`
 | note in file FileId(1) for 834..835: this is of type `real`
+| note in file FileId(1) for 827..828: this is of type `char`
 | error in file FileId(1) for 829..833: `char` cannot be compared to `real`
 | info: operands must both be the same type
 error in file FileId(1) at 852..856: mismatched types for `not =`
-| note in file FileId(1) for 850..851: this is of type `char`
 | note in file FileId(1) for 857..858: this is of type `int`
+| note in file FileId(1) for 850..851: this is of type `char`
 | error in file FileId(1) for 852..856: `char` cannot be compared to `int`
 | info: operands must both be the same type
 error in file FileId(1) at 875..879: mismatched types for `not =`
-| note in file FileId(1) for 873..874: this is of type `char`
 | note in file FileId(1) for 880..881: this is of type `nat`
+| note in file FileId(1) for 873..874: this is of type `char`
 | error in file FileId(1) for 875..879: `char` cannot be compared to `nat`
 | info: operands must both be the same type
 error in file FileId(1) at 898..902: mismatched types for `not =`
-| note in file FileId(1) for 896..897: this is of type `char`
 | note in file FileId(1) for 903..904: this is of type `boolean`
+| note in file FileId(1) for 896..897: this is of type `char`
 | error in file FileId(1) for 898..902: `char` cannot be compared to `boolean`
 | info: operands must both be the same type
 error in file FileId(1) at 925..929: mismatched types for `not =`
-| note in file FileId(1) for 920..924: this is of type `char(6)`
 | note in file FileId(1) for 930..931: this is of type `real`
+| note in file FileId(1) for 920..924: this is of type `char(6)`
 | error in file FileId(1) for 925..929: `char(6)` cannot be compared to `real`
 | info: operands must both be the same type
 error in file FileId(1) at 951..955: mismatched types for `not =`
-| note in file FileId(1) for 946..950: this is of type `char(6)`
 | note in file FileId(1) for 956..957: this is of type `int`
+| note in file FileId(1) for 946..950: this is of type `char(6)`
 | error in file FileId(1) for 951..955: `char(6)` cannot be compared to `int`
 | info: operands must both be the same type
 error in file FileId(1) at 977..981: mismatched types for `not =`
-| note in file FileId(1) for 972..976: this is of type `char(6)`
 | note in file FileId(1) for 982..983: this is of type `nat`
+| note in file FileId(1) for 972..976: this is of type `char(6)`
 | error in file FileId(1) for 977..981: `char(6)` cannot be compared to `nat`
 | info: operands must both be the same type
 error in file FileId(1) at 1003..1007: mismatched types for `not =`
-| note in file FileId(1) for 998..1002: this is of type `char(6)`
 | note in file FileId(1) for 1008..1009: this is of type `boolean`
+| note in file FileId(1) for 998..1002: this is of type `char(6)`
 | error in file FileId(1) for 1003..1007: `char(6)` cannot be compared to `boolean`
 | info: operands must both be the same type
 error in file FileId(1) at 1027..1031: mismatched types for `not =`
-| note in file FileId(1) for 1025..1026: this is of type `string`
 | note in file FileId(1) for 1032..1033: this is of type `real`
+| note in file FileId(1) for 1025..1026: this is of type `string`
 | error in file FileId(1) for 1027..1031: `string` cannot be compared to `real`
 | info: operands must both be the same type
 error in file FileId(1) at 1050..1054: mismatched types for `not =`
-| note in file FileId(1) for 1048..1049: this is of type `string`
 | note in file FileId(1) for 1055..1056: this is of type `int`
+| note in file FileId(1) for 1048..1049: this is of type `string`
 | error in file FileId(1) for 1050..1054: `string` cannot be compared to `int`
 | info: operands must both be the same type
 error in file FileId(1) at 1073..1077: mismatched types for `not =`
-| note in file FileId(1) for 1071..1072: this is of type `string`
 | note in file FileId(1) for 1078..1079: this is of type `nat`
+| note in file FileId(1) for 1071..1072: this is of type `string`
 | error in file FileId(1) for 1073..1077: `string` cannot be compared to `nat`
 | info: operands must both be the same type
 error in file FileId(1) at 1096..1100: mismatched types for `not =`
-| note in file FileId(1) for 1094..1095: this is of type `string`
 | note in file FileId(1) for 1101..1102: this is of type `boolean`
+| note in file FileId(1) for 1094..1095: this is of type `string`
 | error in file FileId(1) for 1096..1100: `string` cannot be compared to `boolean`
 | info: operands must both be the same type
 error in file FileId(1) at 1123..1127: mismatched types for `not =`
-| note in file FileId(1) for 1118..1122: this is of type `string(6)`
 | note in file FileId(1) for 1128..1129: this is of type `real`
+| note in file FileId(1) for 1118..1122: this is of type `string(6)`
 | error in file FileId(1) for 1123..1127: `string(6)` cannot be compared to `real`
 | info: operands must both be the same type
 error in file FileId(1) at 1149..1153: mismatched types for `not =`
-| note in file FileId(1) for 1144..1148: this is of type `string(6)`
 | note in file FileId(1) for 1154..1155: this is of type `int`
+| note in file FileId(1) for 1144..1148: this is of type `string(6)`
 | error in file FileId(1) for 1149..1153: `string(6)` cannot be compared to `int`
 | info: operands must both be the same type
 error in file FileId(1) at 1175..1179: mismatched types for `not =`
-| note in file FileId(1) for 1170..1174: this is of type `string(6)`
 | note in file FileId(1) for 1180..1181: this is of type `nat`
+| note in file FileId(1) for 1170..1174: this is of type `string(6)`
 | error in file FileId(1) for 1175..1179: `string(6)` cannot be compared to `nat`
 | info: operands must both be the same type
 error in file FileId(1) at 1201..1205: mismatched types for `not =`
-| note in file FileId(1) for 1196..1200: this is of type `string(6)`
 | note in file FileId(1) for 1206..1207: this is of type `boolean`
+| note in file FileId(1) for 1196..1200: this is of type `string(6)`
 | error in file FileId(1) for 1201..1205: `string(6)` cannot be compared to `boolean`
 | info: operands must both be the same type

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__equivalence_of_aliases.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__equivalence_of_aliases.snap
@@ -1,0 +1,13 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
+expression: "type a0 : int\ntype a1 : int\nvar i : int\nvar ia0 : a0\nvar ia1 : a1\n\n% base type & alias\nfor : i .. ia0 end for\nfor : i .. ia1 end for\nfor : ia0 .. i end for\nfor : ia1 .. i end for\n% alias with same base type\nfor : ia0 .. ia1 end for\nfor : ia1 .. ia0 end for\n"
+
+---
+"a0"@(FileId(1), 5..7) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of int
+"a1"@(FileId(1), 19..21) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(1))] of int
+"i"@(FileId(1), 32..33) [Declared]: ref_mut int
+"ia0"@(FileId(1), 44..47) [Declared]: ref_mut alias[DefId(LibraryId(0), LocalDefId(0))] of int
+"ia1"@(FileId(1), 57..60) [Declared]: ref_mut alias[DefId(LibraryId(0), LocalDefId(1))] of int
+"<root>"@(dummy) [Declared]: <error>
+

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__equivalence_of_integer.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__equivalence_of_integer.snap
@@ -1,5 +1,6 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "var n : nat\nvar i : int\nvar r : real\n\nfor : 1 .. n end for\nfor : 1 .. i end for\nfor : 1 .. r end for\nfor : n .. 1 end for\nfor : i .. 1 end for\nfor : r .. 1 end for\n"
 
 ---
@@ -8,11 +9,13 @@ expression: "var n : nat\nvar i : int\nvar r : real\n\nfor : 1 .. n end for\nfor
 "r"@(FileId(1), 28..29) [Declared]: ref_mut real
 "<root>"@(dummy) [Declared]: <error>
 
-error in file FileId(1) at 86..92: range bounds are not index types
-| note in file FileId(1) for 86..87: this is of type `{integer}`
+error in file FileId(1) at 86..92: mismatched types
 | note in file FileId(1) for 91..92: this is of type `real`
-| info: expected an index type (an integer, `boolean`, `char`, enumerated type, or a range)
-error in file FileId(1) at 149..155: range bounds are not index types
-| note in file FileId(1) for 149..150: this is of type `real`
+| note in file FileId(1) for 86..87: this is of type `{integer}`
+| error in file FileId(1) for 86..92: expected index types
+| info: range bounds types must both be index types (an integer, `boolean`, `char`, enumerated type, or a range)
+error in file FileId(1) at 149..155: mismatched types
 | note in file FileId(1) for 154..155: this is of type `{integer}`
-| info: expected an index type (an integer, `boolean`, `char`, enumerated type, or a range)
+| note in file FileId(1) for 149..150: this is of type `real`
+| error in file FileId(1) for 149..155: expected index types
+| info: range bounds types must both be index types (an integer, `boolean`, `char`, enumerated type, or a range)

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__logical_op_wrong_type_and.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__logical_op_wrong_type_and.snap
@@ -1,5 +1,6 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "\n    var b : boolean\n    var r : real\n    var i : int\n    var n : nat\n    var _bi := b and i\n    var _bn := b and n\n    var _ib := i and b\n    var _nb := n and b\n    var _ri := r and i\n    var _rn := r and n\n    var _ir := i and r\n    var _nr := n and r\n"
 
 ---
@@ -18,42 +19,42 @@ expression: "\n    var b : boolean\n    var r : real\n    var i : int\n    var n
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 87..90: mismatched types for logical `and`
-| note in file FileId(1) for 85..86: this is of type `boolean`
 | note in file FileId(1) for 91..92: this is of type `int`
+| note in file FileId(1) for 85..86: this is of type `boolean`
 | error in file FileId(1) for 87..90: `boolean` cannot be `and`ed logically by `int`
 | info: operands must both be integers or booleans
 error in file FileId(1) at 110..113: mismatched types for logical `and`
-| note in file FileId(1) for 108..109: this is of type `boolean`
 | note in file FileId(1) for 114..115: this is of type `nat`
+| note in file FileId(1) for 108..109: this is of type `boolean`
 | error in file FileId(1) for 110..113: `boolean` cannot be `and`ed logically by `nat`
 | info: operands must both be integers or booleans
 error in file FileId(1) at 133..136: mismatched types for logical `and`
-| note in file FileId(1) for 131..132: this is of type `int`
 | note in file FileId(1) for 137..138: this is of type `boolean`
+| note in file FileId(1) for 131..132: this is of type `int`
 | error in file FileId(1) for 133..136: `int` cannot be `and`ed logically by `boolean`
 | info: operands must both be integers or booleans
 error in file FileId(1) at 156..159: mismatched types for logical `and`
-| note in file FileId(1) for 154..155: this is of type `nat`
 | note in file FileId(1) for 160..161: this is of type `boolean`
+| note in file FileId(1) for 154..155: this is of type `nat`
 | error in file FileId(1) for 156..159: `nat` cannot be `and`ed logically by `boolean`
 | info: operands must both be integers or booleans
 error in file FileId(1) at 179..182: mismatched types for bitwise `and`
-| note in file FileId(1) for 177..178: this is of type `real`
 | note in file FileId(1) for 183..184: this is of type `int`
+| note in file FileId(1) for 177..178: this is of type `real`
 | error in file FileId(1) for 179..182: `real` cannot be `and`ed bitwise by `int`
 | info: operands must both be integers or booleans
 error in file FileId(1) at 202..205: mismatched types for bitwise `and`
-| note in file FileId(1) for 200..201: this is of type `real`
 | note in file FileId(1) for 206..207: this is of type `nat`
+| note in file FileId(1) for 200..201: this is of type `real`
 | error in file FileId(1) for 202..205: `real` cannot be `and`ed bitwise by `nat`
 | info: operands must both be integers or booleans
 error in file FileId(1) at 225..228: mismatched types for bitwise `and`
-| note in file FileId(1) for 223..224: this is of type `int`
 | note in file FileId(1) for 229..230: this is of type `real`
+| note in file FileId(1) for 223..224: this is of type `int`
 | error in file FileId(1) for 225..228: `int` cannot be `and`ed bitwise by `real`
 | info: operands must both be integers or booleans
 error in file FileId(1) at 248..251: mismatched types for bitwise `and`
-| note in file FileId(1) for 246..247: this is of type `nat`
 | note in file FileId(1) for 252..253: this is of type `real`
+| note in file FileId(1) for 246..247: this is of type `nat`
 | error in file FileId(1) for 248..251: `nat` cannot be `and`ed bitwise by `real`
 | info: operands must both be integers or booleans

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__logical_op_wrong_type_imply.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__logical_op_wrong_type_imply.snap
@@ -1,5 +1,6 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "\n    var b : boolean\n    var r : real\n    var i : int\n    var n : nat\n    var _bi := b => i\n    var _bn := b => n\n    var _ib := i => b\n    var _nb := n => b\n    var _ri := r => i\n    var _rn := r => n\n    var _ir := i => r\n    var _nr := n => r\n"
 
 ---
@@ -18,42 +19,42 @@ expression: "\n    var b : boolean\n    var r : real\n    var i : int\n    var n
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 87..89: mismatched types for `=>`
-| note in file FileId(1) for 85..86: this is of type `boolean`
 | note in file FileId(1) for 90..91: this is of type `int`
+| note in file FileId(1) for 85..86: this is of type `boolean`
 | error in file FileId(1) for 87..89: `boolean` cannot be compared to `int`
 | info: operands must both be booleans
 error in file FileId(1) at 109..111: mismatched types for `=>`
-| note in file FileId(1) for 107..108: this is of type `boolean`
 | note in file FileId(1) for 112..113: this is of type `nat`
+| note in file FileId(1) for 107..108: this is of type `boolean`
 | error in file FileId(1) for 109..111: `boolean` cannot be compared to `nat`
 | info: operands must both be booleans
 error in file FileId(1) at 131..133: mismatched types for `=>`
-| note in file FileId(1) for 129..130: this is of type `int`
 | note in file FileId(1) for 134..135: this is of type `boolean`
+| note in file FileId(1) for 129..130: this is of type `int`
 | error in file FileId(1) for 131..133: `int` cannot be compared to `boolean`
 | info: operands must both be booleans
 error in file FileId(1) at 153..155: mismatched types for `=>`
-| note in file FileId(1) for 151..152: this is of type `nat`
 | note in file FileId(1) for 156..157: this is of type `boolean`
+| note in file FileId(1) for 151..152: this is of type `nat`
 | error in file FileId(1) for 153..155: `nat` cannot be compared to `boolean`
 | info: operands must both be booleans
 error in file FileId(1) at 175..177: mismatched types for `=>`
-| note in file FileId(1) for 173..174: this is of type `real`
 | note in file FileId(1) for 178..179: this is of type `int`
+| note in file FileId(1) for 173..174: this is of type `real`
 | error in file FileId(1) for 175..177: `real` cannot be compared to `int`
 | info: operands must both be booleans
 error in file FileId(1) at 197..199: mismatched types for `=>`
-| note in file FileId(1) for 195..196: this is of type `real`
 | note in file FileId(1) for 200..201: this is of type `nat`
+| note in file FileId(1) for 195..196: this is of type `real`
 | error in file FileId(1) for 197..199: `real` cannot be compared to `nat`
 | info: operands must both be booleans
 error in file FileId(1) at 219..221: mismatched types for `=>`
-| note in file FileId(1) for 217..218: this is of type `int`
 | note in file FileId(1) for 222..223: this is of type `real`
+| note in file FileId(1) for 217..218: this is of type `int`
 | error in file FileId(1) for 219..221: `int` cannot be compared to `real`
 | info: operands must both be booleans
 error in file FileId(1) at 241..243: mismatched types for `=>`
-| note in file FileId(1) for 239..240: this is of type `nat`
 | note in file FileId(1) for 244..245: this is of type `real`
+| note in file FileId(1) for 239..240: this is of type `nat`
 | error in file FileId(1) for 241..243: `nat` cannot be compared to `real`
 | info: operands must both be booleans

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__logical_op_wrong_type_or.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__logical_op_wrong_type_or.snap
@@ -1,5 +1,6 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "\n    var b : boolean\n    var r : real\n    var i : int\n    var n : nat\n    var _bi := b or i\n    var _bn := b or n\n    var _ib := i or b\n    var _nb := n or b\n    var _ri := r or i\n    var _rn := r or n\n    var _ir := i or r\n    var _nr := n or r\n"
 
 ---
@@ -18,42 +19,42 @@ expression: "\n    var b : boolean\n    var r : real\n    var i : int\n    var n
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 87..89: mismatched types for logical `or`
-| note in file FileId(1) for 85..86: this is of type `boolean`
 | note in file FileId(1) for 90..91: this is of type `int`
+| note in file FileId(1) for 85..86: this is of type `boolean`
 | error in file FileId(1) for 87..89: `boolean` cannot be `or`ed by `int`
 | info: operands must both be integers or booleans
 error in file FileId(1) at 109..111: mismatched types for logical `or`
-| note in file FileId(1) for 107..108: this is of type `boolean`
 | note in file FileId(1) for 112..113: this is of type `nat`
+| note in file FileId(1) for 107..108: this is of type `boolean`
 | error in file FileId(1) for 109..111: `boolean` cannot be `or`ed by `nat`
 | info: operands must both be integers or booleans
 error in file FileId(1) at 131..133: mismatched types for logical `or`
-| note in file FileId(1) for 129..130: this is of type `int`
 | note in file FileId(1) for 134..135: this is of type `boolean`
+| note in file FileId(1) for 129..130: this is of type `int`
 | error in file FileId(1) for 131..133: `int` cannot be `or`ed by `boolean`
 | info: operands must both be integers or booleans
 error in file FileId(1) at 153..155: mismatched types for logical `or`
-| note in file FileId(1) for 151..152: this is of type `nat`
 | note in file FileId(1) for 156..157: this is of type `boolean`
+| note in file FileId(1) for 151..152: this is of type `nat`
 | error in file FileId(1) for 153..155: `nat` cannot be `or`ed by `boolean`
 | info: operands must both be integers or booleans
 error in file FileId(1) at 175..177: mismatched types for bitwise `or`
-| note in file FileId(1) for 173..174: this is of type `real`
 | note in file FileId(1) for 178..179: this is of type `int`
+| note in file FileId(1) for 173..174: this is of type `real`
 | error in file FileId(1) for 175..177: `real` cannot be `or`ed bitwise by `int`
 | info: operands must both be integers or booleans
 error in file FileId(1) at 197..199: mismatched types for bitwise `or`
-| note in file FileId(1) for 195..196: this is of type `real`
 | note in file FileId(1) for 200..201: this is of type `nat`
+| note in file FileId(1) for 195..196: this is of type `real`
 | error in file FileId(1) for 197..199: `real` cannot be `or`ed bitwise by `nat`
 | info: operands must both be integers or booleans
 error in file FileId(1) at 219..221: mismatched types for bitwise `or`
-| note in file FileId(1) for 217..218: this is of type `int`
 | note in file FileId(1) for 222..223: this is of type `real`
+| note in file FileId(1) for 217..218: this is of type `int`
 | error in file FileId(1) for 219..221: `int` cannot be `or`ed bitwise by `real`
 | info: operands must both be integers or booleans
 error in file FileId(1) at 241..243: mismatched types for bitwise `or`
-| note in file FileId(1) for 239..240: this is of type `nat`
 | note in file FileId(1) for 244..245: this is of type `real`
+| note in file FileId(1) for 239..240: this is of type `nat`
 | error in file FileId(1) for 241..243: `nat` cannot be `or`ed bitwise by `real`
 | info: operands must both be integers or booleans

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__report_aliased_type_in_assign.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__report_aliased_type_in_assign.snap
@@ -1,15 +1,16 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
 assertion_line: 41
-expression: "type a0 : real\nvar k : a0\nvar i : int\ni := k"
+expression: "type a0 : real\ntype a1 : int\nvar k : a0\nvar i : a1\ni := k"
 
 ---
 "a0"@(FileId(1), 5..7) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of real
-"k"@(FileId(1), 19..20) [Declared]: ref_mut alias[DefId(LibraryId(0), LocalDefId(0))] of real
-"i"@(FileId(1), 30..31) [Declared]: ref_mut int
+"a1"@(FileId(1), 20..22) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(1))] of int
+"k"@(FileId(1), 33..34) [Declared]: ref_mut alias[DefId(LibraryId(0), LocalDefId(0))] of real
+"i"@(FileId(1), 44..45) [Declared]: ref_mut alias[DefId(LibraryId(0), LocalDefId(1))] of int
 "<root>"@(dummy) [Declared]: <error>
 
-error in file FileId(1) at 40..42: mismatched types
-| note in file FileId(1) for 43..44: this is of type `real`
-| note in file FileId(1) for 38..39: this is of type `int`
+error in file FileId(1) at 53..55: mismatched types
+| note in file FileId(1) for 56..57: this is of type `a0 (alias of real)`
+| note in file FileId(1) for 51..52: this is of type `a1 (alias of int)`
 | info: `real` is not assignable into `int`

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__report_aliased_type_in_assign.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__report_aliased_type_in_assign.snap
@@ -1,0 +1,15 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
+expression: "type a0 : real\nvar k : a0\nvar i : int\ni := k"
+
+---
+"a0"@(FileId(1), 5..7) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of real
+"k"@(FileId(1), 19..20) [Declared]: ref_mut alias[DefId(LibraryId(0), LocalDefId(0))] of real
+"i"@(FileId(1), 30..31) [Declared]: ref_mut int
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 40..42: mismatched types
+| note in file FileId(1) for 43..44: this is of type `real`
+| note in file FileId(1) for 38..39: this is of type `int`
+| info: `real` is not assignable into `int`

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__report_aliased_type_in_binary_expr.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__report_aliased_type_in_binary_expr.snap
@@ -1,15 +1,16 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
 assertion_line: 41
-expression: "type a0 : real\nvar k : a0\nvar i : int\ni := i + k"
+expression: "type a0 : real\ntype a1 : int\nvar k : a0\nvar i : int\ni := i + k % unchanged"
 
 ---
 "a0"@(FileId(1), 5..7) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of real
-"k"@(FileId(1), 19..20) [Declared]: ref_mut alias[DefId(LibraryId(0), LocalDefId(0))] of real
-"i"@(FileId(1), 30..31) [Declared]: ref_mut int
+"a1"@(FileId(1), 20..22) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(1))] of int
+"k"@(FileId(1), 33..34) [Declared]: ref_mut alias[DefId(LibraryId(0), LocalDefId(0))] of real
+"i"@(FileId(1), 44..45) [Declared]: ref_mut int
 "<root>"@(dummy) [Declared]: <error>
 
-error in file FileId(1) at 40..42: mismatched types
-| note in file FileId(1) for 43..48: this is of type `real`
-| note in file FileId(1) for 38..39: this is of type `int`
+error in file FileId(1) at 54..56: mismatched types
+| note in file FileId(1) for 57..62: this is of type `real`
+| note in file FileId(1) for 52..53: this is of type `int`
 | info: `real` is not assignable into `int`

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__report_aliased_type_in_binary_expr.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__report_aliased_type_in_binary_expr.snap
@@ -1,0 +1,15 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
+expression: "type a0 : real\nvar k : a0\nvar i : int\ni := i + k"
+
+---
+"a0"@(FileId(1), 5..7) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of real
+"k"@(FileId(1), 19..20) [Declared]: ref_mut alias[DefId(LibraryId(0), LocalDefId(0))] of real
+"i"@(FileId(1), 30..31) [Declared]: ref_mut int
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 40..42: mismatched types
+| note in file FileId(1) for 43..48: this is of type `real`
+| note in file FileId(1) for 38..39: this is of type `int`
+| info: `real` is not assignable into `int`

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__report_aliased_type_in_case.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__report_aliased_type_in_case.snap
@@ -11,7 +11,7 @@ expression: "type a0 : char\ntype a1 : char(6)\nvar ca0 : a0\nconst cna1 : a1 :=
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 93..97: mismatched types
-| note in file FileId(1) for 93..97: this is of type `char(6)`
-| note in file FileId(1) for 80..83: discriminant is of type `char`
-| info: `char(6)` is not a `char`
+| note in file FileId(1) for 80..83: discriminant is of type `a0 (alias of char)`
+| note in file FileId(1) for 93..97: selector is of type `a1 (alias of char(6))`
+| error in file FileId(1) for 93..97: `char(6)` is not a `char`
 | info: selector type must match discriminant type

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__report_aliased_type_in_case.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__report_aliased_type_in_case.snap
@@ -1,0 +1,17 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
+expression: "type a0 : char\ntype a1 : char(6)\nvar ca0 : a0\nconst cna1 : a1 := 'aaaaaa'\n\ncase ca0 of\nlabel cna1:\nend case\n"
+
+---
+"a0"@(FileId(1), 5..7) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of char
+"a1"@(FileId(1), 20..22) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(1))] of char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
+"ca0"@(FileId(1), 37..40) [Declared]: ref_mut alias[DefId(LibraryId(0), LocalDefId(0))] of char
+"cna1"@(FileId(1), 52..56) [Declared]: ref alias[DefId(LibraryId(0), LocalDefId(1))] of char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 93..97: mismatched types
+| note in file FileId(1) for 93..97: this is of type `char(6)`
+| note in file FileId(1) for 80..83: discriminant is of type `char`
+| info: `char(6)` is not a `char`
+| info: selector type must match discriminant type

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__report_aliased_type_in_for.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__report_aliased_type_in_for.snap
@@ -1,7 +1,7 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
 assertion_line: 41
-expression: "type a0 : string\nvar sa0 : a0\nvar s : string\n\nfor : sa0 .. sa0 end for\nfor : s .. sa0 end for\nfor : sa0 .. s end for\n"
+expression: "type a0 : string\nvar sa0 : a0\nvar s : string\n\nfor : sa0 .. sa0 end for\nfor : s .. sa0 end for\nfor : sa0 .. s end for\n\nfor : 1 .. sa0 end for\nfor : sa0 .. 1 end for\n"
 
 ---
 "a0"@(FileId(1), 5..7) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of string
@@ -9,15 +9,28 @@ expression: "type a0 : string\nvar sa0 : a0\nvar s : string\n\nfor : sa0 .. sa0 
 "s"@(FileId(1), 34..35) [Declared]: ref_mut string
 "<root>"@(dummy) [Declared]: <error>
 
-error in file FileId(1) at 52..62: range bounds are not index types
-| note in file FileId(1) for 52..55: this is of type `string`
-| note in file FileId(1) for 59..62: this is also of type `string`
-| info: expected an index type (an integer, `boolean`, `char`, enumerated type, or a range)
-error in file FileId(1) at 77..85: range bounds are not index types
+error in file FileId(1) at 52..62: mismatched types
+| note in file FileId(1) for 59..62: this is of type `a0 (alias of string)`
+| note in file FileId(1) for 52..55: this is also of type `a0 (alias of string)`
+| error in file FileId(1) for 52..62: expected index types
+| info: range bounds types must both be index types (an integer, `boolean`, `char`, enumerated type, or a range)
+error in file FileId(1) at 77..85: mismatched types
+| note in file FileId(1) for 82..85: this is of type `a0 (alias of string)`
 | note in file FileId(1) for 77..78: this is of type `string`
-| note in file FileId(1) for 82..85: this is also of type `string`
-| info: expected an index type (an integer, `boolean`, `char`, enumerated type, or a range)
-error in file FileId(1) at 100..108: range bounds are not index types
-| note in file FileId(1) for 100..103: this is of type `string`
-| note in file FileId(1) for 107..108: this is also of type `string`
-| info: expected an index type (an integer, `boolean`, `char`, enumerated type, or a range)
+| error in file FileId(1) for 77..85: expected index types
+| info: range bounds types must both be index types (an integer, `boolean`, `char`, enumerated type, or a range)
+error in file FileId(1) at 100..108: mismatched types
+| note in file FileId(1) for 107..108: this is of type `string`
+| note in file FileId(1) for 100..103: this is of type `a0 (alias of string)`
+| error in file FileId(1) for 100..108: expected index types
+| info: range bounds types must both be index types (an integer, `boolean`, `char`, enumerated type, or a range)
+error in file FileId(1) at 124..132: mismatched types
+| note in file FileId(1) for 129..132: this is of type `a0 (alias of string)`
+| note in file FileId(1) for 124..125: this is of type `{integer}`
+| error in file FileId(1) for 124..132: `string` is not equivalent to `{integer}`
+| info: range bounds types must be equivalent
+error in file FileId(1) at 147..155: mismatched types
+| note in file FileId(1) for 154..155: this is of type `{integer}`
+| note in file FileId(1) for 147..150: this is of type `a0 (alias of string)`
+| error in file FileId(1) for 147..155: `{integer}` is not equivalent to `string`
+| info: range bounds types must be equivalent

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__report_aliased_type_in_for.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__report_aliased_type_in_for.snap
@@ -1,0 +1,23 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
+expression: "type a0 : string\nvar sa0 : a0\nvar s : string\n\nfor : sa0 .. sa0 end for\nfor : s .. sa0 end for\nfor : sa0 .. s end for\n"
+
+---
+"a0"@(FileId(1), 5..7) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of string
+"sa0"@(FileId(1), 21..24) [Declared]: ref_mut alias[DefId(LibraryId(0), LocalDefId(0))] of string
+"s"@(FileId(1), 34..35) [Declared]: ref_mut string
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 52..62: range bounds are not index types
+| note in file FileId(1) for 52..55: this is of type `string`
+| note in file FileId(1) for 59..62: this is also of type `string`
+| info: expected an index type (an integer, `boolean`, `char`, enumerated type, or a range)
+error in file FileId(1) at 77..85: range bounds are not index types
+| note in file FileId(1) for 77..78: this is of type `string`
+| note in file FileId(1) for 82..85: this is also of type `string`
+| info: expected an index type (an integer, `boolean`, `char`, enumerated type, or a range)
+error in file FileId(1) at 100..108: range bounds are not index types
+| note in file FileId(1) for 100..103: this is of type `string`
+| note in file FileId(1) for 107..108: this is also of type `string`
+| info: expected an index type (an integer, `boolean`, `char`, enumerated type, or a range)

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__report_aliased_type_in_inferred_ty.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__report_aliased_type_in_inferred_ty.snap
@@ -1,15 +1,16 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
 assertion_line: 41
-expression: "type a0 : real\nvar k : a0\nvar i : int := k"
+expression: "type a0 : real\ntype a1 : int\nvar k : a0\nvar i : a1 := k"
 
 ---
 "a0"@(FileId(1), 5..7) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of real
-"k"@(FileId(1), 19..20) [Declared]: ref_mut alias[DefId(LibraryId(0), LocalDefId(0))] of real
-"i"@(FileId(1), 30..31) [Declared]: ref_mut int
+"a1"@(FileId(1), 20..22) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(1))] of int
+"k"@(FileId(1), 33..34) [Declared]: ref_mut alias[DefId(LibraryId(0), LocalDefId(0))] of real
+"i"@(FileId(1), 44..45) [Declared]: ref_mut alias[DefId(LibraryId(0), LocalDefId(1))] of int
 "<root>"@(dummy) [Declared]: <error>
 
-error in file FileId(1) at 41..42: mismatched types
-| note in file FileId(1) for 41..42: this is of type `real`
-| note in file FileId(1) for 34..37: this is of type `int`
+error in file FileId(1) at 54..55: mismatched types
+| note in file FileId(1) for 54..55: this is of type `a0 (alias of real)`
+| note in file FileId(1) for 48..50: this is of type `a1 (alias of int)`
 | info: `real` is not assignable into `int`

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__report_aliased_type_in_inferred_ty.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__report_aliased_type_in_inferred_ty.snap
@@ -1,0 +1,15 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
+expression: "type a0 : real\nvar k : a0\nvar i : int := k"
+
+---
+"a0"@(FileId(1), 5..7) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of real
+"k"@(FileId(1), 19..20) [Declared]: ref_mut alias[DefId(LibraryId(0), LocalDefId(0))] of real
+"i"@(FileId(1), 30..31) [Declared]: ref_mut int
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 41..42: mismatched types
+| note in file FileId(1) for 41..42: this is of type `real`
+| note in file FileId(1) for 34..37: this is of type `int`
+| info: `real` is not assignable into `int`

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__report_aliased_type_in_unary_expr.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__report_aliased_type_in_unary_expr.snap
@@ -1,7 +1,7 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
 assertion_line: 41
-expression: "type a0 : real\nvar k : a0\nvar _ := not k\n"
+expression: "type a0 : real\nvar k : a0\nvar _ := not k % unchanged\n"
 
 ---
 "a0"@(FileId(1), 5..7) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of real
@@ -10,6 +10,6 @@ expression: "type a0 : real\nvar k : a0\nvar _ := not k\n"
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 35..38: mismatched types for logical `not`
-| note in file FileId(1) for 39..40: this is of type `real`
+| note in file FileId(1) for 39..40: this is of type `a0 (alias of real)`
 | error in file FileId(1) for 35..38: cannot apply logical `not` to `real`
 | info: operand must be an integer or boolean

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__report_aliased_type_in_unary_expr.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__report_aliased_type_in_unary_expr.snap
@@ -1,0 +1,15 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
+expression: "type a0 : real\nvar k : a0\nvar _ := not k\n"
+
+---
+"a0"@(FileId(1), 5..7) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of real
+"k"@(FileId(1), 19..20) [Declared]: ref_mut alias[DefId(LibraryId(0), LocalDefId(0))] of real
+"_"@(FileId(1), 30..31) [Declared]: ref_mut <error>
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 35..38: mismatched types for logical `not`
+| note in file FileId(1) for 39..40: this is of type `real`
+| error in file FileId(1) for 35..38: cannot apply logical `not` to `real`
+| info: operand must be an integer or boolean

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__require_resolved_type_in_constvar.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__require_resolved_type_in_constvar.snap
@@ -1,0 +1,12 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
+expression: "type fowo : forward var _ : fowo"
+
+---
+"fowo"@(FileId(1), 5..9) [Forward(Type, None)]: alias[DefId(LibraryId(0), LocalDefId(0))] of forward
+"_"@(FileId(1), 24..25) [Declared]: ref_mut <error>
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 28..32: `fowo` has not been resolved at this point
+| error in file FileId(1) for 28..32: `fowo` is required to be resolved at this point

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__require_resolved_type_in_type_decl.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__require_resolved_type_in_type_decl.snap
@@ -1,0 +1,12 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
+expression: "type fowo : forward type _ : fowo"
+
+---
+"fowo"@(FileId(1), 5..9) [Forward(Type, None)]: alias[DefId(LibraryId(0), LocalDefId(0))] of forward
+"_"@(FileId(1), 25..26) [Resolved(Type)]: <error>
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 29..33: `fowo` has not been resolved at this point
+| error in file FileId(1) for 29..33: `fowo` is required to be resolved at this point

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__string_manip_op_wrong_type_concat.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__string_manip_op_wrong_type_concat.snap
@@ -1,5 +1,6 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "\n    var c : char\n    var c_dyn : char(*)\n    var c_sz : char(6)\n    var s : string\n    var s_dyn : string(*)\n    var s_sz : string(6)\n    var i : int\n\n    var _e00 := c + i\n    var _e01 := c_dyn + i\n    var _e02 := c_sz + i\n    var _e03 := s + i\n    var _e04 := s_dyn + i\n    var _e05 := s_sz + i\n\n    var _e10 := i + c\n    var _e11 := i + c_dyn\n    var _e12 := i + c_sz\n    var _e13 := i + s\n    var _e14 := i + s_dyn\n    var _e15 := i + s_sz\n\n    % TODO: Uncomment to verify incompatible types\n    /*\n    var _e20 : char(13) := c_sz + c_sz\n    var _e21 : char(8) := c_sz + c\n    var _e22 : char(8) := c + c_sz\n    var _e23 : char(3) := c + c\n    var _e24 : char := c + c\n    */\n    "
 
 ---
@@ -25,62 +26,62 @@ expression: "\n    var c : char\n    var c_dyn : char(*)\n    var c_sz : char(6)
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 170..171: mismatched types for string concatenation
-| note in file FileId(1) for 168..169: this is of type `char`
 | note in file FileId(1) for 172..173: this is of type `int`
+| note in file FileId(1) for 168..169: this is of type `char`
 | error in file FileId(1) for 170..171: `char` cannot be concatenated to `int`
 | info: operands must both be numbers, strings, or sets
 error in file FileId(1) at 196..197: mismatched types for string concatenation
-| note in file FileId(1) for 190..195: this is of type `char(*)`
 | note in file FileId(1) for 198..199: this is of type `int`
+| note in file FileId(1) for 190..195: this is of type `char(*)`
 | error in file FileId(1) for 196..197: `char(*)` cannot be concatenated to `int`
 | info: operands must both be numbers, strings, or sets
 error in file FileId(1) at 221..222: mismatched types for string concatenation
-| note in file FileId(1) for 216..220: this is of type `char(6)`
 | note in file FileId(1) for 223..224: this is of type `int`
+| note in file FileId(1) for 216..220: this is of type `char(6)`
 | error in file FileId(1) for 221..222: `char(6)` cannot be concatenated to `int`
 | info: operands must both be numbers, strings, or sets
 error in file FileId(1) at 243..244: mismatched types for string concatenation
-| note in file FileId(1) for 241..242: this is of type `string`
 | note in file FileId(1) for 245..246: this is of type `int`
+| note in file FileId(1) for 241..242: this is of type `string`
 | error in file FileId(1) for 243..244: `string` cannot be concatenated to `int`
 | info: operands must both be numbers, strings, or sets
 error in file FileId(1) at 269..270: mismatched types for string concatenation
-| note in file FileId(1) for 263..268: this is of type `string(*)`
 | note in file FileId(1) for 271..272: this is of type `int`
+| note in file FileId(1) for 263..268: this is of type `string(*)`
 | error in file FileId(1) for 269..270: `string(*)` cannot be concatenated to `int`
 | info: operands must both be numbers, strings, or sets
 error in file FileId(1) at 294..295: mismatched types for string concatenation
-| note in file FileId(1) for 289..293: this is of type `string(6)`
 | note in file FileId(1) for 296..297: this is of type `int`
+| note in file FileId(1) for 289..293: this is of type `string(6)`
 | error in file FileId(1) for 294..295: `string(6)` cannot be concatenated to `int`
 | info: operands must both be numbers, strings, or sets
 error in file FileId(1) at 317..318: mismatched types for string concatenation
-| note in file FileId(1) for 315..316: this is of type `int`
 | note in file FileId(1) for 319..320: this is of type `char`
+| note in file FileId(1) for 315..316: this is of type `int`
 | error in file FileId(1) for 317..318: `int` cannot be concatenated to `char`
 | info: operands must both be numbers, strings, or sets
 error in file FileId(1) at 339..340: mismatched types for string concatenation
-| note in file FileId(1) for 337..338: this is of type `int`
 | note in file FileId(1) for 341..346: this is of type `char(*)`
+| note in file FileId(1) for 337..338: this is of type `int`
 | error in file FileId(1) for 339..340: `int` cannot be concatenated to `char(*)`
 | info: operands must both be numbers, strings, or sets
 error in file FileId(1) at 365..366: mismatched types for string concatenation
-| note in file FileId(1) for 363..364: this is of type `int`
 | note in file FileId(1) for 367..371: this is of type `char(6)`
+| note in file FileId(1) for 363..364: this is of type `int`
 | error in file FileId(1) for 365..366: `int` cannot be concatenated to `char(6)`
 | info: operands must both be numbers, strings, or sets
 error in file FileId(1) at 390..391: mismatched types for string concatenation
-| note in file FileId(1) for 388..389: this is of type `int`
 | note in file FileId(1) for 392..393: this is of type `string`
+| note in file FileId(1) for 388..389: this is of type `int`
 | error in file FileId(1) for 390..391: `int` cannot be concatenated to `string`
 | info: operands must both be numbers, strings, or sets
 error in file FileId(1) at 412..413: mismatched types for string concatenation
-| note in file FileId(1) for 410..411: this is of type `int`
 | note in file FileId(1) for 414..419: this is of type `string(*)`
+| note in file FileId(1) for 410..411: this is of type `int`
 | error in file FileId(1) for 412..413: `int` cannot be concatenated to `string(*)`
 | info: operands must both be numbers, strings, or sets
 error in file FileId(1) at 438..439: mismatched types for string concatenation
-| note in file FileId(1) for 436..437: this is of type `int`
 | note in file FileId(1) for 440..444: this is of type `string(6)`
+| note in file FileId(1) for 436..437: this is of type `int`
 | error in file FileId(1) for 438..439: `int` cannot be concatenated to `string(6)`
 | info: operands must both be numbers, strings, or sets

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typecheck_error_prop.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typecheck_error_prop.snap
@@ -1,5 +1,6 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "var a : int\nvar b : string\nvar c := a + b\nvar j := c + a\n"
 
 ---
@@ -10,7 +11,7 @@ expression: "var a : int\nvar b : string\nvar c := a + b\nvar j := c + a\n"
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 38..39: mismatched types for string concatenation
-| note in file FileId(1) for 36..37: this is of type `int`
 | note in file FileId(1) for 40..41: this is of type `string`
+| note in file FileId(1) for 36..37: this is of type `int`
 | error in file FileId(1) for 38..39: `int` cannot be concatenated to `string`
 | info: operands must both be numbers, strings, or sets

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_assignment_invalid_compound_add.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_assignment_invalid_compound_add.snap
@@ -1,5 +1,6 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "var lhs : real\nvar rhs : boolean\nlhs += rhs\n"
 
 ---
@@ -8,7 +9,7 @@ expression: "var lhs : real\nvar rhs : boolean\nlhs += rhs\n"
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 37..39: mismatched types for addition
-| note in file FileId(1) for 33..36: this is of type `real`
 | note in file FileId(1) for 40..43: this is of type `boolean`
+| note in file FileId(1) for 33..36: this is of type `real`
 | error in file FileId(1) for 37..39: `real` cannot be added to `boolean`
 | info: operands must both be numbers, strings, or sets

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_case_mismatch_discrim_select_ty.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_case_mismatch_discrim_select_ty.snap
@@ -1,22 +1,23 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "case 'c' of label 123, 'dd', false end case"
 
 ---
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 18..21: mismatched types
-| note in file FileId(1) for 18..21: this is of type `{integer}`
 | note in file FileId(1) for 5..8: discriminant is of type `char`
-| info: `{integer}` is not a `char`
+| note in file FileId(1) for 18..21: selector is of type `{integer}`
+| error in file FileId(1) for 18..21: `{integer}` is not a `char`
 | info: selector type must match discriminant type
 error in file FileId(1) at 23..27: mismatched types
-| note in file FileId(1) for 23..27: this is of type `char(2)`
 | note in file FileId(1) for 5..8: discriminant is of type `char`
-| info: `char(2)` is not a `char`
+| note in file FileId(1) for 23..27: selector is of type `char(2)`
+| error in file FileId(1) for 23..27: `char(2)` is not a `char`
 | info: selector type must match discriminant type
 error in file FileId(1) at 29..34: mismatched types
-| note in file FileId(1) for 29..34: this is of type `boolean`
 | note in file FileId(1) for 5..8: discriminant is of type `char`
-| info: `boolean` is not a `char`
+| note in file FileId(1) for 29..34: selector is of type `boolean`
+| error in file FileId(1) for 29..34: `boolean` is not a `char`
 | info: selector type must match discriminant type

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_case_wrong_mismatch_discrim_select_ty.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_case_wrong_mismatch_discrim_select_ty.snap
@@ -10,12 +10,12 @@ error in file FileId(1) at 5..8: mismatched types
 | error in file FileId(1) for 5..8: `real` cannot be used as a case discriminant
 | info: `case` discriminant must be either an index type (an integer, `boolean`, `char`, enumerated type, or a range), or a `string`
 error in file FileId(1) at 21..24: mismatched types
-| note in file FileId(1) for 21..24: this is of type `char`
 | note in file FileId(1) for 5..8: discriminant is of type `real`
-| info: `char` is not a `real`
+| note in file FileId(1) for 21..24: selector is of type `char`
+| error in file FileId(1) for 21..24: `char` is not a `real`
 | info: selector type must match discriminant type
 error in file FileId(1) at 26..31: mismatched types
-| note in file FileId(1) for 26..31: this is of type `boolean`
 | note in file FileId(1) for 5..8: discriminant is of type `real`
-| info: `boolean` is not a `real`
+| note in file FileId(1) for 26..31: selector is of type `boolean`
+| error in file FileId(1) for 26..31: `boolean` is not a `real`
 | info: selector type must match discriminant type

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_const_error_prop.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_const_error_prop.snap
@@ -1,5 +1,6 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "const k := 20 + false\nconst l : int := k   % Nothing reported here\n"
 
 ---
@@ -8,7 +9,7 @@ expression: "const k := 20 + false\nconst l : int := k   % Nothing reported here
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 14..15: mismatched types for addition
-| note in file FileId(1) for 11..13: this is of type `{integer}`
 | note in file FileId(1) for 16..21: this is of type `boolean`
+| note in file FileId(1) for 11..13: this is of type `{integer}`
 | error in file FileId(1) for 14..15: `{integer}` cannot be added to `boolean`
 | info: operands must both be numbers, strings, or sets

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_for_infer_concrete_counter_ty.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_for_infer_concrete_counter_ty.snap
@@ -1,5 +1,6 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "% Both should fail\nfor c : 1.0 .. 1 var k : int := c end for\nfor c : 1 .. 1.0 var k : int := c end for\n"
 
 ---
@@ -9,18 +10,20 @@ expression: "% Both should fail\nfor c : 1.0 .. 1 var k : int := c end for\nfor 
 "k"@(FileId(1), 82..83) [Declared]: ref_mut int
 "<root>"@(dummy) [Declared]: <error>
 
-error in file FileId(1) at 27..35: range bounds are not index types
-| note in file FileId(1) for 27..30: this is of type `real`
+error in file FileId(1) at 27..35: mismatched types
 | note in file FileId(1) for 34..35: this is of type `{integer}`
-| info: expected an index type (an integer, `boolean`, `char`, enumerated type, or a range)
+| note in file FileId(1) for 27..30: this is of type `real`
+| error in file FileId(1) for 27..35: expected index types
+| info: range bounds types must both be index types (an integer, `boolean`, `char`, enumerated type, or a range)
 error in file FileId(1) at 51..52: mismatched types
 | note in file FileId(1) for 51..52: this is of type `real`
 | note in file FileId(1) for 44..47: this is of type `int`
 | info: `real` is not assignable into `int`
-error in file FileId(1) at 69..77: range bounds are not index types
-| note in file FileId(1) for 69..70: this is of type `{integer}`
+error in file FileId(1) at 69..77: mismatched types
 | note in file FileId(1) for 74..77: this is of type `real`
-| info: expected an index type (an integer, `boolean`, `char`, enumerated type, or a range)
+| note in file FileId(1) for 69..70: this is of type `{integer}`
+| error in file FileId(1) for 69..77: expected index types
+| info: range bounds types must both be index types (an integer, `boolean`, `char`, enumerated type, or a range)
 error in file FileId(1) at 93..94: mismatched types
 | note in file FileId(1) for 93..94: this is of type `real`
 | note in file FileId(1) for 86..89: this is of type `int`

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_for_wrong_types_bounds_concrete_integer.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_for_wrong_types_bounds_concrete_integer.snap
@@ -1,12 +1,14 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "var r : real for : r .. 1 end for"
 
 ---
 "r"@(FileId(1), 4..5) [Declared]: ref_mut real
 "<root>"@(dummy) [Declared]: <error>
 
-error in file FileId(1) at 19..25: range bounds are not index types
-| note in file FileId(1) for 19..20: this is of type `real`
+error in file FileId(1) at 19..25: mismatched types
 | note in file FileId(1) for 24..25: this is of type `{integer}`
-| info: expected an index type (an integer, `boolean`, `char`, enumerated type, or a range)
+| note in file FileId(1) for 19..20: this is of type `real`
+| error in file FileId(1) for 19..25: expected index types
+| info: range bounds types must both be index types (an integer, `boolean`, `char`, enumerated type, or a range)

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_for_wrong_types_bounds_integer_concrete.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_for_wrong_types_bounds_integer_concrete.snap
@@ -1,12 +1,14 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "var r : real for : 1 .. r end for"
 
 ---
 "r"@(FileId(1), 4..5) [Declared]: ref_mut real
 "<root>"@(dummy) [Declared]: <error>
 
-error in file FileId(1) at 19..25: range bounds are not index types
-| note in file FileId(1) for 19..20: this is of type `{integer}`
+error in file FileId(1) at 19..25: mismatched types
 | note in file FileId(1) for 24..25: this is of type `real`
-| info: expected an index type (an integer, `boolean`, `char`, enumerated type, or a range)
+| note in file FileId(1) for 19..20: this is of type `{integer}`
+| error in file FileId(1) for 19..25: expected index types
+| info: range bounds types must both be index types (an integer, `boolean`, `char`, enumerated type, or a range)

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_for_wrong_types_bounds_not_index.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_for_wrong_types_bounds_not_index.snap
@@ -1,11 +1,13 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "for : \"no\" .. \"yes\" end for"
 
 ---
 "<root>"@(dummy) [Declared]: <error>
 
-error in file FileId(1) at 6..19: range bounds are not index types
-| note in file FileId(1) for 6..10: this is of type `string`
-| note in file FileId(1) for 14..19: this is also of type `string`
-| info: expected an index type (an integer, `boolean`, `char`, enumerated type, or a range)
+error in file FileId(1) at 6..19: mismatched types
+| note in file FileId(1) for 14..19: this is of type `string`
+| note in file FileId(1) for 6..10: this is also of type `string`
+| error in file FileId(1) for 6..19: expected index types
+| info: range bounds types must both be index types (an integer, `boolean`, `char`, enumerated type, or a range)

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_for_wrong_types_bounds_not_same.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_for_wrong_types_bounds_not_same.snap
@@ -1,11 +1,13 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "for : 1 .. true end for"
 
 ---
 "<root>"@(dummy) [Declared]: <error>
 
-error in file FileId(1) at 6..15: range bounds are not the same type
-| note in file FileId(1) for 6..7: this is of type `{integer}`
+error in file FileId(1) at 6..15: mismatched types
 | note in file FileId(1) for 11..15: this is of type `boolean`
-| info: `{integer}` is not equivalent to `boolean`
+| note in file FileId(1) for 6..7: this is of type `{integer}`
+| error in file FileId(1) for 6..15: `boolean` is not equivalent to `{integer}`
+| info: range bounds types must be equivalent

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_type_alias_as_expr.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_type_alias_as_expr.snap
@@ -1,0 +1,12 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
+expression: "type k : int var a := k"
+
+---
+"k"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of int
+"a"@(FileId(1), 17..18) [Declared]: ref_mut alias[DefId(LibraryId(0), LocalDefId(0))] of int
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 22..23: cannot use `k` as an expression
+| error in file FileId(1) for 22..23: `k` is a reference to a type

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_type_alias_chained.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_type_alias_chained.snap
@@ -1,0 +1,11 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
+expression: "type a : int\ntype b : a\ntype c : a"
+
+---
+"a"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of int
+"b"@(FileId(1), 18..19) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(1))] of int
+"c"@(FileId(1), 29..30) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(2))] of int
+"<root>"@(dummy) [Declared]: <error>
+

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_type_alias_normal.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_type_alias_normal.snap
@@ -1,0 +1,10 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
+expression: "type a : int var _ : a"
+
+---
+"a"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of int
+"_"@(FileId(1), 17..18) [Declared]: ref_mut alias[DefId(LibraryId(0), LocalDefId(0))] of int
+"<root>"@(dummy) [Declared]: <error>
+

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_type_alias_resolved_forward.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_type_alias_resolved_forward.snap
@@ -1,0 +1,11 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
+expression: "type fowo : forward\ntype fowo : int\nvar _ : fowo"
+
+---
+"fowo"@(FileId(1), 5..9) [Forward(Type, Some(LocalDefId(1)))]: forward
+"fowo"@(FileId(1), 25..29) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(1))] of int
+"_"@(FileId(1), 40..41) [Declared]: ref_mut alias[DefId(LibraryId(0), LocalDefId(1))] of int
+"<root>"@(dummy) [Declared]: <error>
+

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_type_alias_resolved_forward.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_type_alias_resolved_forward.snap
@@ -4,7 +4,7 @@ assertion_line: 41
 expression: "type fowo : forward\ntype fowo : int\nvar _ : fowo"
 
 ---
-"fowo"@(FileId(1), 5..9) [Forward(Type, Some(LocalDefId(1)))]: forward
+"fowo"@(FileId(1), 5..9) [Forward(Type, Some(LocalDefId(1)))]: alias[DefId(LibraryId(0), LocalDefId(0))] of forward
 "fowo"@(FileId(1), 25..29) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(1))] of int
 "_"@(FileId(1), 40..41) [Declared]: ref_mut alias[DefId(LibraryId(0), LocalDefId(1))] of int
 "<root>"@(dummy) [Declared]: <error>

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_type_alias_unresolved_forward.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_type_alias_unresolved_forward.snap
@@ -1,0 +1,10 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
+expression: "type fowo : forward\ntype a : fowo"
+
+---
+"fowo"@(FileId(1), 5..9) [Forward(Type, None)]: forward
+"a"@(FileId(1), 25..26) [Resolved(Type)]: <error>
+"<root>"@(dummy) [Declared]: <error>
+

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_type_alias_unresolved_forward.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_type_alias_unresolved_forward.snap
@@ -4,7 +4,9 @@ assertion_line: 41
 expression: "type fowo : forward\ntype a : fowo"
 
 ---
-"fowo"@(FileId(1), 5..9) [Forward(Type, None)]: forward
+"fowo"@(FileId(1), 5..9) [Forward(Type, None)]: alias[DefId(LibraryId(0), LocalDefId(0))] of forward
 "a"@(FileId(1), 25..26) [Resolved(Type)]: <error>
 "<root>"@(dummy) [Declared]: <error>
 
+error in file FileId(1) at 29..33: `fowo` has not been resolved at this point
+| error in file FileId(1) for 29..33: `fowo` is required to be resolved at this point

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_var_error_prop.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_var_error_prop.snap
@@ -1,5 +1,6 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "var k := 20 + false\nvar l : int := k   % Nothing reported here\n"
 
 ---
@@ -8,7 +9,7 @@ expression: "var k := 20 + false\nvar l : int := k   % Nothing reported here\n"
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 12..13: mismatched types for addition
-| note in file FileId(1) for 9..11: this is of type `{integer}`
 | note in file FileId(1) for 14..19: this is of type `boolean`
+| note in file FileId(1) for 9..11: this is of type `{integer}`
 | error in file FileId(1) for 12..13: `{integer}` cannot be added to `boolean`
 | info: operands must both be numbers, strings, or sets

--- a/compiler/toc_analysis/src/typeck/test.rs
+++ b/compiler/toc_analysis/src/typeck/test.rs
@@ -1066,6 +1066,22 @@ test_named_group! { equivalence_of,
         for : n .. 1 end for
         for : i .. 1 end for
         for : r .. 1 end for
+        "#,
+        aliases => r#"
+        type a0 : int
+        type a1 : int
+        var i : int
+        var ia0 : a0
+        var ia1 : a1
+
+        % base type & alias
+        for : i .. ia0 end for
+        for : i .. ia1 end for
+        for : ia0 .. i end for
+        for : ia1 .. i end for
+        % alias with same base type
+        for : ia0 .. ia1 end for
+        for : ia1 .. ia0 end for
         "#
     ]
 }
@@ -1329,6 +1345,24 @@ test_named_group! {
         var k : int
         case 1 of label k + 1: end case
         "#
+    ]
+}
+
+test_named_group! { typeck_type_alias,
+    [
+        normal => "type a : int var _ : a",
+        chained => "
+        type a : int
+        type b : a
+        type c : a",
+        resolved_forward => "
+        type fowo : forward
+        type fowo : int
+        var _ : fowo",
+        // unresolved forwards can't even be used in type decls
+        unresolved_forward => "
+        type fowo : forward
+        type a : fowo",
     ]
 }
 

--- a/compiler/toc_analysis/src/typeck/test.rs
+++ b/compiler/toc_analysis/src/typeck/test.rs
@@ -1363,6 +1363,7 @@ test_named_group! { typeck_type_alias,
         unresolved_forward => "
         type fowo : forward
         type a : fowo",
+        as_expr => "type k : int var a := k",
     ]
 }
 

--- a/compiler/toc_analysis/src/typeck/test.rs
+++ b/compiler/toc_analysis/src/typeck/test.rs
@@ -1367,6 +1367,13 @@ test_named_group! { typeck_type_alias,
     ]
 }
 
+test_named_group! { require_resolved_type,
+    [
+        in_type_decl => "type fowo : forward type _ : fowo",
+        in_constvar => "type fowo : forward var _ : fowo",
+    ]
+}
+
 test_named_group! { report_aliased_type,
     [
         in_inferred_ty => r#"

--- a/compiler/toc_analysis/src/typeck/test.rs
+++ b/compiler/toc_analysis/src/typeck/test.rs
@@ -62,7 +62,7 @@ fn stringify_typeck_results(
         let def_info = library.local_def(did);
         let name = def_info.name.item();
         let name_span = library.lookup_span(def_info.name.span());
-        let ty = db.aliased_type_of(DefId(lib, did).into());
+        let ty = db.type_of(DefId(lib, did).into());
         let name_fmt = format!("{:?}@{:?} [{:?}]: ", name, name_span, def_info.kind);
 
         s.push_str(&name_fmt);
@@ -1370,22 +1370,25 @@ test_named_group! { report_aliased_type,
     [
         in_inferred_ty => r#"
         type a0 : real
+        type a1 : int
         var k : a0
-        var i : int := k"#,
+        var i : a1 := k"#,
         in_assign => r#"
         type a0 : real
+        type a1 : int
         var k : a0
-        var i : int
+        var i : a1
         i := k"#,
         in_binary_expr => r#"
         type a0 : real
+        type a1 : int
         var k : a0
         var i : int
-        i := i + k"#,
+        i := i + k % unchanged"#,
         in_unary_expr => r#"
         type a0 : real
         var k : a0
-        var _ := not k
+        var _ := not k % unchanged
         "#,
         in_for => r#"
         type a0 : string
@@ -1395,6 +1398,9 @@ test_named_group! { report_aliased_type,
         for : sa0 .. sa0 end for
         for : s .. sa0 end for
         for : sa0 .. s end for
+
+        for : 1 .. sa0 end for
+        for : sa0 .. 1 end for
         "#,
         in_case => r#"
         type a0 : char

--- a/compiler/toc_analysis/src/typeck/test.rs
+++ b/compiler/toc_analysis/src/typeck/test.rs
@@ -62,7 +62,7 @@ fn stringify_typeck_results(
         let def_info = library.local_def(did);
         let name = def_info.name.item();
         let name_span = library.lookup_span(def_info.name.span());
-        let ty = db.type_of(DefId(lib, did).into());
+        let ty = db.aliased_type_of(DefId(lib, did).into());
         let name_fmt = format!("{:?}@{:?} [{:?}]: ", name, name_span, def_info.kind);
 
         s.push_str(&name_fmt);
@@ -1363,6 +1363,49 @@ test_named_group! { typeck_type_alias,
         unresolved_forward => "
         type fowo : forward
         type a : fowo",
+    ]
+}
+
+test_named_group! { report_aliased_type,
+    [
+        in_inferred_ty => r#"
+        type a0 : real
+        var k : a0
+        var i : int := k"#,
+        in_assign => r#"
+        type a0 : real
+        var k : a0
+        var i : int
+        i := k"#,
+        in_binary_expr => r#"
+        type a0 : real
+        var k : a0
+        var i : int
+        i := i + k"#,
+        in_unary_expr => r#"
+        type a0 : real
+        var k : a0
+        var _ := not k
+        "#,
+        in_for => r#"
+        type a0 : string
+        var sa0 : a0
+        var s : string
+
+        for : sa0 .. sa0 end for
+        for : s .. sa0 end for
+        for : sa0 .. s end for
+        "#,
+        in_case => r#"
+        type a0 : char
+        type a1 : char(6)
+        var ca0 : a0
+        const cna1 : a1 := 'aaaaaa'
+
+        case ca0 of
+        label cna1:
+        end case
+        "#,
     ]
 }
 

--- a/compiler/toc_hir/src/builder.rs
+++ b/compiler/toc_hir/src/builder.rs
@@ -68,6 +68,10 @@ impl LibraryBuilder {
         self.add_body(body)
     }
 
+    pub fn local_def_mut(&mut self, def_id: symbol::LocalDefId) -> &mut symbol::DefInfo {
+        &mut self.defs[def_id.into()]
+    }
+
     pub fn finish(self, root_items: Vec<(FileId, item::ItemId)>) -> library::Library {
         let Self { library } = self;
 
@@ -154,7 +158,7 @@ impl BodyBuilder {
         }
     }
 
-    /// Finish as a statment group body
+    /// Finish as a statement group body
     pub fn finish_stmts(
         self,
         body_stmts: Vec<stmt::StmtId>,

--- a/compiler/toc_hir/src/item.rs
+++ b/compiler/toc_hir/src/item.rs
@@ -32,7 +32,8 @@ pub enum ItemKind {
     /// Combined representation for `const` and `var` declarations
     /// (disambiguated by `mutability`)
     ConstVar(ConstVar),
-    // Type { .. },
+    /// Type alias & forward declaration
+    Type(Type),
     // Bind { .. },
     /// general function, rolls up function, procedure, and process
     /// distinguished by return type
@@ -72,32 +73,19 @@ pub struct ConstVar {
     pub init_expr: Option<body::BodyId>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ConstVarTail {
-    /// Only the type spec is specified
-    TypeSpec(ty::TypeId),
-    /// Only the initializer is specified
-    InitExpr(body::BodyId),
-    /// Both the type spec and init expr are specified
-    Both(ty::TypeId, body::BodyId),
+#[derive(Debug, PartialEq, Eq)]
+pub struct Type {
+    pub def_id: symbol::LocalDefId,
+    pub type_def: DefinedType,
 }
 
-impl ConstVarTail {
-    pub fn type_spec(self) -> Option<ty::TypeId> {
-        match self {
-            ConstVarTail::TypeSpec(ty_spec) => Some(ty_spec),
-            ConstVarTail::InitExpr(_) => None,
-            ConstVarTail::Both(ty_spec, _) => Some(ty_spec),
-        }
-    }
-
-    pub fn init_expr(self) -> Option<body::BodyId> {
-        match self {
-            ConstVarTail::TypeSpec(_) => None,
-            ConstVarTail::InitExpr(init_expr) => Some(init_expr),
-            ConstVarTail::Both(_, init_expr) => Some(init_expr),
-        }
-    }
+#[derive(Debug, PartialEq, Eq)]
+pub enum DefinedType {
+    /// Declaring an alias of a type
+    Alias(ty::TypeId),
+    /// Declaring a forward declaration of a type.
+    /// Provided SpanId is the span of the token
+    Forward(SpanId),
 }
 
 #[derive(Debug, PartialEq, Eq)]

--- a/compiler/toc_hir/src/symbol.rs
+++ b/compiler/toc_hir/src/symbol.rs
@@ -41,11 +41,21 @@ pub enum SymbolKind {
     Undeclared,
     /// The symbol is a normal declaration at the point of definition.
     Declared,
-    /// The symbol is a forward reference to a later declaration.
-    Forward,
-    /// The symbol is a resolution of a forward declaration, with a `DefId`
-    /// pointing back to the original forward declaration symbol.
-    Resolved(DefId),
+    /// The symbol is a forward reference to a later declaration,
+    /// with a [`LocaLDefId`] pointing to the resolving definition.
+    Forward(ForwardKind, Option<LocalDefId>),
+    /// The symbol is a resolution of a forward declaration.
+    Resolved(ForwardKind),
+}
+
+/// Disambiguates between different forward declaration kinds
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ForwardKind {
+    /// `type` forward declaration
+    Type,
+    /// `procedure` forward declaration
+    // Only constructed in tests right now
+    _Procedure,
 }
 
 /// Any HIR node that contains a definition

--- a/compiler/toc_hir/src/symbol.rs
+++ b/compiler/toc_hir/src/symbol.rs
@@ -42,7 +42,7 @@ pub enum SymbolKind {
     /// The symbol is a normal declaration at the point of definition.
     Declared,
     /// The symbol is a forward reference to a later declaration,
-    /// with a [`LocaLDefId`] pointing to the resolving definition.
+    /// with a [`LocalDefId`] pointing to the resolving definition.
     Forward(ForwardKind, Option<LocalDefId>),
     /// The symbol is a resolution of a forward declaration.
     Resolved(ForwardKind),

--- a/compiler/toc_hir/src/ty.rs
+++ b/compiler/toc_hir/src/ty.rs
@@ -7,8 +7,8 @@ use toc_span::SpanId;
 
 pub use crate::ids::TypeId;
 
-use crate::body;
 use crate::ids::TypeIndex;
+use crate::{body, symbol};
 
 /// An interner for HIR types
 #[derive(Debug, Default, PartialEq, Eq)]
@@ -47,6 +47,8 @@ pub enum TypeKind {
     Missing,
     /// Primitive Type
     Primitive(Primitive),
+    /// Alias Type
+    Alias(Alias),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -78,3 +80,7 @@ pub enum SeqLength {
     /// that might be computable at compile time.
     Expr(body::BodyId),
 }
+
+// FIXME: Use the proper representation of an item path
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct Alias(pub symbol::LocalDefId);

--- a/compiler/toc_hir/src/visitor.rs
+++ b/compiler/toc_hir/src/visitor.rs
@@ -53,6 +53,7 @@ pub trait HirVisitor {
         self.specify_type(id, ty);
     }
     fn visit_primitive(&self, id: ty::TypeId, ty: &ty::Primitive) {}
+    fn visit_alias(&self, id: ty::TypeId, ty: &ty::Alias) {}
 
     // Node specification //
 
@@ -93,6 +94,7 @@ pub trait HirVisitor {
         match &ty.kind {
             ty::TypeKind::Missing => {}
             ty::TypeKind::Primitive(ty) => self.visit_primitive(id, ty),
+            ty::TypeKind::Alias(ty) => self.visit_alias(id, ty),
         }
     }
 }
@@ -442,6 +444,7 @@ impl<'hir> Walker<'hir> {
         match &node.kind {
             ty::TypeKind::Missing => {}
             ty::TypeKind::Primitive(ty) => self.walk_primitive(ty),
+            ty::TypeKind::Alias(_) => {}
         }
     }
 

--- a/compiler/toc_hir/src/visitor.rs
+++ b/compiler/toc_hir/src/visitor.rs
@@ -22,6 +22,7 @@ pub trait HirVisitor {
         self.specify_item(id, item);
     }
     fn visit_constvar(&self, id: item::ItemId, item: &item::ConstVar) {}
+    fn visit_type_decl(&self, id: item::ItemId, item: &item::Type) {}
     fn visit_module(&self, id: item::ItemId, item: &item::Module) {}
     // Body
     fn visit_body(&self, id: body::BodyId, body: &body::Body) {}
@@ -58,6 +59,7 @@ pub trait HirVisitor {
     fn specify_item(&self, id: item::ItemId, item: &item::Item) {
         match &item.kind {
             item::ItemKind::ConstVar(item) => self.visit_constvar(id, item),
+            item::ItemKind::Type(item) => self.visit_type_decl(id, item),
             item::ItemKind::Module(item) => self.visit_module(id, item),
         }
     }
@@ -270,6 +272,7 @@ impl<'hir> Walker<'hir> {
     fn walk_item(&mut self, item: &item::Item) {
         match &item.kind {
             item::ItemKind::ConstVar(item) => self.walk_constvar(item),
+            item::ItemKind::Type(item) => self.walk_type_decl(item),
             item::ItemKind::Module(item) => self.walk_module(item),
         }
     }
@@ -281,6 +284,13 @@ impl<'hir> Walker<'hir> {
 
         if let Some(id) = node.init_expr {
             self.enter_body(id, self.lib.body(id));
+        }
+    }
+
+    fn walk_type_decl(&mut self, node: &item::Type) {
+        match node.type_def {
+            item::DefinedType::Alias(ty) => self.enter_type(ty, self.lib.lookup_type(ty)),
+            item::DefinedType::Forward(_) => {}
         }
     }
 

--- a/compiler/toc_hir_codegen/src/lib.rs
+++ b/compiler/toc_hir_codegen/src/lib.rs
@@ -2148,7 +2148,10 @@ impl CodeFragment {
                 self.emit_opcode(Opcode::PUSHINT(char_len.into_u32().expect("not a u32")));
                 Opcode::ASNSTRINV()
             }
-            ty::TypeKind::Ref(_, _) | ty::TypeKind::Error => unreachable!(),
+            ty::TypeKind::Ref(_, _)
+            | ty::TypeKind::Error
+            | ty::TypeKind::Forward
+            | ty::TypeKind::Alias(_, _) => unreachable!(),
         };
 
         self.emit_opcode(opcode);
@@ -2190,7 +2193,10 @@ impl CodeFragment {
                 self.emit_opcode(Opcode::PUSHINT(char_len.into_u32().expect("not a u32")));
                 Opcode::ASNSTR()
             }
-            ty::TypeKind::Ref(_, _) | ty::TypeKind::Error => unreachable!(),
+            ty::TypeKind::Ref(_, _)
+            | ty::TypeKind::Error
+            | ty::TypeKind::Forward
+            | ty::TypeKind::Alias(_, _) => unreachable!(),
         };
 
         self.emit_opcode(opcode);
@@ -2230,7 +2236,10 @@ impl CodeFragment {
             ty::TypeKind::Char => Opcode::FETCHNAT1(), // chars are equivalent to nat1 on regular Turing backend
             ty::TypeKind::String | ty::TypeKind::StringN(_) => Opcode::FETCHSTR(),
             ty::TypeKind::CharN(_) => return, // don't need to dereference the pointer to storage
-            ty::TypeKind::Error | ty::TypeKind::Ref(_, _) => unreachable!(),
+            ty::TypeKind::Ref(_, _)
+            | ty::TypeKind::Error
+            | ty::TypeKind::Forward
+            | ty::TypeKind::Alias(_, _) => unreachable!(),
         };
 
         self.emit_opcode(opcode);

--- a/compiler/toc_hir_codegen/src/lib.rs
+++ b/compiler/toc_hir_codegen/src/lib.rs
@@ -1404,6 +1404,7 @@ impl BodyCodeGenerator<'_> {
 
         match &item.kind {
             hir_item::ItemKind::ConstVar(item) => self.generate_item_constvar(item),
+            hir_item::ItemKind::Type(_) => {}
             hir_item::ItemKind::Module(_) => {
                 // We already generate code for module bodies as part of walking
                 // over all of the bodies in a library

--- a/compiler/toc_hir_db/src/query.rs
+++ b/compiler/toc_hir_db/src/query.rs
@@ -67,6 +67,10 @@ impl HirVisitor for DefCollector {
         self.add_owner(item.def_id, DefOwner::Item(id));
     }
 
+    fn visit_type_decl(&self, id: item::ItemId, item: &item::Type) {
+        self.add_owner(item.def_id, DefOwner::Item(id));
+    }
+
     fn visit_for(&self, id: stmt::BodyStmt, stmt: &stmt::For) {
         if let Some(def_id) = stmt.counter_def {
             self.add_owner(def_id, DefOwner::Stmt(id))

--- a/compiler/toc_hir_lowering/src/lower.rs
+++ b/compiler/toc_hir_lowering/src/lower.rs
@@ -214,6 +214,22 @@ impl<'ctx> FileLowering<'ctx> {
         let span = self.mk_span(range);
         self.library.intern_span(span)
     }
+
+    // Helper for using a symbol, handling undeclared reporting
+    fn use_sym(&mut self, name: &str, span: Span) -> LocalDefId {
+        self.scopes.use_sym(name, || {
+            // make an undeclared
+            self.messages.error(
+                &format!("`{}` is undeclared", name),
+                &format!("no definitions of `{}` are in scope", name),
+                span,
+            );
+
+            let span = self.library.intern_span(span);
+            self.library
+                .add_def(name, span, symbol::SymbolKind::Undeclared)
+        })
+    }
 }
 
 /// For lowering things within a body

--- a/compiler/toc_hir_lowering/src/lower/expr.rs
+++ b/compiler/toc_hir_lowering/src/lower/expr.rs
@@ -1,5 +1,5 @@
 //! Lowering into `Expr` HIR nodes
-use toc_hir::{body, expr, symbol};
+use toc_hir::{body, expr};
 use toc_span::{Span, SpanId, Spanned};
 use toc_syntax::ast::{self, AstNode};
 use toc_syntax::LiteralValue;
@@ -131,19 +131,8 @@ impl super::BodyLowering<'_, '_> {
     fn lower_name_expr(&mut self, expr: ast::NameExpr) -> Option<expr::ExprKind> {
         let name = expr.name()?.identifier_token()?;
         let span = self.ctx.mk_span(name.text_range());
+        let def_id = self.ctx.use_sym(name.text(), span);
 
-        let def_id = self.ctx.scopes.use_sym(name.text(), || {
-            // make an undeclared
-            self.ctx.messages.error(
-                &format!("`{}` is undeclared", name.text()),
-                &format!("no definitions of `{}` are in scope", name.text()),
-                span,
-            );
-
-            let library = &mut self.ctx.library;
-            let span = library.intern_span(span);
-            library.add_def(name.text(), span, symbol::SymbolKind::Undeclared)
-        });
         Some(expr::ExprKind::Name(expr::Name::Name(def_id)))
     }
 }

--- a/compiler/toc_hir_lowering/src/lower/ty.rs
+++ b/compiler/toc_hir_lowering/src/lower/ty.rs
@@ -4,6 +4,19 @@ use toc_span::Span;
 use toc_syntax::ast::{self, AstNode};
 
 impl super::BodyLowering<'_, '_> {
+    /// Lowers a required type. If not present, constructs a `Type::Missing` node in-place
+    pub(super) fn lower_required_type(&mut self, ty: Option<ast::Type>) -> ty::TypeId {
+        ty.and_then(|ty| self.lower_type(ty)).unwrap_or_else(|| {
+            // Allocate a generic span
+            let ty = ty::Type {
+                kind: ty::TypeKind::Missing,
+                span: self.ctx.library.span_map.dummy_span(),
+            };
+            self.ctx.library.intern_type(ty)
+        })
+    }
+
+    /// Lowers a type.
     pub(super) fn lower_type(&mut self, ty: ast::Type) -> Option<ty::TypeId> {
         let span = self.ctx.mk_span(ty.syntax().text_range());
 

--- a/compiler/toc_hir_lowering/src/scopes/test.rs
+++ b/compiler/toc_hir_lowering/src/scopes/test.rs
@@ -1,5 +1,5 @@
 //! Scope testing
-use toc_hir::symbol::LocalDefId;
+use toc_hir::symbol::{ForwardKind, LocalDefId, SymbolKind};
 
 use super::ScopeTracker;
 
@@ -31,7 +31,7 @@ fn test_ident_declare_use() {
     let mut defs = LocalDefAlloc::default();
 
     let def_id = defs.next();
-    scopes.def_sym("a", def_id, false);
+    scopes.def_sym("a", def_id, SymbolKind::Declared, false);
     let lookup_id = scopes.use_sym("a", assert_declared);
 
     assert_eq!(def_id, lookup_id);
@@ -44,12 +44,12 @@ fn test_ident_redeclare() {
 
     // First decl, pass
     let initial_id = defs.next();
-    let old_def = scopes.def_sym("a", initial_id, false);
+    let old_def = scopes.def_sym("a", initial_id, SymbolKind::Declared, false);
     assert_eq!(old_def, None);
 
     // Redecl, have different ids
     let redeclare_id = defs.next();
-    let old_def = scopes.def_sym("a", redeclare_id, false);
+    let old_def = scopes.def_sym("a", redeclare_id, SymbolKind::Declared, false);
 
     assert_ne!(initial_id, redeclare_id);
     // Should be the initial id
@@ -64,13 +64,13 @@ fn test_ident_declare_shadow() {
 
     // Outer declare
     let outer_def = defs.next();
-    let old_def = scopes.def_sym("a", outer_def, false);
+    let old_def = scopes.def_sym("a", outer_def, SymbolKind::Declared, false);
     assert_eq!(old_def, None);
 
     // Inner declare
     scopes.with_scope(false, |scopes| {
         let shadow_def = defs.next();
-        let old_def = scopes.def_sym("a", shadow_def, false);
+        let old_def = scopes.def_sym("a", shadow_def, SymbolKind::Declared, false);
 
         // Identifiers should be different
         assert_ne!(shadow_def, outer_def);
@@ -93,7 +93,7 @@ fn test_ident_declare_no_shadow() {
     // Inner declare
     let (shadow_def, shadow_use) = scopes.with_scope(false, |scopes| {
         let shadow_def = defs.next();
-        let old_def = scopes.def_sym("a", shadow_def, false);
+        let old_def = scopes.def_sym("a", shadow_def, SymbolKind::Declared, false);
         let shadow_use = scopes.use_sym("a", assert_declared);
 
         assert!(old_def.is_none());
@@ -103,7 +103,7 @@ fn test_ident_declare_no_shadow() {
 
     // Outer declare
     let outer_def = defs.next();
-    let old_def = scopes.def_sym("a", outer_def, false);
+    let old_def = scopes.def_sym("a", outer_def, SymbolKind::Declared, false);
     let outer_use = scopes.use_sym("a", assert_declared);
 
     // No shadowing should be done, outer_use should match outer_def,
@@ -165,7 +165,7 @@ fn test_use_import() {
 
     // Root declare
     let declare_id = defs.next();
-    scopes.def_sym("a", declare_id, false);
+    scopes.def_sym("a", declare_id, SymbolKind::Declared, false);
 
     // Inner use
     scopes.with_scope(false, |scopes| {
@@ -183,9 +183,9 @@ fn test_import_boundaries() {
 
     // Declare some external identifiers
     let non_pervasive = defs.next();
-    scopes.def_sym("non_pervasive", non_pervasive, false);
+    scopes.def_sym("non_pervasive", non_pervasive, SymbolKind::Declared, false);
     let pervasive = defs.next();
-    scopes.def_sym("pervasive", pervasive, true);
+    scopes.def_sym("pervasive", pervasive, SymbolKind::Declared, true);
     let undecl = scopes.use_sym("undecl", make_undeclared(&mut defs));
 
     // Make an inner block
@@ -213,4 +213,201 @@ fn test_import_boundaries() {
             assert_ne!(undecl_use_c, undecl);
         });
     });
+}
+
+#[test]
+fn test_forward_declare() {
+    let mut scopes = ScopeTracker::new();
+    let mut defs = LocalDefAlloc::default();
+
+    let forward_def = defs.next();
+    scopes.def_sym(
+        "fwd",
+        forward_def,
+        SymbolKind::Forward(ForwardKind::Type, None),
+        false,
+    );
+    let resolve_def = defs.next();
+    scopes.def_sym(
+        "fwd",
+        resolve_def,
+        SymbolKind::Resolved(ForwardKind::Type),
+        false,
+    );
+
+    assert_eq!(scopes.use_sym("fwd", assert_declared), resolve_def);
+    assert_eq!(
+        scopes.take_resolved_forwards("fwd", ForwardKind::Type),
+        Some(vec![forward_def])
+    );
+}
+
+#[test]
+fn test_forward_declare_double() {
+    // Forward declares in the same scope should be captured
+    // when resolving them
+    let mut scopes = ScopeTracker::new();
+    let mut defs = LocalDefAlloc::default();
+
+    let forward_def0 = defs.next();
+    scopes.def_sym(
+        "fwd",
+        forward_def0,
+        SymbolKind::Forward(ForwardKind::Type, None),
+        false,
+    );
+    let forward_def1 = defs.next();
+    scopes.def_sym(
+        "fwd",
+        forward_def1,
+        SymbolKind::Forward(ForwardKind::Type, None),
+        false,
+    );
+
+    let resolve_def = defs.next();
+    scopes.def_sym(
+        "fwd",
+        resolve_def,
+        SymbolKind::Resolved(ForwardKind::Type),
+        false,
+    );
+
+    assert_eq!(scopes.use_sym("fwd", assert_declared), resolve_def);
+    assert_eq!(
+        scopes.take_resolved_forwards("fwd", ForwardKind::Type),
+        Some(vec![forward_def0, forward_def1])
+    );
+}
+
+#[test]
+fn test_forward_declare_overwritten() {
+    // Later forward declares of different types should replace old forward lists
+    let mut scopes = ScopeTracker::new();
+    let mut defs = LocalDefAlloc::default();
+
+    let forward_type = defs.next();
+    let forward_proc = defs.next();
+    let resolve_def = defs.next();
+
+    scopes.def_sym(
+        "fwd",
+        forward_type,
+        SymbolKind::Forward(ForwardKind::Type, None),
+        false,
+    );
+    scopes.def_sym(
+        "fwd",
+        forward_proc,
+        SymbolKind::Forward(ForwardKind::_Procedure, None),
+        false,
+    );
+
+    scopes.def_sym(
+        "fwd",
+        resolve_def,
+        SymbolKind::Resolved(ForwardKind::Type),
+        false,
+    );
+
+    assert_eq!(scopes.use_sym("fwd", assert_declared), resolve_def);
+    assert_eq!(
+        scopes.take_resolved_forwards("fwd", ForwardKind::Type),
+        None
+    );
+}
+
+#[test]
+fn test_forward_declare_overwritten_normal() {
+    // Normal declarations should overwrite forward lists
+    let mut scopes = ScopeTracker::new();
+    let mut defs = LocalDefAlloc::default();
+
+    let forward_type = defs.next();
+    let normal_def = defs.next();
+    let resolve_def = defs.next();
+
+    scopes.def_sym(
+        "fwd",
+        forward_type,
+        SymbolKind::Forward(ForwardKind::Type, None),
+        false,
+    );
+    scopes.def_sym("fwd", normal_def, SymbolKind::Declared, false);
+
+    scopes.def_sym(
+        "fwd",
+        resolve_def,
+        SymbolKind::Resolved(ForwardKind::Type),
+        false,
+    );
+
+    assert_eq!(scopes.use_sym("fwd", assert_declared), resolve_def);
+    assert_eq!(
+        scopes.take_resolved_forwards("fwd", ForwardKind::Type),
+        None
+    );
+}
+
+#[test]
+fn test_forward_resolve_only_same_scope() {
+    // Forward declares are only resolved in the same scope,
+    // doesn't matter if it's an import boundary,
+    // doesn't matter if the identifier is pervasive or not
+    let mut scopes = ScopeTracker::new();
+    let mut defs = LocalDefAlloc::default();
+
+    let forward_def = defs.next();
+    let inner_def = defs.next();
+    let resolve_def = defs.next();
+
+    // def scope def
+    scopes.def_sym(
+        "fwd",
+        forward_def,
+        SymbolKind::Forward(ForwardKind::Type, None),
+        true,
+    );
+
+    // Not import boundary
+    scopes.with_scope(false, |scopes| {
+        scopes.def_sym(
+            "fwd",
+            inner_def,
+            SymbolKind::Forward(ForwardKind::Type, None),
+            false,
+        );
+
+        assert_eq!(
+            scopes.take_resolved_forwards("fwd", ForwardKind::Type),
+            Some(vec![inner_def])
+        );
+    });
+
+    // Is import boundary
+    scopes.with_scope(true, |scopes| {
+        scopes.def_sym(
+            "fwd",
+            inner_def,
+            SymbolKind::Forward(ForwardKind::Type, None),
+            false,
+        );
+
+        assert_eq!(
+            scopes.take_resolved_forwards("fwd", ForwardKind::Type),
+            Some(vec![inner_def])
+        );
+    });
+
+    scopes.def_sym(
+        "fwd",
+        resolve_def,
+        SymbolKind::Resolved(ForwardKind::Type),
+        false,
+    );
+
+    assert_eq!(scopes.use_sym("fwd", assert_declared), resolve_def);
+    assert_eq!(
+        scopes.take_resolved_forwards("fwd", ForwardKind::Type),
+        Some(vec![forward_def])
+    );
 }

--- a/compiler/toc_hir_lowering/tests/lowering.rs
+++ b/compiler/toc_hir_lowering/tests/lowering.rs
@@ -738,13 +738,41 @@ fn lower_type_def() {
 }
 
 #[test]
+fn lower_type_alias() {
+    assert_lower(
+        "
+    type a : int
+    type use_it : a
+    var _ : a
+    ",
+    );
+    // type aliases also cover general expressions in type position, which are invalid
+    assert_lower(
+        "
+    type a : 1 + 1
+    ",
+    );
+}
+
+#[test]
+fn lower_type_path() {
+    // Type paths aren't supported yet
+    assert_lower(
+        "
+    type a : int
+    type not_yet: a.b.c.d.e
+    ",
+    );
+}
+
+#[test]
 fn lower_type_def_forward() {
     // Normal
     assert_lower(
         "
     type a : forward
-    type a : int
     type use_it : a
+    type a : int
     ",
     );
     // Duplicate forward declare
@@ -752,8 +780,8 @@ fn lower_type_def_forward() {
         "
     type a : forward
     type a : forward
-    type a : int
     type use_it : a
+    type a : int
     ",
     );
     // Must be resolved in the same scope

--- a/compiler/toc_hir_lowering/tests/lowering.rs
+++ b/compiler/toc_hir_lowering/tests/lowering.rs
@@ -736,3 +736,44 @@ fn lower_type_def() {
     // missing name
     assert_lower("type : forward");
 }
+
+#[test]
+fn lower_type_def_forward() {
+    // Normal
+    assert_lower(
+        "
+    type a : forward
+    type a : int
+    type use_it : a
+    ",
+    );
+    // Duplicate forward declare
+    assert_lower(
+        "
+    type a : forward
+    type a : forward
+    type a : int
+    type use_it : a
+    ",
+    );
+    // Must be resolved in the same scope
+    assert_lower(
+        "
+    type a : forward
+    begin
+        type a : int
+    end
+    type use_it : a
+    ",
+    );
+    // Different declarations should leave forwards unresolved
+    assert_lower(
+        "
+    type a : forward
+    type use_it : a % should not be resolved to latter a
+    var a : int
+    type a : char
+    ",
+    );
+    // TODO: Add test for different forward kinds
+}

--- a/compiler/toc_hir_lowering/tests/lowering.rs
+++ b/compiler/toc_hir_lowering/tests/lowering.rs
@@ -724,3 +724,15 @@ fn lower_case_stmt() {
     "#,
     );
 }
+
+#[test]
+fn lower_type_def() {
+    // with type
+    assert_lower("type alias : int");
+    // with forward
+    assert_lower("type alias : forward");
+    // missing defined
+    assert_lower("type alias : ");
+    // missing name
+    assert_lower("type : forward");
+}

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_type_alias-2.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_type_alias-2.snap
@@ -1,0 +1,15 @@
+---
+source: compiler/toc_hir_lowering/tests/lowering.rs
+assertion_line: 59
+expression: "\n    type a : 1 + 1\n    "
+
+---
+Library@(dummy)
+  Root@(dummy): FileId(1) -> ItemId(1)
+    Module@(FileId(1), 0..24): "<root>"@(dummy)
+      StmtBody@(FileId(1), 5..19): []
+        StmtItem@(FileId(1), 5..19): ItemId(0)
+          Type@(FileId(1), 5..19): "a"@(FileId(1), 10..11)
+error in file FileId(1) at 14..19: invalid type
+| error in file FileId(1) for 14..19: expressions can't be used as types
+

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_type_alias.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_type_alias.snap
@@ -1,0 +1,20 @@
+---
+source: compiler/toc_hir_lowering/tests/lowering.rs
+assertion_line: 59
+expression: "\n    type a : int\n    type use_it : a\n    var _ : a\n    "
+
+---
+Library@(dummy)
+  Root@(dummy): FileId(1) -> ItemId(3)
+    Module@(FileId(1), 0..56): "<root>"@(dummy)
+      StmtBody@(FileId(1), 5..51): []
+        StmtItem@(FileId(1), 5..17): ItemId(0)
+          Type@(FileId(1), 5..17): "a"@(FileId(1), 10..11)
+            Primitive@(FileId(1), 14..17): Int
+        StmtItem@(FileId(1), 22..37): ItemId(1)
+          Type@(FileId(1), 22..37): "use_it"@(FileId(1), 27..33)
+            Alias@(FileId(1), 36..37): "a"@(FileId(1), 10..11), resolved(Type)
+        StmtItem@(FileId(1), 42..51): ItemId(2)
+          ConstVar@(FileId(1), 42..51): var "_"@(FileId(1), 46..47)
+            Alias@(FileId(1), 50..51): "a"@(FileId(1), 10..11), resolved(Type)
+

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_type_def-2.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_type_def-2.snap
@@ -1,0 +1,13 @@
+---
+source: compiler/toc_hir_lowering/tests/lowering.rs
+assertion_line: 59
+expression: "type alias : forward"
+
+---
+Library@(dummy)
+  Root@(dummy): FileId(1) -> ItemId(1)
+    Module@(FileId(1), 0..20): "<root>"@(dummy)
+      StmtBody@(FileId(1), 0..20): []
+        StmtItem@(FileId(1), 0..20): ItemId(0)
+          Type@(FileId(1), 0..20): forward "alias"@(FileId(1), 5..10)
+

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_type_def-3.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_type_def-3.snap
@@ -1,0 +1,15 @@
+---
+source: compiler/toc_hir_lowering/tests/lowering.rs
+assertion_line: 59
+expression: "type alias : "
+
+---
+Library@(dummy)
+  Root@(dummy): FileId(1) -> ItemId(1)
+    Module@(FileId(1), 0..13): "<root>"@(dummy)
+      StmtBody@(FileId(1), 0..12): []
+        StmtItem@(FileId(1), 0..12): ItemId(0)
+          Type@(FileId(1), 0..12): "alias"@(FileId(1), 5..10)
+error in file FileId(1) at 11..12: unexpected end of file
+| error in file FileId(1) for 11..12: expected type specifier after here
+

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_type_def-4.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_type_def-4.snap
@@ -1,0 +1,13 @@
+---
+source: compiler/toc_hir_lowering/tests/lowering.rs
+assertion_line: 59
+expression: "type : forward"
+
+---
+Library@(dummy)
+  Root@(dummy): FileId(1) -> ItemId(0)
+    Module@(FileId(1), 0..14): "<root>"@(dummy)
+      StmtBody@(FileId(1), 0..14): []
+error in file FileId(1) at 5..6: unexpected token
+| error in file FileId(1) for 5..6: expected identifier, but found ‘:’
+

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_type_def.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_type_def.snap
@@ -1,0 +1,14 @@
+---
+source: compiler/toc_hir_lowering/tests/lowering.rs
+assertion_line: 59
+expression: "type alias : int"
+
+---
+Library@(dummy)
+  Root@(dummy): FileId(1) -> ItemId(1)
+    Module@(FileId(1), 0..16): "<root>"@(dummy)
+      StmtBody@(FileId(1), 0..16): []
+        StmtItem@(FileId(1), 0..16): ItemId(0)
+          Type@(FileId(1), 0..16): "alias"@(FileId(1), 5..10)
+            Primitive@(FileId(1), 13..16): Int
+

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_type_def_forward-2.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_type_def_forward-2.snap
@@ -1,0 +1,25 @@
+---
+source: compiler/toc_hir_lowering/tests/lowering.rs
+assertion_line: 59
+expression: "\n    type a : forward\n    type a : forward\n    type a : int\n    type use_it : a\n    "
+
+---
+Library@(dummy)
+  Root@(dummy): FileId(1) -> ItemId(4)
+    Module@(FileId(1), 0..84): "<root>"@(dummy)
+      StmtBody@(FileId(1), 5..79): []
+        StmtItem@(FileId(1), 5..21): ItemId(0)
+          Type@(FileId(1), 5..21): forward "a"@(FileId(1), 10..11)
+        StmtItem@(FileId(1), 26..42): ItemId(1)
+          Type@(FileId(1), 26..42): forward "a"@(FileId(1), 31..32)
+        StmtItem@(FileId(1), 47..59): ItemId(2)
+          Type@(FileId(1), 47..59): "a"@(FileId(1), 52..53)
+            Primitive@(FileId(1), 56..59): Int
+        StmtItem@(FileId(1), 64..79): ItemId(3)
+          Type@(FileId(1), 64..79): "use_it"@(FileId(1), 69..75)
+error in file FileId(1) at 31..32: `a` is already a forward declaration
+| note in file FileId(1) for 10..11: previous forward declaration here
+| error in file FileId(1) for 31..32: new one here
+error in file FileId(1) at 78..79: unsupported type
+| error in file FileId(1) for 78..79: this type is not handled yet
+

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_type_def_forward-2.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_type_def_forward-2.snap
@@ -1,7 +1,7 @@
 ---
 source: compiler/toc_hir_lowering/tests/lowering.rs
 assertion_line: 59
-expression: "\n    type a : forward\n    type a : forward\n    type a : int\n    type use_it : a\n    "
+expression: "\n    type a : forward\n    type a : forward\n    type use_it : a\n    type a : int\n    "
 
 ---
 Library@(dummy)
@@ -12,14 +12,13 @@ Library@(dummy)
           Type@(FileId(1), 5..21): forward "a"@(FileId(1), 10..11)
         StmtItem@(FileId(1), 26..42): ItemId(1)
           Type@(FileId(1), 26..42): forward "a"@(FileId(1), 31..32)
-        StmtItem@(FileId(1), 47..59): ItemId(2)
-          Type@(FileId(1), 47..59): "a"@(FileId(1), 52..53)
-            Primitive@(FileId(1), 56..59): Int
-        StmtItem@(FileId(1), 64..79): ItemId(3)
-          Type@(FileId(1), 64..79): "use_it"@(FileId(1), 69..75)
+        StmtItem@(FileId(1), 47..62): ItemId(2)
+          Type@(FileId(1), 47..62): "use_it"@(FileId(1), 52..58)
+            Alias@(FileId(1), 61..62): "a"@(FileId(1), 31..32), forward(Type) -> "a"@(FileId(1), 72..73)
+        StmtItem@(FileId(1), 67..79): ItemId(3)
+          Type@(FileId(1), 67..79): "a"@(FileId(1), 72..73)
+            Primitive@(FileId(1), 76..79): Int
 error in file FileId(1) at 31..32: `a` is already a forward declaration
 | note in file FileId(1) for 10..11: previous forward declaration here
 | error in file FileId(1) for 31..32: new one here
-error in file FileId(1) at 78..79: unsupported type
-| error in file FileId(1) for 78..79: this type is not handled yet
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_type_def_forward-3.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_type_def_forward-3.snap
@@ -16,9 +16,8 @@ Library@(dummy)
               Primitive@(FileId(1), 49..52): Int
         StmtItem@(FileId(1), 65..80): ItemId(2)
           Type@(FileId(1), 65..80): "use_it"@(FileId(1), 70..76)
+            Alias@(FileId(1), 79..80): "a"@(FileId(1), 10..11), unresolved forward(Type)
 error in file FileId(1) at 45..46: `a` must be resolved in the same scope
 | note in file FileId(1) for 10..11: forward declaration of `a` here
 | error in file FileId(1) for 45..46: resolution of `a` is not in the same scope
-error in file FileId(1) at 79..80: unsupported type
-| error in file FileId(1) for 79..80: this type is not handled yet
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_type_def_forward-3.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_type_def_forward-3.snap
@@ -1,0 +1,24 @@
+---
+source: compiler/toc_hir_lowering/tests/lowering.rs
+assertion_line: 59
+expression: "\n    type a : forward\n    begin\n        type a : int\n    end\n    type use_it : a\n    "
+
+---
+Library@(dummy)
+  Root@(dummy): FileId(1) -> ItemId(3)
+    Module@(FileId(1), 0..85): "<root>"@(dummy)
+      StmtBody@(FileId(1), 5..80): []
+        StmtItem@(FileId(1), 5..21): ItemId(0)
+          Type@(FileId(1), 5..21): forward "a"@(FileId(1), 10..11)
+        Block@(FileId(1), 26..60): Normal
+          StmtItem@(FileId(1), 40..52): ItemId(1)
+            Type@(FileId(1), 40..52): "a"@(FileId(1), 45..46)
+              Primitive@(FileId(1), 49..52): Int
+        StmtItem@(FileId(1), 65..80): ItemId(2)
+          Type@(FileId(1), 65..80): "use_it"@(FileId(1), 70..76)
+error in file FileId(1) at 45..46: `a` must be resolved in the same scope
+| note in file FileId(1) for 10..11: forward declaration of `a` here
+| error in file FileId(1) for 45..46: resolution of `a` is not in the same scope
+error in file FileId(1) at 79..80: unsupported type
+| error in file FileId(1) for 79..80: this type is not handled yet
+

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_type_def_forward-4.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_type_def_forward-4.snap
@@ -12,14 +12,13 @@ Library@(dummy)
           Type@(FileId(1), 5..21): forward "a"@(FileId(1), 10..11)
         StmtItem@(FileId(1), 26..41): ItemId(1)
           Type@(FileId(1), 26..41): "use_it"@(FileId(1), 31..37)
+            Alias@(FileId(1), 40..41): "a"@(FileId(1), 10..11), unresolved forward(Type)
         StmtItem@(FileId(1), 83..94): ItemId(2)
           ConstVar@(FileId(1), 83..94): var "a"@(FileId(1), 87..88)
             Primitive@(FileId(1), 91..94): Int
         StmtItem@(FileId(1), 99..112): ItemId(3)
           Type@(FileId(1), 99..112): "a"@(FileId(1), 104..105)
             Primitive@(FileId(1), 108..112): Char
-error in file FileId(1) at 40..41: unsupported type
-| error in file FileId(1) for 40..41: this type is not handled yet
 error in file FileId(1) at 87..88: `a` is already declared in this scope
 | note in file FileId(1) for 10..11: `a` previously declared here
 | error in file FileId(1) for 87..88: `a` redeclared here

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_type_def_forward-4.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_type_def_forward-4.snap
@@ -1,0 +1,29 @@
+---
+source: compiler/toc_hir_lowering/tests/lowering.rs
+assertion_line: 59
+expression: "\n    type a : forward\n    type use_it : a % should not be resolved to latter a\n    var a : int\n    type a : char\n    "
+
+---
+Library@(dummy)
+  Root@(dummy): FileId(1) -> ItemId(4)
+    Module@(FileId(1), 0..117): "<root>"@(dummy)
+      StmtBody@(FileId(1), 5..112): []
+        StmtItem@(FileId(1), 5..21): ItemId(0)
+          Type@(FileId(1), 5..21): forward "a"@(FileId(1), 10..11)
+        StmtItem@(FileId(1), 26..41): ItemId(1)
+          Type@(FileId(1), 26..41): "use_it"@(FileId(1), 31..37)
+        StmtItem@(FileId(1), 83..94): ItemId(2)
+          ConstVar@(FileId(1), 83..94): var "a"@(FileId(1), 87..88)
+            Primitive@(FileId(1), 91..94): Int
+        StmtItem@(FileId(1), 99..112): ItemId(3)
+          Type@(FileId(1), 99..112): "a"@(FileId(1), 104..105)
+            Primitive@(FileId(1), 108..112): Char
+error in file FileId(1) at 40..41: unsupported type
+| error in file FileId(1) for 40..41: this type is not handled yet
+error in file FileId(1) at 87..88: `a` is already declared in this scope
+| note in file FileId(1) for 10..11: `a` previously declared here
+| error in file FileId(1) for 87..88: `a` redeclared here
+error in file FileId(1) at 104..105: `a` is already declared in this scope
+| note in file FileId(1) for 87..88: `a` previously declared here
+| error in file FileId(1) for 104..105: `a` redeclared here
+

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_type_def_forward.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_type_def_forward.snap
@@ -1,0 +1,20 @@
+---
+source: compiler/toc_hir_lowering/tests/lowering.rs
+assertion_line: 59
+expression: "\n    type a : forward\n    type a : int\n    type use_it : a\n    "
+
+---
+Library@(dummy)
+  Root@(dummy): FileId(1) -> ItemId(3)
+    Module@(FileId(1), 0..63): "<root>"@(dummy)
+      StmtBody@(FileId(1), 5..58): []
+        StmtItem@(FileId(1), 5..21): ItemId(0)
+          Type@(FileId(1), 5..21): forward "a"@(FileId(1), 10..11)
+        StmtItem@(FileId(1), 26..38): ItemId(1)
+          Type@(FileId(1), 26..38): "a"@(FileId(1), 31..32)
+            Primitive@(FileId(1), 35..38): Int
+        StmtItem@(FileId(1), 43..58): ItemId(2)
+          Type@(FileId(1), 43..58): "use_it"@(FileId(1), 48..54)
+error in file FileId(1) at 57..58: unsupported type
+| error in file FileId(1) for 57..58: this type is not handled yet
+

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_type_def_forward.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_type_def_forward.snap
@@ -1,7 +1,7 @@
 ---
 source: compiler/toc_hir_lowering/tests/lowering.rs
 assertion_line: 59
-expression: "\n    type a : forward\n    type a : int\n    type use_it : a\n    "
+expression: "\n    type a : forward\n    type use_it : a\n    type a : int\n    "
 
 ---
 Library@(dummy)
@@ -10,11 +10,10 @@ Library@(dummy)
       StmtBody@(FileId(1), 5..58): []
         StmtItem@(FileId(1), 5..21): ItemId(0)
           Type@(FileId(1), 5..21): forward "a"@(FileId(1), 10..11)
-        StmtItem@(FileId(1), 26..38): ItemId(1)
-          Type@(FileId(1), 26..38): "a"@(FileId(1), 31..32)
-            Primitive@(FileId(1), 35..38): Int
-        StmtItem@(FileId(1), 43..58): ItemId(2)
-          Type@(FileId(1), 43..58): "use_it"@(FileId(1), 48..54)
-error in file FileId(1) at 57..58: unsupported type
-| error in file FileId(1) for 57..58: this type is not handled yet
+        StmtItem@(FileId(1), 26..41): ItemId(1)
+          Type@(FileId(1), 26..41): "use_it"@(FileId(1), 31..37)
+            Alias@(FileId(1), 40..41): "a"@(FileId(1), 10..11), forward(Type) -> "a"@(FileId(1), 51..52)
+        StmtItem@(FileId(1), 46..58): ItemId(2)
+          Type@(FileId(1), 46..58): "a"@(FileId(1), 51..52)
+            Primitive@(FileId(1), 55..58): Int
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_type_path.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_type_path.snap
@@ -1,0 +1,18 @@
+---
+source: compiler/toc_hir_lowering/tests/lowering.rs
+assertion_line: 59
+expression: "\n    type a : int\n    type not_yet: a.b.c.d.e\n    "
+
+---
+Library@(dummy)
+  Root@(dummy): FileId(1) -> ItemId(2)
+    Module@(FileId(1), 0..50): "<root>"@(dummy)
+      StmtBody@(FileId(1), 5..45): []
+        StmtItem@(FileId(1), 5..17): ItemId(0)
+          Type@(FileId(1), 5..17): "a"@(FileId(1), 10..11)
+            Primitive@(FileId(1), 14..17): Int
+        StmtItem@(FileId(1), 22..45): ItemId(1)
+          Type@(FileId(1), 22..45): "not_yet"@(FileId(1), 27..34)
+error in file FileId(1) at 36..45: unsupported type
+| error in file FileId(1) for 36..45: type paths are not handled yet
+


### PR DESCRIPTION
We're keeping the same forward type usage semantics in, as that avoids us having to deal with cyclic types (for now).