### PR TITLE
Remove `Ref` from the analysis type system

### DIFF
--- a/compiler/toc_analysis/src/const_eval/query.rs
+++ b/compiler/toc_analysis/src/const_eval/query.rs
@@ -149,16 +149,14 @@ pub(crate) fn evaluate_const(
                         let left = db.type_of(DefId(library_id, def_id).into());
                         let right = db.type_of((library_id, body).into());
 
-                        if !ty::rules::is_assignable(db, left, right, true)
-                            .expect("ignores mutability")
-                        {
+                        if !ty::rules::is_assignable(db, left, right) {
                             // Wrong types
                             let span = library.body(body).span.lookup_in(&library.span_map);
                             return Err(ConstError::new(ErrorKind::WrongResultType, span));
                         }
 
                         // If bounds of `left` is known, check if `right` is in the range
-                        let left_ty = left.in_db(db).peel_ref();
+                        let left_ty = left.in_db(db);
 
                         if let Some((min, max)) = left_ty.min_int_of().zip(left_ty.max_int_of()) {
                             // Since right is assignable into left, we can treat right as ConstInt

--- a/compiler/toc_analysis/src/ty.rs
+++ b/compiler/toc_analysis/src/ty.rs
@@ -72,11 +72,6 @@ pub enum TypeKind {
     /// This is used to prevent cyclic type declarations, which we can't detect
     /// yet.
     Forward,
-    /// Reference type.
-    ///
-    /// This type does not appear in syntax (except for parameter binding),
-    /// and is an implementation detail.
-    Ref(Mutability, TypeId),
 }
 
 // Other types to add:
@@ -228,7 +223,6 @@ where
             // Defer to the aliased type
             TypeKind::Alias(_, base_ty) => return base_ty.in_db(self.db).align_of(),
             TypeKind::Forward => return None,
-            TypeKind::Ref(_, _) => return None,
         };
 
         Some(align_of)
@@ -267,9 +261,7 @@ where
             }
             // Defer to the aliased type
             TypeKind::Alias(_, base_ty) => return base_ty.in_db(self.db).align_of(),
-            TypeKind::Integer | TypeKind::Ref(_, _) | TypeKind::Forward | TypeKind::Error => {
-                return None
-            }
+            TypeKind::Integer | TypeKind::Forward | TypeKind::Error => return None,
         };
 
         Some(size_of)
@@ -287,7 +279,7 @@ where
 
                 (char_len.into_u32()?) as usize
             }
-            TypeKind::Ref(_, _) | TypeKind::Error => unreachable!(),
+            TypeKind::Error => unreachable!(),
             _ => return None,
         };
 

--- a/compiler/toc_analysis/src/ty/db.rs
+++ b/compiler/toc_analysis/src/ty/db.rs
@@ -45,7 +45,6 @@ pub trait TypeInternExt {
     fn mk_string_n(&self, seq_size: ty::SeqSize) -> ty::TypeId;
     fn mk_alias(&self, def_id: DefId, base_ty: ty::TypeId) -> ty::TypeId;
     fn mk_forward(&self) -> ty::TypeId;
-    fn mk_ref(&self, mutability: ty::Mutability, to: ty::TypeId) -> ty::TypeId;
 }
 
 /// Anything which can produce a type

--- a/compiler/toc_analysis/src/ty/pretty.rs
+++ b/compiler/toc_analysis/src/ty/pretty.rs
@@ -9,7 +9,7 @@ use crate::{
     ty::{IntSize, NatSize, RealSize, TyRef, TypeKind},
 };
 
-use super::{Mutability, NotFixedLen, TypeId};
+use super::{NotFixedLen, TypeId};
 
 impl<'db, DB> fmt::Debug for TyRef<'db, DB>
 where
@@ -36,8 +36,6 @@ impl TypeKind {
             TypeKind::CharN(_) => "char",
             TypeKind::StringN(_) => "string",
             TypeKind::Alias(_, _) => "",
-            // Refs are not shown to the user
-            TypeKind::Ref(_, _) => unreachable!("refs should be peeled before display"),
             _ => self.debug_prefix(),
         }
     }
@@ -65,8 +63,6 @@ impl TypeKind {
             TypeKind::StringN(_) => "string_n",
             TypeKind::Alias(_, _) => "alias",
             TypeKind::Forward => "forward",
-            TypeKind::Ref(Mutability::Const, _) => "ref",
-            TypeKind::Ref(Mutability::Var, _) => "ref_mut",
         }
     }
 }
@@ -85,10 +81,6 @@ where
         }
         TypeKind::Alias(def_id, to) => {
             out.write_fmt(format_args!("[{:?}] of ", def_id))?;
-            emit_debug_ty(db, out, *to)?
-        }
-        TypeKind::Ref(_, to) => {
-            out.write_char(' ')?;
             emit_debug_ty(db, out, *to)?
         }
         _ => {}
@@ -122,7 +114,6 @@ where
             emit_display_ty(db, out, *to)?;
             out.write_char(')')?;
         }
-        TypeKind::Ref(_, to) => emit_display_ty(db, out, *to)?,
         _ => {}
     }
 

--- a/compiler/toc_analysis/src/ty/query.rs
+++ b/compiler/toc_analysis/src/ty/query.rs
@@ -11,7 +11,7 @@ use toc_hir::{
 use crate::db;
 
 use super::lower;
-use super::{IntSize, Mutability, NatSize, RealSize, SeqSize, Type, TypeId, TypeKind};
+use super::{IntSize, NatSize, RealSize, SeqSize, Type, TypeId, TypeKind};
 
 pub(crate) fn from_hir_type(db: &dyn db::TypeDatabase, type_id: InLibrary<HirTypeId>) -> TypeId {
     lower::ty_from_hir_ty(db, type_id)
@@ -168,15 +168,6 @@ where
         self.intern_type(
             Type {
                 kind: TypeKind::Forward,
-            }
-            .into(),
-        )
-    }
-
-    fn mk_ref(&self, mutability: Mutability, to: TypeId) -> TypeId {
-        self.intern_type(
-            Type {
-                kind: TypeKind::Ref(mutability, to),
             }
             .into(),
         )

--- a/compiler/toc_analysis/src/typeck.rs
+++ b/compiler/toc_analysis/src/typeck.rs
@@ -772,19 +772,15 @@ impl TypeCheck<'_> {
                     .binding_kind(DefId(self.library_id, *def_id).into())
                     .expect("undecl defs are bindings");
 
-                if !matches!(binding_kind, BindingKind::Storage(_)) {
+                if !binding_kind.is_ref() {
                     let span = self.library.body(id.0).expr(id.1).span;
                     let span = self.library.lookup_span(span);
                     let name = self.library.local_def(*def_id).name.item();
                     let reason = match binding_kind {
-                        BindingKind::Storage(_) => unreachable!(),
+                        BindingKind::Undeclared | BindingKind::Storage(_) => unreachable!(),
                         BindingKind::Type => format!("`{}` is a reference to a type", name),
                         BindingKind::Module => {
                             format!("`{}` is a reference to a module", name)
-                        }
-                        BindingKind::Undeclared => {
-                            // Undeclared identifier, can safely skip
-                            return;
                         }
                     };
 

--- a/compiler/toc_analysis/src/typeck.rs
+++ b/compiler/toc_analysis/src/typeck.rs
@@ -8,7 +8,7 @@ use std::cell::RefCell;
 use toc_hir::expr::{self, BodyExpr};
 use toc_hir::library::{self, LibraryId, WrapInLibrary};
 use toc_hir::stmt::BodyStmt;
-use toc_hir::symbol::DefId;
+use toc_hir::symbol::{BindingKind, DefId};
 use toc_hir::{body, item, stmt};
 use toc_reporting::CompileResult;
 use toc_span::Span;
@@ -169,9 +169,7 @@ impl TypeCheck<'_> {
         let left = self.db.type_of(def_id.into());
         let right = self.db.type_of((self.library_id, init).into());
 
-        // Ignore mutability because we're checking an initializer
-        let valid_asn = ty::rules::is_assignable(self.db, left, right, true);
-        if !valid_asn.expect("lhs ty not from reference") {
+        if !ty::rules::is_assignable(self.db, left, right) {
             // Incompatible, report it
             let init_span = self
                 .library
@@ -202,41 +200,42 @@ impl TypeCheck<'_> {
     fn typeck_assign(&self, in_body: body::BodyId, item: &stmt::Assign) {
         let lib_id = self.library_id;
         let db = self.db;
-
-        let left = db.type_of((lib_id, in_body, item.lhs).into());
-        let right = db.type_of((lib_id, in_body, item.rhs).into());
-
-        // Check if types are assignable
-        // Leave error types as "always assignable"
-        let asn_able = ty::rules::is_assignable(db, left, right, false);
         let asn_span = item.asn.lookup_in(&self.library.span_map);
 
-        match asn_able {
-            Some(true) => {} // Valid
-            Some(false) => {
+        // Check if we're assigning into a mut ref
+        if !db
+            .binding_kind((lib_id, in_body, item.lhs).into())
+            .map(BindingKind::is_ref_mut)
+            .unwrap_or(false)
+        {
+            // Not a mut ref
+            let left_span = self
+                .library
+                .body(in_body)
+                .expr(item.lhs)
+                .span
+                .lookup_in(&self.library.span_map);
+
+            // TODO: Stringify lhs for more clarity on the error location
+            // TODO: If it's a ref expr, get the definition point
+            self.state()
+                .reporter
+                .error_detailed("cannot assign into expression", asn_span)
+                .with_note("not a reference to a variable", left_span)
+                .finish();
+        } else {
+            let left = db.type_of((lib_id, in_body, item.lhs).into());
+            let right = db.type_of((lib_id, in_body, item.rhs).into());
+
+            // Check if types are assignable
+            // Leave error types as "always assignable"
+            if !ty::rules::is_assignable(db, left, right) {
                 // Invalid types!
                 let body = self.library.body(in_body);
                 let left_span = body.expr(item.lhs).span.lookup_in(&self.library.span_map);
                 let right_span = body.expr(item.rhs).span.lookup_in(&self.library.span_map);
 
                 self.report_mismatched_assign_tys(left, right, asn_span, left_span, right_span);
-            }
-            None => {
-                // Not a mut ref
-                let left_span = self
-                    .library
-                    .body(in_body)
-                    .expr(item.lhs)
-                    .span
-                    .lookup_in(&self.library.span_map);
-
-                // TODO: Stringify lhs for more clarity on the error location
-                // TODO: If it's a ref expr, get the definition point
-                self.state()
-                    .reporter
-                    .error_detailed("cannot assign into expression", asn_span)
-                    .with_note("not a reference to a variable", left_span)
-                    .finish();
             }
         }
     }
@@ -250,8 +249,8 @@ impl TypeCheck<'_> {
         right_span: toc_span::Span,
     ) {
         let db = self.db;
-        let left_ty = left.in_db(db).peel_ref();
-        let right_ty = right.in_db(db).peel_ref();
+        let left_ty = left.in_db(db);
+        let right_ty = right.in_db(db);
 
         self.state()
             .reporter
@@ -288,8 +287,7 @@ impl TypeCheck<'_> {
             let put_ty = self
                 .db
                 .type_of((self.library_id, body_id, item.expr).into())
-                .in_db(self.db)
-                .peel_ref();
+                .in_db(self.db);
 
             if !self.is_text_io_item(put_ty.id()) {
                 continue;
@@ -365,11 +363,11 @@ impl TypeCheck<'_> {
             let body_expr = item.expr.in_body(body_id);
             let ty = db.type_of((self.library_id, body_expr).into()).in_db(db);
 
-            if !self.is_text_io_item(ty.id()) {
-                continue;
-            }
-
-            if !ty.kind().is_ref_mut() {
+            if !db
+                .binding_kind((self.library_id, body_expr).into())
+                .map(BindingKind::is_ref_mut)
+                .unwrap_or(false)
+            {
                 let get_item_span = body.expr(item.expr).span.lookup_in(&self.library.span_map);
 
                 // TODO: Stringify item for more clarity on the error location
@@ -381,7 +379,9 @@ impl TypeCheck<'_> {
                     .finish();
             }
 
-            let ty = ty.peel_ref();
+            if !self.is_text_io_item(ty.id()) {
+                continue;
+            }
 
             // Verify that the item type can use the given width
             match &item.width {
@@ -443,7 +443,7 @@ impl TypeCheck<'_> {
 
     fn is_text_io_item(&self, ty: ty::TypeId) -> bool {
         let db = self.db;
-        let ty_dat = ty.in_db(db).peel_ref();
+        let ty_dat = ty.in_db(db);
 
         // Must be a valid put/get type
         // Can be one of the following:
@@ -470,8 +470,6 @@ impl TypeCheck<'_> {
             | ty::TypeKind::String
             | ty::TypeKind::CharN(_)
             | ty::TypeKind::StringN(_) => true,
-            // Already deref'd
-            ty::TypeKind::Ref(_, _) => unreachable!(),
             // Already de-aliased
             ty::TypeKind::Alias(_, _) => unreachable!(),
         }
@@ -497,8 +495,7 @@ impl TypeCheck<'_> {
                 let end_ty = db.type_of((self.library_id, body_id, end).into());
 
                 // Wrap up both types
-                let (start_ty, end_ty) =
-                    (start_ty.in_db(db).peel_ref(), end_ty.in_db(db).peel_ref());
+                let (start_ty, end_ty) = (start_ty.in_db(db), end_ty.in_db(db));
 
                 let start_span = self.library.body(body_id).expr(start).span;
                 let end_span = self.library.body(body_id).expr(end).span;
@@ -608,8 +605,7 @@ impl TypeCheck<'_> {
 
         let discrim_display = db
             .type_of((self.library_id, body_id, stmt.discriminant).into())
-            .in_db(db)
-            .peel_ref();
+            .in_db(db);
         let discrim_ty = discrim_display.clone().to_base_type();
         let discrim_span = self.library.body(body_id).expr(stmt.discriminant).span;
         let discrim_span = self.library.lookup_span(discrim_span);
@@ -659,7 +655,7 @@ impl TypeCheck<'_> {
 
             // Must match discriminant type
             if !ty::rules::is_coercible_into(db, discrim_ty.id(), selector_ty) {
-                let selector_ty = selector_ty.in_db(db).peel_ref();
+                let selector_ty = selector_ty.in_db(db);
 
                 self.state()
                     .reporter
@@ -697,7 +693,7 @@ impl TypeCheck<'_> {
                 Ok(ConstValue::String(s)) if matches!(discrim_ty.kind(), ty::TypeKind::Char) => {
                     // Check that it's a length 1 string
                     if s.len() != 1 {
-                        let selector_ty = selector_ty.in_db(db).peel_ref();
+                        let selector_ty = selector_ty.in_db(db);
 
                         self.state()
                             .reporter
@@ -771,19 +767,30 @@ impl TypeCheck<'_> {
         match expr {
             expr::Name::Name(def_id) => {
                 // Validate it's a ref to a storage location
-                let ty_ref = self
+                let binding_kind = self
                     .db
-                    .type_of(DefId(self.library_id, *def_id).into())
-                    .in_db(self.db);
+                    .binding_kind(DefId(self.library_id, *def_id).into())
+                    .expect("undecl defs are bindings");
 
-                if !matches!(ty_ref.kind(), ty::TypeKind::Ref(_, _)) {
+                if !matches!(binding_kind, BindingKind::Storage(_)) {
                     let span = self.library.body(id.0).expr(id.1).span;
                     let span = self.library.lookup_span(span);
                     let name = self.library.local_def(*def_id).name.item();
+                    let reason = match binding_kind {
+                        BindingKind::Storage(_) => unreachable!(),
+                        BindingKind::Type => format!("`{}` is a reference to a type", name),
+                        BindingKind::Module => {
+                            format!("`{}` is a reference to a module", name)
+                        }
+                        BindingKind::Undeclared => {
+                            // Undeclared identifier, can safely skip
+                            return;
+                        }
+                    };
 
                     self.state().reporter.error(
                         format!("cannot use `{}` as an expression", name),
-                        format!("`{}` is a reference to a type", name),
+                        reason,
                         span,
                     );
                 }
@@ -861,7 +868,7 @@ impl TypeCheck<'_> {
     // TODO: Replace `expect_*_type` with `expect_type` once we have `ty::rules::is_equivalent`
 
     fn expect_integer_type(&self, type_id: ty::TypeId, span: Span) {
-        let ty = type_id.in_db(self.db).peel_ref();
+        let ty = type_id.in_db(self.db);
 
         if !ty.kind().is_integer() && !ty.kind().is_error() {
             self.state()
@@ -874,7 +881,7 @@ impl TypeCheck<'_> {
     }
 
     fn expect_boolean_type(&self, type_id: ty::TypeId, span: Span) {
-        let ty = type_id.in_db(self.db).peel_ref();
+        let ty = type_id.in_db(self.db);
         let expected_ty = self.db.mk_boolean().in_db(self.db);
 
         if !ty.kind().is_boolean() && !ty.kind().is_error() {

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__arithmetic_op_add.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__arithmetic_op_add.snap
@@ -1,19 +1,20 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "\n    % Compatibility with all variant of numbers\n    var r : real\n    var i : int\n    var n : nat\n    var _rr := r + r\n    var _ri := r + i\n    var _ir := i + r\n    var _rn := r + n\n    var _nr := n + r\n    var _ii := i + i\n    var _in := i + n\n    var _ni := n + i\n    var _nn := n + n\n"
 
 ---
-"r"@(FileId(1), 57..58) [Declared]: ref_mut real
-"i"@(FileId(1), 74..75) [Declared]: ref_mut int
-"n"@(FileId(1), 90..91) [Declared]: ref_mut nat
-"_rr"@(FileId(1), 106..109) [Declared]: ref_mut real
-"_ri"@(FileId(1), 127..130) [Declared]: ref_mut real
-"_ir"@(FileId(1), 148..151) [Declared]: ref_mut real
-"_rn"@(FileId(1), 169..172) [Declared]: ref_mut real
-"_nr"@(FileId(1), 190..193) [Declared]: ref_mut real
-"_ii"@(FileId(1), 211..214) [Declared]: ref_mut int
-"_in"@(FileId(1), 232..235) [Declared]: ref_mut int
-"_ni"@(FileId(1), 253..256) [Declared]: ref_mut int
-"_nn"@(FileId(1), 274..277) [Declared]: ref_mut nat
+"r"@(FileId(1), 57..58) [Declared]: real
+"i"@(FileId(1), 74..75) [Declared]: int
+"n"@(FileId(1), 90..91) [Declared]: nat
+"_rr"@(FileId(1), 106..109) [Declared]: real
+"_ri"@(FileId(1), 127..130) [Declared]: real
+"_ir"@(FileId(1), 148..151) [Declared]: real
+"_rn"@(FileId(1), 169..172) [Declared]: real
+"_nr"@(FileId(1), 190..193) [Declared]: real
+"_ii"@(FileId(1), 211..214) [Declared]: int
+"_in"@(FileId(1), 232..235) [Declared]: int
+"_ni"@(FileId(1), 253..256) [Declared]: int
+"_nn"@(FileId(1), 274..277) [Declared]: nat
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__arithmetic_op_exp.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__arithmetic_op_exp.snap
@@ -1,19 +1,20 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "\n    % Compatibility with all variant of numbers\n    var r : real\n    var i : int\n    var n : nat\n    var _rr := r ** r\n    var _ri := r ** i\n    var _ir := i ** r\n    var _rn := r ** n\n    var _nr := n ** r\n    var _ii := i ** i\n    var _in := i ** n\n    var _ni := n ** i\n    var _nn := n ** n\n"
 
 ---
-"r"@(FileId(1), 57..58) [Declared]: ref_mut real
-"i"@(FileId(1), 74..75) [Declared]: ref_mut int
-"n"@(FileId(1), 90..91) [Declared]: ref_mut nat
-"_rr"@(FileId(1), 106..109) [Declared]: ref_mut real
-"_ri"@(FileId(1), 128..131) [Declared]: ref_mut real
-"_ir"@(FileId(1), 150..153) [Declared]: ref_mut real
-"_rn"@(FileId(1), 172..175) [Declared]: ref_mut real
-"_nr"@(FileId(1), 194..197) [Declared]: ref_mut real
-"_ii"@(FileId(1), 216..219) [Declared]: ref_mut int
-"_in"@(FileId(1), 238..241) [Declared]: ref_mut int
-"_ni"@(FileId(1), 260..263) [Declared]: ref_mut int
-"_nn"@(FileId(1), 282..285) [Declared]: ref_mut nat
+"r"@(FileId(1), 57..58) [Declared]: real
+"i"@(FileId(1), 74..75) [Declared]: int
+"n"@(FileId(1), 90..91) [Declared]: nat
+"_rr"@(FileId(1), 106..109) [Declared]: real
+"_ri"@(FileId(1), 128..131) [Declared]: real
+"_ir"@(FileId(1), 150..153) [Declared]: real
+"_rn"@(FileId(1), 172..175) [Declared]: real
+"_nr"@(FileId(1), 194..197) [Declared]: real
+"_ii"@(FileId(1), 216..219) [Declared]: int
+"_in"@(FileId(1), 238..241) [Declared]: int
+"_ni"@(FileId(1), 260..263) [Declared]: int
+"_nn"@(FileId(1), 282..285) [Declared]: nat
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__arithmetic_op_identity.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__arithmetic_op_identity.snap
@@ -1,13 +1,14 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "\n    var r : real\n    var i : int\n    var n : nat\n    var _r := + r\n    var _i := + i\n    var _n := + n\n    "
 
 ---
-"r"@(FileId(1), 9..10) [Declared]: ref_mut real
-"i"@(FileId(1), 26..27) [Declared]: ref_mut int
-"n"@(FileId(1), 42..43) [Declared]: ref_mut nat
-"_r"@(FileId(1), 58..60) [Declared]: ref_mut real
-"_i"@(FileId(1), 76..78) [Declared]: ref_mut int
-"_n"@(FileId(1), 94..96) [Declared]: ref_mut nat
+"r"@(FileId(1), 9..10) [Declared]: real
+"i"@(FileId(1), 26..27) [Declared]: int
+"n"@(FileId(1), 42..43) [Declared]: nat
+"_r"@(FileId(1), 58..60) [Declared]: real
+"_i"@(FileId(1), 76..78) [Declared]: int
+"_n"@(FileId(1), 94..96) [Declared]: nat
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__arithmetic_op_idiv.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__arithmetic_op_idiv.snap
@@ -1,19 +1,20 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "\n    % Compatibility with all variant of numbers\n    var r : real\n    var i : int\n    var n : nat\n    var _rr := r div r\n    var _ri := r div i\n    var _ir := i div r\n    var _rn := r div n\n    var _nr := n div r\n    var _ii := i div i\n    var _in := i div n\n    var _ni := n div i\n    var _nn := n div n\n"
 
 ---
-"r"@(FileId(1), 57..58) [Declared]: ref_mut real
-"i"@(FileId(1), 74..75) [Declared]: ref_mut int
-"n"@(FileId(1), 90..91) [Declared]: ref_mut nat
-"_rr"@(FileId(1), 106..109) [Declared]: ref_mut int
-"_ri"@(FileId(1), 129..132) [Declared]: ref_mut int
-"_ir"@(FileId(1), 152..155) [Declared]: ref_mut int
-"_rn"@(FileId(1), 175..178) [Declared]: ref_mut int
-"_nr"@(FileId(1), 198..201) [Declared]: ref_mut int
-"_ii"@(FileId(1), 221..224) [Declared]: ref_mut int
-"_in"@(FileId(1), 244..247) [Declared]: ref_mut int
-"_ni"@(FileId(1), 267..270) [Declared]: ref_mut int
-"_nn"@(FileId(1), 290..293) [Declared]: ref_mut nat
+"r"@(FileId(1), 57..58) [Declared]: real
+"i"@(FileId(1), 74..75) [Declared]: int
+"n"@(FileId(1), 90..91) [Declared]: nat
+"_rr"@(FileId(1), 106..109) [Declared]: int
+"_ri"@(FileId(1), 129..132) [Declared]: int
+"_ir"@(FileId(1), 152..155) [Declared]: int
+"_rn"@(FileId(1), 175..178) [Declared]: int
+"_nr"@(FileId(1), 198..201) [Declared]: int
+"_ii"@(FileId(1), 221..224) [Declared]: int
+"_in"@(FileId(1), 244..247) [Declared]: int
+"_ni"@(FileId(1), 267..270) [Declared]: int
+"_nn"@(FileId(1), 290..293) [Declared]: nat
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__arithmetic_op_mod.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__arithmetic_op_mod.snap
@@ -1,19 +1,20 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "\n    % Compatibility with all variant of numbers\n    var r : real\n    var i : int\n    var n : nat\n    var _rr := r mod r\n    var _ri := r mod i\n    var _ir := i mod r\n    var _rn := r mod n\n    var _nr := n mod r\n    var _ii := i mod i\n    var _in := i mod n\n    var _ni := n mod i\n    var _nn := n mod n\n"
 
 ---
-"r"@(FileId(1), 57..58) [Declared]: ref_mut real
-"i"@(FileId(1), 74..75) [Declared]: ref_mut int
-"n"@(FileId(1), 90..91) [Declared]: ref_mut nat
-"_rr"@(FileId(1), 106..109) [Declared]: ref_mut real
-"_ri"@(FileId(1), 129..132) [Declared]: ref_mut real
-"_ir"@(FileId(1), 152..155) [Declared]: ref_mut real
-"_rn"@(FileId(1), 175..178) [Declared]: ref_mut real
-"_nr"@(FileId(1), 198..201) [Declared]: ref_mut real
-"_ii"@(FileId(1), 221..224) [Declared]: ref_mut int
-"_in"@(FileId(1), 244..247) [Declared]: ref_mut int
-"_ni"@(FileId(1), 267..270) [Declared]: ref_mut int
-"_nn"@(FileId(1), 290..293) [Declared]: ref_mut nat
+"r"@(FileId(1), 57..58) [Declared]: real
+"i"@(FileId(1), 74..75) [Declared]: int
+"n"@(FileId(1), 90..91) [Declared]: nat
+"_rr"@(FileId(1), 106..109) [Declared]: real
+"_ri"@(FileId(1), 129..132) [Declared]: real
+"_ir"@(FileId(1), 152..155) [Declared]: real
+"_rn"@(FileId(1), 175..178) [Declared]: real
+"_nr"@(FileId(1), 198..201) [Declared]: real
+"_ii"@(FileId(1), 221..224) [Declared]: int
+"_in"@(FileId(1), 244..247) [Declared]: int
+"_ni"@(FileId(1), 267..270) [Declared]: int
+"_nn"@(FileId(1), 290..293) [Declared]: nat
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__arithmetic_op_mul.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__arithmetic_op_mul.snap
@@ -1,19 +1,20 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "\n    % Compatibility with all variant of numbers\n    var r : real\n    var i : int\n    var n : nat\n    var _rr := r * r\n    var _ri := r * i\n    var _ir := i * r\n    var _rn := r * n\n    var _nr := n * r\n    var _ii := i * i\n    var _in := i * n\n    var _ni := n * i\n    var _nn := n * n\n"
 
 ---
-"r"@(FileId(1), 57..58) [Declared]: ref_mut real
-"i"@(FileId(1), 74..75) [Declared]: ref_mut int
-"n"@(FileId(1), 90..91) [Declared]: ref_mut nat
-"_rr"@(FileId(1), 106..109) [Declared]: ref_mut real
-"_ri"@(FileId(1), 127..130) [Declared]: ref_mut real
-"_ir"@(FileId(1), 148..151) [Declared]: ref_mut real
-"_rn"@(FileId(1), 169..172) [Declared]: ref_mut real
-"_nr"@(FileId(1), 190..193) [Declared]: ref_mut real
-"_ii"@(FileId(1), 211..214) [Declared]: ref_mut int
-"_in"@(FileId(1), 232..235) [Declared]: ref_mut int
-"_ni"@(FileId(1), 253..256) [Declared]: ref_mut int
-"_nn"@(FileId(1), 274..277) [Declared]: ref_mut nat
+"r"@(FileId(1), 57..58) [Declared]: real
+"i"@(FileId(1), 74..75) [Declared]: int
+"n"@(FileId(1), 90..91) [Declared]: nat
+"_rr"@(FileId(1), 106..109) [Declared]: real
+"_ri"@(FileId(1), 127..130) [Declared]: real
+"_ir"@(FileId(1), 148..151) [Declared]: real
+"_rn"@(FileId(1), 169..172) [Declared]: real
+"_nr"@(FileId(1), 190..193) [Declared]: real
+"_ii"@(FileId(1), 211..214) [Declared]: int
+"_in"@(FileId(1), 232..235) [Declared]: int
+"_ni"@(FileId(1), 253..256) [Declared]: int
+"_nn"@(FileId(1), 274..277) [Declared]: nat
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__arithmetic_op_negate.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__arithmetic_op_negate.snap
@@ -1,13 +1,14 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "\n    var r : real\n    var i : int\n    var n : nat\n    var _r := - r\n    var _i := - i\n    var _n := - n\n    "
 
 ---
-"r"@(FileId(1), 9..10) [Declared]: ref_mut real
-"i"@(FileId(1), 26..27) [Declared]: ref_mut int
-"n"@(FileId(1), 42..43) [Declared]: ref_mut nat
-"_r"@(FileId(1), 58..60) [Declared]: ref_mut real
-"_i"@(FileId(1), 76..78) [Declared]: ref_mut int
-"_n"@(FileId(1), 94..96) [Declared]: ref_mut nat
+"r"@(FileId(1), 9..10) [Declared]: real
+"i"@(FileId(1), 26..27) [Declared]: int
+"n"@(FileId(1), 42..43) [Declared]: nat
+"_r"@(FileId(1), 58..60) [Declared]: real
+"_i"@(FileId(1), 76..78) [Declared]: int
+"_n"@(FileId(1), 94..96) [Declared]: nat
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__arithmetic_op_rdiv.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__arithmetic_op_rdiv.snap
@@ -1,19 +1,20 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "\n    % Compatibility with all variant of numbers\n    var r : real\n    var i : int\n    var n : nat\n    var _rr := r / r\n    var _ri := r / i\n    var _ir := i / r\n    var _rn := r / n\n    var _nr := n / r\n    var _ii := i / i\n    var _in := i / n\n    var _ni := n / i\n    var _nn := n / n\n"
 
 ---
-"r"@(FileId(1), 57..58) [Declared]: ref_mut real
-"i"@(FileId(1), 74..75) [Declared]: ref_mut int
-"n"@(FileId(1), 90..91) [Declared]: ref_mut nat
-"_rr"@(FileId(1), 106..109) [Declared]: ref_mut real
-"_ri"@(FileId(1), 127..130) [Declared]: ref_mut real
-"_ir"@(FileId(1), 148..151) [Declared]: ref_mut real
-"_rn"@(FileId(1), 169..172) [Declared]: ref_mut real
-"_nr"@(FileId(1), 190..193) [Declared]: ref_mut real
-"_ii"@(FileId(1), 211..214) [Declared]: ref_mut real
-"_in"@(FileId(1), 232..235) [Declared]: ref_mut real
-"_ni"@(FileId(1), 253..256) [Declared]: ref_mut real
-"_nn"@(FileId(1), 274..277) [Declared]: ref_mut real
+"r"@(FileId(1), 57..58) [Declared]: real
+"i"@(FileId(1), 74..75) [Declared]: int
+"n"@(FileId(1), 90..91) [Declared]: nat
+"_rr"@(FileId(1), 106..109) [Declared]: real
+"_ri"@(FileId(1), 127..130) [Declared]: real
+"_ir"@(FileId(1), 148..151) [Declared]: real
+"_rn"@(FileId(1), 169..172) [Declared]: real
+"_nr"@(FileId(1), 190..193) [Declared]: real
+"_ii"@(FileId(1), 211..214) [Declared]: real
+"_in"@(FileId(1), 232..235) [Declared]: real
+"_ni"@(FileId(1), 253..256) [Declared]: real
+"_nn"@(FileId(1), 274..277) [Declared]: real
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__arithmetic_op_rem.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__arithmetic_op_rem.snap
@@ -1,19 +1,20 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "\n    % Compatibility with all variant of numbers\n    var r : real\n    var i : int\n    var n : nat\n    var _rr := r rem r\n    var _ri := r rem i\n    var _ir := i rem r\n    var _rn := r rem n\n    var _nr := n rem r\n    var _ii := i rem i\n    var _in := i rem n\n    var _ni := n rem i\n    var _nn := n rem n\n"
 
 ---
-"r"@(FileId(1), 57..58) [Declared]: ref_mut real
-"i"@(FileId(1), 74..75) [Declared]: ref_mut int
-"n"@(FileId(1), 90..91) [Declared]: ref_mut nat
-"_rr"@(FileId(1), 106..109) [Declared]: ref_mut real
-"_ri"@(FileId(1), 129..132) [Declared]: ref_mut real
-"_ir"@(FileId(1), 152..155) [Declared]: ref_mut real
-"_rn"@(FileId(1), 175..178) [Declared]: ref_mut real
-"_nr"@(FileId(1), 198..201) [Declared]: ref_mut real
-"_ii"@(FileId(1), 221..224) [Declared]: ref_mut int
-"_in"@(FileId(1), 244..247) [Declared]: ref_mut int
-"_ni"@(FileId(1), 267..270) [Declared]: ref_mut int
-"_nn"@(FileId(1), 290..293) [Declared]: ref_mut nat
+"r"@(FileId(1), 57..58) [Declared]: real
+"i"@(FileId(1), 74..75) [Declared]: int
+"n"@(FileId(1), 90..91) [Declared]: nat
+"_rr"@(FileId(1), 106..109) [Declared]: real
+"_ri"@(FileId(1), 129..132) [Declared]: real
+"_ir"@(FileId(1), 152..155) [Declared]: real
+"_rn"@(FileId(1), 175..178) [Declared]: real
+"_nr"@(FileId(1), 198..201) [Declared]: real
+"_ii"@(FileId(1), 221..224) [Declared]: int
+"_in"@(FileId(1), 244..247) [Declared]: int
+"_ni"@(FileId(1), 267..270) [Declared]: int
+"_nn"@(FileId(1), 290..293) [Declared]: nat
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__arithmetic_op_sub.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__arithmetic_op_sub.snap
@@ -1,19 +1,20 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "\n    % Compatibility with all variant of numbers\n    var r : real\n    var i : int\n    var n : nat\n    var _rr := r - r\n    var _ri := r - i\n    var _ir := i - r\n    var _rn := r - n\n    var _nr := n - r\n    var _ii := i - i\n    var _in := i - n\n    var _ni := n - i\n    var _nn := n - n\n"
 
 ---
-"r"@(FileId(1), 57..58) [Declared]: ref_mut real
-"i"@(FileId(1), 74..75) [Declared]: ref_mut int
-"n"@(FileId(1), 90..91) [Declared]: ref_mut nat
-"_rr"@(FileId(1), 106..109) [Declared]: ref_mut real
-"_ri"@(FileId(1), 127..130) [Declared]: ref_mut real
-"_ir"@(FileId(1), 148..151) [Declared]: ref_mut real
-"_rn"@(FileId(1), 169..172) [Declared]: ref_mut real
-"_nr"@(FileId(1), 190..193) [Declared]: ref_mut real
-"_ii"@(FileId(1), 211..214) [Declared]: ref_mut int
-"_in"@(FileId(1), 232..235) [Declared]: ref_mut int
-"_ni"@(FileId(1), 253..256) [Declared]: ref_mut int
-"_nn"@(FileId(1), 274..277) [Declared]: ref_mut nat
+"r"@(FileId(1), 57..58) [Declared]: real
+"i"@(FileId(1), 74..75) [Declared]: int
+"n"@(FileId(1), 90..91) [Declared]: nat
+"_rr"@(FileId(1), 106..109) [Declared]: real
+"_ri"@(FileId(1), 127..130) [Declared]: real
+"_ir"@(FileId(1), 148..151) [Declared]: real
+"_rn"@(FileId(1), 169..172) [Declared]: real
+"_nr"@(FileId(1), 190..193) [Declared]: real
+"_ii"@(FileId(1), 211..214) [Declared]: int
+"_in"@(FileId(1), 232..235) [Declared]: int
+"_ni"@(FileId(1), 253..256) [Declared]: int
+"_nn"@(FileId(1), 274..277) [Declared]: nat
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__arithmetic_op_wrong_type_add.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__arithmetic_op_wrong_type_add.snap
@@ -4,17 +4,17 @@ assertion_line: 41
 expression: "\n    var b : boolean\n    var r : real\n    var i : int\n    var n : nat\n    var _br := b + r\n    var _bi := b + i\n    var _bn := b + n\n    var _rb := r + b\n    var _ib := i + b\n    var _nb := n + b\n    var _bb := b + b\n"
 
 ---
-"b"@(FileId(1), 9..10) [Declared]: ref_mut boolean
-"r"@(FileId(1), 29..30) [Declared]: ref_mut real
-"i"@(FileId(1), 46..47) [Declared]: ref_mut int
-"n"@(FileId(1), 62..63) [Declared]: ref_mut nat
-"_br"@(FileId(1), 78..81) [Declared]: ref_mut <error>
-"_bi"@(FileId(1), 99..102) [Declared]: ref_mut <error>
-"_bn"@(FileId(1), 120..123) [Declared]: ref_mut <error>
-"_rb"@(FileId(1), 141..144) [Declared]: ref_mut <error>
-"_ib"@(FileId(1), 162..165) [Declared]: ref_mut <error>
-"_nb"@(FileId(1), 183..186) [Declared]: ref_mut <error>
-"_bb"@(FileId(1), 204..207) [Declared]: ref_mut <error>
+"b"@(FileId(1), 9..10) [Declared]: boolean
+"r"@(FileId(1), 29..30) [Declared]: real
+"i"@(FileId(1), 46..47) [Declared]: int
+"n"@(FileId(1), 62..63) [Declared]: nat
+"_br"@(FileId(1), 78..81) [Declared]: <error>
+"_bi"@(FileId(1), 99..102) [Declared]: <error>
+"_bn"@(FileId(1), 120..123) [Declared]: <error>
+"_rb"@(FileId(1), 141..144) [Declared]: <error>
+"_ib"@(FileId(1), 162..165) [Declared]: <error>
+"_nb"@(FileId(1), 183..186) [Declared]: <error>
+"_bb"@(FileId(1), 204..207) [Declared]: <error>
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 87..88: mismatched types for addition

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__arithmetic_op_wrong_type_exp.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__arithmetic_op_wrong_type_exp.snap
@@ -4,17 +4,17 @@ assertion_line: 41
 expression: "\n    var b : boolean\n    var r : real\n    var i : int\n    var n : nat\n    var _br := b ** r\n    var _bi := b ** i\n    var _bn := b ** n\n    var _rb := r ** b\n    var _ib := i ** b\n    var _nb := n ** b\n    var _bb := b ** b\n"
 
 ---
-"b"@(FileId(1), 9..10) [Declared]: ref_mut boolean
-"r"@(FileId(1), 29..30) [Declared]: ref_mut real
-"i"@(FileId(1), 46..47) [Declared]: ref_mut int
-"n"@(FileId(1), 62..63) [Declared]: ref_mut nat
-"_br"@(FileId(1), 78..81) [Declared]: ref_mut <error>
-"_bi"@(FileId(1), 100..103) [Declared]: ref_mut <error>
-"_bn"@(FileId(1), 122..125) [Declared]: ref_mut <error>
-"_rb"@(FileId(1), 144..147) [Declared]: ref_mut <error>
-"_ib"@(FileId(1), 166..169) [Declared]: ref_mut <error>
-"_nb"@(FileId(1), 188..191) [Declared]: ref_mut <error>
-"_bb"@(FileId(1), 210..213) [Declared]: ref_mut <error>
+"b"@(FileId(1), 9..10) [Declared]: boolean
+"r"@(FileId(1), 29..30) [Declared]: real
+"i"@(FileId(1), 46..47) [Declared]: int
+"n"@(FileId(1), 62..63) [Declared]: nat
+"_br"@(FileId(1), 78..81) [Declared]: <error>
+"_bi"@(FileId(1), 100..103) [Declared]: <error>
+"_bn"@(FileId(1), 122..125) [Declared]: <error>
+"_rb"@(FileId(1), 144..147) [Declared]: <error>
+"_ib"@(FileId(1), 166..169) [Declared]: <error>
+"_nb"@(FileId(1), 188..191) [Declared]: <error>
+"_bb"@(FileId(1), 210..213) [Declared]: <error>
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 87..89: mismatched types for exponentiation

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__arithmetic_op_wrong_type_identity.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__arithmetic_op_wrong_type_identity.snap
@@ -1,10 +1,11 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "\n    var b : boolean\n    var _b := + b\n"
 
 ---
-"b"@(FileId(1), 9..10) [Declared]: ref_mut boolean
-"_b"@(FileId(1), 29..31) [Declared]: ref_mut <error>
+"b"@(FileId(1), 9..10) [Declared]: boolean
+"_b"@(FileId(1), 29..31) [Declared]: <error>
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 35..36: mismatched types for unary `+`

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__arithmetic_op_wrong_type_idiv.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__arithmetic_op_wrong_type_idiv.snap
@@ -4,17 +4,17 @@ assertion_line: 41
 expression: "\n    var b : boolean\n    var r : real\n    var i : int\n    var n : nat\n    var _br := b div r\n    var _bi := b div i\n    var _bn := b div n\n    var _rb := r div b\n    var _ib := i div b\n    var _nb := n div b\n    var _bb := b div b\n"
 
 ---
-"b"@(FileId(1), 9..10) [Declared]: ref_mut boolean
-"r"@(FileId(1), 29..30) [Declared]: ref_mut real
-"i"@(FileId(1), 46..47) [Declared]: ref_mut int
-"n"@(FileId(1), 62..63) [Declared]: ref_mut nat
-"_br"@(FileId(1), 78..81) [Declared]: ref_mut <error>
-"_bi"@(FileId(1), 101..104) [Declared]: ref_mut <error>
-"_bn"@(FileId(1), 124..127) [Declared]: ref_mut <error>
-"_rb"@(FileId(1), 147..150) [Declared]: ref_mut <error>
-"_ib"@(FileId(1), 170..173) [Declared]: ref_mut <error>
-"_nb"@(FileId(1), 193..196) [Declared]: ref_mut <error>
-"_bb"@(FileId(1), 216..219) [Declared]: ref_mut <error>
+"b"@(FileId(1), 9..10) [Declared]: boolean
+"r"@(FileId(1), 29..30) [Declared]: real
+"i"@(FileId(1), 46..47) [Declared]: int
+"n"@(FileId(1), 62..63) [Declared]: nat
+"_br"@(FileId(1), 78..81) [Declared]: <error>
+"_bi"@(FileId(1), 101..104) [Declared]: <error>
+"_bn"@(FileId(1), 124..127) [Declared]: <error>
+"_rb"@(FileId(1), 147..150) [Declared]: <error>
+"_ib"@(FileId(1), 170..173) [Declared]: <error>
+"_nb"@(FileId(1), 193..196) [Declared]: <error>
+"_bb"@(FileId(1), 216..219) [Declared]: <error>
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 87..90: mismatched types for integer division

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__arithmetic_op_wrong_type_mod.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__arithmetic_op_wrong_type_mod.snap
@@ -4,17 +4,17 @@ assertion_line: 41
 expression: "\n    var b : boolean\n    var r : real\n    var i : int\n    var n : nat\n    var _br := b mod r\n    var _bi := b mod i\n    var _bn := b mod n\n    var _rb := r mod b\n    var _ib := i mod b\n    var _nb := n mod b\n    var _bb := b mod b\n"
 
 ---
-"b"@(FileId(1), 9..10) [Declared]: ref_mut boolean
-"r"@(FileId(1), 29..30) [Declared]: ref_mut real
-"i"@(FileId(1), 46..47) [Declared]: ref_mut int
-"n"@(FileId(1), 62..63) [Declared]: ref_mut nat
-"_br"@(FileId(1), 78..81) [Declared]: ref_mut <error>
-"_bi"@(FileId(1), 101..104) [Declared]: ref_mut <error>
-"_bn"@(FileId(1), 124..127) [Declared]: ref_mut <error>
-"_rb"@(FileId(1), 147..150) [Declared]: ref_mut <error>
-"_ib"@(FileId(1), 170..173) [Declared]: ref_mut <error>
-"_nb"@(FileId(1), 193..196) [Declared]: ref_mut <error>
-"_bb"@(FileId(1), 216..219) [Declared]: ref_mut <error>
+"b"@(FileId(1), 9..10) [Declared]: boolean
+"r"@(FileId(1), 29..30) [Declared]: real
+"i"@(FileId(1), 46..47) [Declared]: int
+"n"@(FileId(1), 62..63) [Declared]: nat
+"_br"@(FileId(1), 78..81) [Declared]: <error>
+"_bi"@(FileId(1), 101..104) [Declared]: <error>
+"_bn"@(FileId(1), 124..127) [Declared]: <error>
+"_rb"@(FileId(1), 147..150) [Declared]: <error>
+"_ib"@(FileId(1), 170..173) [Declared]: <error>
+"_nb"@(FileId(1), 193..196) [Declared]: <error>
+"_bb"@(FileId(1), 216..219) [Declared]: <error>
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 87..90: mismatched types for modulus

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__arithmetic_op_wrong_type_mul.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__arithmetic_op_wrong_type_mul.snap
@@ -4,17 +4,17 @@ assertion_line: 41
 expression: "\n    var b : boolean\n    var r : real\n    var i : int\n    var n : nat\n    var _br := b * r\n    var _bi := b * i\n    var _bn := b * n\n    var _rb := r * b\n    var _ib := i * b\n    var _nb := n * b\n    var _bb := b * b\n"
 
 ---
-"b"@(FileId(1), 9..10) [Declared]: ref_mut boolean
-"r"@(FileId(1), 29..30) [Declared]: ref_mut real
-"i"@(FileId(1), 46..47) [Declared]: ref_mut int
-"n"@(FileId(1), 62..63) [Declared]: ref_mut nat
-"_br"@(FileId(1), 78..81) [Declared]: ref_mut <error>
-"_bi"@(FileId(1), 99..102) [Declared]: ref_mut <error>
-"_bn"@(FileId(1), 120..123) [Declared]: ref_mut <error>
-"_rb"@(FileId(1), 141..144) [Declared]: ref_mut <error>
-"_ib"@(FileId(1), 162..165) [Declared]: ref_mut <error>
-"_nb"@(FileId(1), 183..186) [Declared]: ref_mut <error>
-"_bb"@(FileId(1), 204..207) [Declared]: ref_mut <error>
+"b"@(FileId(1), 9..10) [Declared]: boolean
+"r"@(FileId(1), 29..30) [Declared]: real
+"i"@(FileId(1), 46..47) [Declared]: int
+"n"@(FileId(1), 62..63) [Declared]: nat
+"_br"@(FileId(1), 78..81) [Declared]: <error>
+"_bi"@(FileId(1), 99..102) [Declared]: <error>
+"_bn"@(FileId(1), 120..123) [Declared]: <error>
+"_rb"@(FileId(1), 141..144) [Declared]: <error>
+"_ib"@(FileId(1), 162..165) [Declared]: <error>
+"_nb"@(FileId(1), 183..186) [Declared]: <error>
+"_bb"@(FileId(1), 204..207) [Declared]: <error>
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 87..88: mismatched types for multiplication

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__arithmetic_op_wrong_type_negate.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__arithmetic_op_wrong_type_negate.snap
@@ -1,10 +1,11 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "\n    var b : boolean\n    var _b := - b\n"
 
 ---
-"b"@(FileId(1), 9..10) [Declared]: ref_mut boolean
-"_b"@(FileId(1), 29..31) [Declared]: ref_mut <error>
+"b"@(FileId(1), 9..10) [Declared]: boolean
+"_b"@(FileId(1), 29..31) [Declared]: <error>
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 35..36: mismatched types for unary `-`

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__arithmetic_op_wrong_type_rdiv.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__arithmetic_op_wrong_type_rdiv.snap
@@ -4,17 +4,17 @@ assertion_line: 41
 expression: "\n    var b : boolean\n    var r : real\n    var i : int\n    var n : nat\n    var _br := b / r\n    var _bi := b / i\n    var _bn := b / n\n    var _rb := r / b\n    var _ib := i / b\n    var _nb := n / b\n    var _bb := b / b\n"
 
 ---
-"b"@(FileId(1), 9..10) [Declared]: ref_mut boolean
-"r"@(FileId(1), 29..30) [Declared]: ref_mut real
-"i"@(FileId(1), 46..47) [Declared]: ref_mut int
-"n"@(FileId(1), 62..63) [Declared]: ref_mut nat
-"_br"@(FileId(1), 78..81) [Declared]: ref_mut <error>
-"_bi"@(FileId(1), 99..102) [Declared]: ref_mut <error>
-"_bn"@(FileId(1), 120..123) [Declared]: ref_mut <error>
-"_rb"@(FileId(1), 141..144) [Declared]: ref_mut <error>
-"_ib"@(FileId(1), 162..165) [Declared]: ref_mut <error>
-"_nb"@(FileId(1), 183..186) [Declared]: ref_mut <error>
-"_bb"@(FileId(1), 204..207) [Declared]: ref_mut <error>
+"b"@(FileId(1), 9..10) [Declared]: boolean
+"r"@(FileId(1), 29..30) [Declared]: real
+"i"@(FileId(1), 46..47) [Declared]: int
+"n"@(FileId(1), 62..63) [Declared]: nat
+"_br"@(FileId(1), 78..81) [Declared]: <error>
+"_bi"@(FileId(1), 99..102) [Declared]: <error>
+"_bn"@(FileId(1), 120..123) [Declared]: <error>
+"_rb"@(FileId(1), 141..144) [Declared]: <error>
+"_ib"@(FileId(1), 162..165) [Declared]: <error>
+"_nb"@(FileId(1), 183..186) [Declared]: <error>
+"_bb"@(FileId(1), 204..207) [Declared]: <error>
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 87..88: mismatched types for real division

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__arithmetic_op_wrong_type_rem.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__arithmetic_op_wrong_type_rem.snap
@@ -4,17 +4,17 @@ assertion_line: 41
 expression: "\n    var b : boolean\n    var r : real\n    var i : int\n    var n : nat\n    var _br := b rem r\n    var _bi := b rem i\n    var _bn := b rem n\n    var _rb := r rem b\n    var _ib := i rem b\n    var _nb := n rem b\n    var _bb := b rem b\n"
 
 ---
-"b"@(FileId(1), 9..10) [Declared]: ref_mut boolean
-"r"@(FileId(1), 29..30) [Declared]: ref_mut real
-"i"@(FileId(1), 46..47) [Declared]: ref_mut int
-"n"@(FileId(1), 62..63) [Declared]: ref_mut nat
-"_br"@(FileId(1), 78..81) [Declared]: ref_mut <error>
-"_bi"@(FileId(1), 101..104) [Declared]: ref_mut <error>
-"_bn"@(FileId(1), 124..127) [Declared]: ref_mut <error>
-"_rb"@(FileId(1), 147..150) [Declared]: ref_mut <error>
-"_ib"@(FileId(1), 170..173) [Declared]: ref_mut <error>
-"_nb"@(FileId(1), 193..196) [Declared]: ref_mut <error>
-"_bb"@(FileId(1), 216..219) [Declared]: ref_mut <error>
+"b"@(FileId(1), 9..10) [Declared]: boolean
+"r"@(FileId(1), 29..30) [Declared]: real
+"i"@(FileId(1), 46..47) [Declared]: int
+"n"@(FileId(1), 62..63) [Declared]: nat
+"_br"@(FileId(1), 78..81) [Declared]: <error>
+"_bi"@(FileId(1), 101..104) [Declared]: <error>
+"_bn"@(FileId(1), 124..127) [Declared]: <error>
+"_rb"@(FileId(1), 147..150) [Declared]: <error>
+"_ib"@(FileId(1), 170..173) [Declared]: <error>
+"_nb"@(FileId(1), 193..196) [Declared]: <error>
+"_bb"@(FileId(1), 216..219) [Declared]: <error>
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 87..90: mismatched types for remainder

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__arithmetic_op_wrong_type_sub.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__arithmetic_op_wrong_type_sub.snap
@@ -4,17 +4,17 @@ assertion_line: 41
 expression: "\n    var b : boolean\n    var r : real\n    var i : int\n    var n : nat\n    var _br := b - r\n    var _bi := b - i\n    var _bn := b - n\n    var _rb := r - b\n    var _ib := i - b\n    var _nb := n - b\n    var _bb := b - b\n"
 
 ---
-"b"@(FileId(1), 9..10) [Declared]: ref_mut boolean
-"r"@(FileId(1), 29..30) [Declared]: ref_mut real
-"i"@(FileId(1), 46..47) [Declared]: ref_mut int
-"n"@(FileId(1), 62..63) [Declared]: ref_mut nat
-"_br"@(FileId(1), 78..81) [Declared]: ref_mut <error>
-"_bi"@(FileId(1), 99..102) [Declared]: ref_mut <error>
-"_bn"@(FileId(1), 120..123) [Declared]: ref_mut <error>
-"_rb"@(FileId(1), 141..144) [Declared]: ref_mut <error>
-"_ib"@(FileId(1), 162..165) [Declared]: ref_mut <error>
-"_nb"@(FileId(1), 183..186) [Declared]: ref_mut <error>
-"_bb"@(FileId(1), 204..207) [Declared]: ref_mut <error>
+"b"@(FileId(1), 9..10) [Declared]: boolean
+"r"@(FileId(1), 29..30) [Declared]: real
+"i"@(FileId(1), 46..47) [Declared]: int
+"n"@(FileId(1), 62..63) [Declared]: nat
+"_br"@(FileId(1), 78..81) [Declared]: <error>
+"_bi"@(FileId(1), 99..102) [Declared]: <error>
+"_bn"@(FileId(1), 120..123) [Declared]: <error>
+"_rb"@(FileId(1), 141..144) [Declared]: <error>
+"_ib"@(FileId(1), 162..165) [Declared]: <error>
+"_nb"@(FileId(1), 183..186) [Declared]: <error>
+"_bb"@(FileId(1), 204..207) [Declared]: <error>
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 87..88: mismatched types for subtraction

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_boolean.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_boolean.snap
@@ -1,9 +1,10 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "var b : boolean\n\nvar _v00 : boolean := b\n"
 
 ---
-"b"@(FileId(1), 4..5) [Declared]: ref_mut boolean
-"_v00"@(FileId(1), 21..25) [Declared]: ref_mut boolean
+"b"@(FileId(1), 4..5) [Declared]: boolean
+"_v00"@(FileId(1), 21..25) [Declared]: boolean
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_boolean_err.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_boolean_err.snap
@@ -1,15 +1,16 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "var r : real\nvar i : int\nvar n : nat\n\nvar _e00 : boolean := 1\nvar _e01 : boolean := i\nvar _e02 : boolean := n\nvar _e03 : boolean := r\n"
 
 ---
-"r"@(FileId(1), 4..5) [Declared]: ref_mut real
-"i"@(FileId(1), 17..18) [Declared]: ref_mut int
-"n"@(FileId(1), 29..30) [Declared]: ref_mut nat
-"_e00"@(FileId(1), 42..46) [Declared]: ref_mut boolean
-"_e01"@(FileId(1), 66..70) [Declared]: ref_mut boolean
-"_e02"@(FileId(1), 90..94) [Declared]: ref_mut boolean
-"_e03"@(FileId(1), 114..118) [Declared]: ref_mut boolean
+"r"@(FileId(1), 4..5) [Declared]: real
+"i"@(FileId(1), 17..18) [Declared]: int
+"n"@(FileId(1), 29..30) [Declared]: nat
+"_e00"@(FileId(1), 42..46) [Declared]: boolean
+"_e01"@(FileId(1), 66..70) [Declared]: boolean
+"_e02"@(FileId(1), 90..94) [Declared]: boolean
+"_e03"@(FileId(1), 114..118) [Declared]: boolean
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 60..61: mismatched types

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_char.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_char.snap
@@ -1,15 +1,16 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "var c : char\nvar c1 : char(1)\nvar s : string\nvar s1 : string(1)\n\nvar _v00 : char := c\nvar _v01 : char := c1\nvar _v02 : char := s1\nvar _v03 : char := s % runtime checked\n"
 
 ---
-"c"@(FileId(1), 4..5) [Declared]: ref_mut char
-"c1"@(FileId(1), 17..19) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
-"s"@(FileId(1), 34..35) [Declared]: ref_mut string
-"s1"@(FileId(1), 49..51) [Declared]: ref_mut string_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
-"_v00"@(FileId(1), 69..73) [Declared]: ref_mut char
-"_v01"@(FileId(1), 90..94) [Declared]: ref_mut char
-"_v02"@(FileId(1), 112..116) [Declared]: ref_mut char
-"_v03"@(FileId(1), 134..138) [Declared]: ref_mut char
+"c"@(FileId(1), 4..5) [Declared]: char
+"c1"@(FileId(1), 17..19) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
+"s"@(FileId(1), 34..35) [Declared]: string
+"s1"@(FileId(1), 49..51) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
+"_v00"@(FileId(1), 69..73) [Declared]: char
+"_v01"@(FileId(1), 90..94) [Declared]: char
+"_v02"@(FileId(1), 112..116) [Declared]: char
+"_v03"@(FileId(1), 134..138) [Declared]: char
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_char_1.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_char_1.snap
@@ -1,18 +1,19 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "const N := 1\nvar c : char\nvar c1 : char(1)\nvar s : string\nvar s1 : string(1)\nvar s5 : string(5)\n\nvar _v00 : char(N) := c\nvar _v01 : char(N) := c1\nvar _v02 : char(N) := s % runtime checked\nvar _v03 : char(N) := s1\nvar _v04 : char(N) := s5 % runtime checked\n"
 
 ---
-"N"@(FileId(1), 6..7) [Declared]: ref int
-"c"@(FileId(1), 17..18) [Declared]: ref_mut char
-"c1"@(FileId(1), 30..32) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
-"s"@(FileId(1), 47..48) [Declared]: ref_mut string
-"s1"@(FileId(1), 62..64) [Declared]: ref_mut string_n Fixed(Unevaluated(LibraryId(0), BodyId(2)))
-"s5"@(FileId(1), 81..83) [Declared]: ref_mut string_n Fixed(Unevaluated(LibraryId(0), BodyId(3)))
-"_v00"@(FileId(1), 101..105) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(4)))
-"_v01"@(FileId(1), 125..129) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(6)))
-"_v02"@(FileId(1), 150..154) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(8)))
-"_v03"@(FileId(1), 192..196) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(10)))
-"_v04"@(FileId(1), 217..221) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(12)))
+"N"@(FileId(1), 6..7) [Declared]: int
+"c"@(FileId(1), 17..18) [Declared]: char
+"c1"@(FileId(1), 30..32) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
+"s"@(FileId(1), 47..48) [Declared]: string
+"s1"@(FileId(1), 62..64) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(2)))
+"s5"@(FileId(1), 81..83) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(3)))
+"_v00"@(FileId(1), 101..105) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(4)))
+"_v01"@(FileId(1), 125..129) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(6)))
+"_v02"@(FileId(1), 150..154) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(8)))
+"_v03"@(FileId(1), 192..196) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(10)))
+"_v04"@(FileId(1), 217..221) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(12)))
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_char_1_err.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_char_1_err.snap
@@ -1,11 +1,12 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "const N := 1\nvar c5 : char(5)\n\nvar _e00 : char(N) := c5\n"
 
 ---
-"N"@(FileId(1), 6..7) [Declared]: ref int
-"c5"@(FileId(1), 17..19) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
-"_e00"@(FileId(1), 35..39) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(2)))
+"N"@(FileId(1), 6..7) [Declared]: int
+"c5"@(FileId(1), 17..19) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
+"_e00"@(FileId(1), 35..39) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(2)))
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 53..55: mismatched types

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_char_256.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_char_256.snap
@@ -1,12 +1,13 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "const N := 256\nvar c256 : char(256)\nvar s : string\n\nvar _v00 : char(N) := c256\nvar _v01 : char(N) := s % runtime checked, always fails\n"
 
 ---
-"N"@(FileId(1), 6..7) [Declared]: ref int
-"c256"@(FileId(1), 19..23) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
-"s"@(FileId(1), 40..41) [Declared]: ref_mut string
-"_v00"@(FileId(1), 56..60) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(2)))
-"_v01"@(FileId(1), 83..87) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(4)))
+"N"@(FileId(1), 6..7) [Declared]: int
+"c256"@(FileId(1), 19..23) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
+"s"@(FileId(1), 40..41) [Declared]: string
+"_v00"@(FileId(1), 56..60) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(2)))
+"_v01"@(FileId(1), 83..87) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(4)))
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_char_256_err.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_char_256_err.snap
@@ -1,17 +1,18 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "const N := 256\nvar c : char\nvar c5 : char(5)\nvar c257 : char(257)\nvar s5 : string(5)\n\nvar _e00 : char(N) := c\nvar _e01 : char(N) := c5\nvar _e01 : char(N) := c257\nvar _e02 : char(N) := s5 % [not captured by ctc]\n"
 
 ---
-"N"@(FileId(1), 6..7) [Declared]: ref int
-"c"@(FileId(1), 19..20) [Declared]: ref_mut char
-"c5"@(FileId(1), 32..34) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
-"c257"@(FileId(1), 49..53) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(2)))
-"s5"@(FileId(1), 70..72) [Declared]: ref_mut string_n Fixed(Unevaluated(LibraryId(0), BodyId(3)))
-"_e00"@(FileId(1), 90..94) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(4)))
-"_e01"@(FileId(1), 114..118) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(6)))
-"_e01"@(FileId(1), 139..143) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(8)))
-"_e02"@(FileId(1), 166..170) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(10)))
+"N"@(FileId(1), 6..7) [Declared]: int
+"c"@(FileId(1), 19..20) [Declared]: char
+"c5"@(FileId(1), 32..34) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
+"c257"@(FileId(1), 49..53) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(2)))
+"s5"@(FileId(1), 70..72) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(3)))
+"_e00"@(FileId(1), 90..94) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(4)))
+"_e01"@(FileId(1), 114..118) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(6)))
+"_e01"@(FileId(1), 139..143) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(8)))
+"_e02"@(FileId(1), 166..170) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(10)))
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 108..109: mismatched types

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_char_3.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_char_3.snap
@@ -1,16 +1,17 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "const N := 3\nvar c3 : char(3)\nvar s : string\nvar s3 : string(3)\nvar s5 : string(5)\n\nvar _v00 : char(N) := c3\nvar _v01 : char(N) := s % runtime checked\nvar _v02 : char(N) := s3\nvar _v03 : char(N) := s5 % runtime checked\n"
 
 ---
-"N"@(FileId(1), 6..7) [Declared]: ref int
-"c3"@(FileId(1), 17..19) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
-"s"@(FileId(1), 34..35) [Declared]: ref_mut string
-"s3"@(FileId(1), 49..51) [Declared]: ref_mut string_n Fixed(Unevaluated(LibraryId(0), BodyId(2)))
-"s5"@(FileId(1), 68..70) [Declared]: ref_mut string_n Fixed(Unevaluated(LibraryId(0), BodyId(3)))
-"_v00"@(FileId(1), 88..92) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(4)))
-"_v01"@(FileId(1), 113..117) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(6)))
-"_v02"@(FileId(1), 155..159) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(8)))
-"_v03"@(FileId(1), 180..184) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(10)))
+"N"@(FileId(1), 6..7) [Declared]: int
+"c3"@(FileId(1), 17..19) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
+"s"@(FileId(1), 34..35) [Declared]: string
+"s3"@(FileId(1), 49..51) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(2)))
+"s5"@(FileId(1), 68..70) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(3)))
+"_v00"@(FileId(1), 88..92) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(4)))
+"_v01"@(FileId(1), 113..117) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(6)))
+"_v02"@(FileId(1), 155..159) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(8)))
+"_v03"@(FileId(1), 180..184) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(10)))
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_char_3_err.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_char_3_err.snap
@@ -1,17 +1,18 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "const N := 3\nvar c : char\nvar c1 : char(1)\nvar c5 : char(5)\nvar s1 : string(1)\n\nvar _e00 : char(N) := c\nvar _e01 : char(N) := c1\nvar _e02 : char(N) := c5\nvar _e03 : char(N) := s1 % [not captured by ctc]\n"
 
 ---
-"N"@(FileId(1), 6..7) [Declared]: ref int
-"c"@(FileId(1), 17..18) [Declared]: ref_mut char
-"c1"@(FileId(1), 30..32) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
-"c5"@(FileId(1), 47..49) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(2)))
-"s1"@(FileId(1), 64..66) [Declared]: ref_mut string_n Fixed(Unevaluated(LibraryId(0), BodyId(3)))
-"_e00"@(FileId(1), 84..88) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(4)))
-"_e01"@(FileId(1), 108..112) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(6)))
-"_e02"@(FileId(1), 133..137) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(8)))
-"_e03"@(FileId(1), 158..162) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(10)))
+"N"@(FileId(1), 6..7) [Declared]: int
+"c"@(FileId(1), 17..18) [Declared]: char
+"c1"@(FileId(1), 30..32) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
+"c5"@(FileId(1), 47..49) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(2)))
+"s1"@(FileId(1), 64..66) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(3)))
+"_e00"@(FileId(1), 84..88) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(4)))
+"_e01"@(FileId(1), 108..112) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(6)))
+"_e02"@(FileId(1), 133..137) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(8)))
+"_e03"@(FileId(1), 158..162) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(10)))
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 102..103: mismatched types

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_char_dyn_lhs.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_char_dyn_lhs.snap
@@ -1,25 +1,26 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "% all runtime checked\nvar c : char\nvar c1 : char(1)\nvar c5 : char(5)\nvar c255 : char(255)\nvar c_dyn : char(*)\nvar s : string\nvar s1 : string(1)\nvar s5 : string(5)\nvar s_dyn : string(*)\n\nvar _v00 : char(*) := c\nvar _v01 : char(*) := c1\nvar _v02 : char(*) := c5\nvar _v03 : char(*) := c255\nvar _v04 : char(*) := c_dyn\nvar _v05 : char(*) := s\nvar _v06 : char(*) := s1\nvar _v07 : char(*) := s5\nvar _v08 : char(*) := s_dyn\n"
 
 ---
-"c"@(FileId(1), 26..27) [Declared]: ref_mut char
-"c1"@(FileId(1), 39..41) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
-"c5"@(FileId(1), 56..58) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
-"c255"@(FileId(1), 73..77) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(2)))
-"c_dyn"@(FileId(1), 94..99) [Declared]: ref_mut char_n Dynamic
-"s"@(FileId(1), 114..115) [Declared]: ref_mut string
-"s1"@(FileId(1), 129..131) [Declared]: ref_mut string_n Fixed(Unevaluated(LibraryId(0), BodyId(3)))
-"s5"@(FileId(1), 148..150) [Declared]: ref_mut string_n Fixed(Unevaluated(LibraryId(0), BodyId(4)))
-"s_dyn"@(FileId(1), 167..172) [Declared]: ref_mut string_n Dynamic
-"_v00"@(FileId(1), 190..194) [Declared]: ref_mut char_n Dynamic
-"_v01"@(FileId(1), 214..218) [Declared]: ref_mut char_n Dynamic
-"_v02"@(FileId(1), 239..243) [Declared]: ref_mut char_n Dynamic
-"_v03"@(FileId(1), 264..268) [Declared]: ref_mut char_n Dynamic
-"_v04"@(FileId(1), 291..295) [Declared]: ref_mut char_n Dynamic
-"_v05"@(FileId(1), 319..323) [Declared]: ref_mut char_n Dynamic
-"_v06"@(FileId(1), 343..347) [Declared]: ref_mut char_n Dynamic
-"_v07"@(FileId(1), 368..372) [Declared]: ref_mut char_n Dynamic
-"_v08"@(FileId(1), 393..397) [Declared]: ref_mut char_n Dynamic
+"c"@(FileId(1), 26..27) [Declared]: char
+"c1"@(FileId(1), 39..41) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
+"c5"@(FileId(1), 56..58) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
+"c255"@(FileId(1), 73..77) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(2)))
+"c_dyn"@(FileId(1), 94..99) [Declared]: char_n Dynamic
+"s"@(FileId(1), 114..115) [Declared]: string
+"s1"@(FileId(1), 129..131) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(3)))
+"s5"@(FileId(1), 148..150) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(4)))
+"s_dyn"@(FileId(1), 167..172) [Declared]: string_n Dynamic
+"_v00"@(FileId(1), 190..194) [Declared]: char_n Dynamic
+"_v01"@(FileId(1), 214..218) [Declared]: char_n Dynamic
+"_v02"@(FileId(1), 239..243) [Declared]: char_n Dynamic
+"_v03"@(FileId(1), 264..268) [Declared]: char_n Dynamic
+"_v04"@(FileId(1), 291..295) [Declared]: char_n Dynamic
+"_v05"@(FileId(1), 319..323) [Declared]: char_n Dynamic
+"_v06"@(FileId(1), 343..347) [Declared]: char_n Dynamic
+"_v07"@(FileId(1), 368..372) [Declared]: char_n Dynamic
+"_v08"@(FileId(1), 393..397) [Declared]: char_n Dynamic
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_char_dyn_rhs.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_char_dyn_rhs.snap
@@ -1,18 +1,19 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "% all runtime checked\nvar c_dyn : string(*)\n\nvar _v00 : char := c_dyn\nvar _v01 : char(1) := c_dyn\nvar _v02 : char(5) := c_dyn\nvar _v03 : char(255) := c_dyn\nvar _v04 : char(256) := c_dyn\nvar _v05 : char(*) := c_dyn\nvar _v06 : string := c_dyn\nvar _v07 : string(1) := c_dyn\nvar _v08 : string(5) := c_dyn\nvar _v09 : string(*) := c_dyn\n"
 
 ---
-"c_dyn"@(FileId(1), 26..31) [Declared]: ref_mut string_n Dynamic
-"_v00"@(FileId(1), 49..53) [Declared]: ref_mut char
-"_v01"@(FileId(1), 74..78) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
-"_v02"@(FileId(1), 102..106) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(3)))
-"_v03"@(FileId(1), 130..134) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(5)))
-"_v04"@(FileId(1), 160..164) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(7)))
-"_v05"@(FileId(1), 190..194) [Declared]: ref_mut char_n Dynamic
-"_v06"@(FileId(1), 218..222) [Declared]: ref_mut string
-"_v07"@(FileId(1), 245..249) [Declared]: ref_mut string_n Fixed(Unevaluated(LibraryId(0), BodyId(11)))
-"_v08"@(FileId(1), 275..279) [Declared]: ref_mut string_n Fixed(Unevaluated(LibraryId(0), BodyId(13)))
-"_v09"@(FileId(1), 305..309) [Declared]: ref_mut string_n Dynamic
+"c_dyn"@(FileId(1), 26..31) [Declared]: string_n Dynamic
+"_v00"@(FileId(1), 49..53) [Declared]: char
+"_v01"@(FileId(1), 74..78) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
+"_v02"@(FileId(1), 102..106) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(3)))
+"_v03"@(FileId(1), 130..134) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(5)))
+"_v04"@(FileId(1), 160..164) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(7)))
+"_v05"@(FileId(1), 190..194) [Declared]: char_n Dynamic
+"_v06"@(FileId(1), 218..222) [Declared]: string
+"_v07"@(FileId(1), 245..249) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(11)))
+"_v08"@(FileId(1), 275..279) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(13)))
+"_v09"@(FileId(1), 305..309) [Declared]: string_n Dynamic
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_char_err.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_char_err.snap
@@ -1,12 +1,13 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "var c5 : char(5)\nvar s5 : string(5)\n\nvar _e00 : char := s5\nvar _e01 : char := c5 % [not captured by ctc]\n"
 
 ---
-"c5"@(FileId(1), 4..6) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
-"s5"@(FileId(1), 21..23) [Declared]: ref_mut string_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
-"_e00"@(FileId(1), 41..45) [Declared]: ref_mut char
-"_e01"@(FileId(1), 63..67) [Declared]: ref_mut char
+"c5"@(FileId(1), 4..6) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
+"s5"@(FileId(1), 21..23) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
+"_e00"@(FileId(1), 41..45) [Declared]: char
+"_e01"@(FileId(1), 63..67) [Declared]: char
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 56..58: mismatched types

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_int.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_int.snap
@@ -1,12 +1,13 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "var i : int\nvar n : nat\n\nvar _v00 : int := 1\nvar _v01 : int := i\nvar _v02 : int := n\n"
 
 ---
-"i"@(FileId(1), 4..5) [Declared]: ref_mut int
-"n"@(FileId(1), 16..17) [Declared]: ref_mut nat
-"_v00"@(FileId(1), 29..33) [Declared]: ref_mut int
-"_v01"@(FileId(1), 49..53) [Declared]: ref_mut int
-"_v02"@(FileId(1), 69..73) [Declared]: ref_mut int
+"i"@(FileId(1), 4..5) [Declared]: int
+"n"@(FileId(1), 16..17) [Declared]: nat
+"_v00"@(FileId(1), 29..33) [Declared]: int
+"_v01"@(FileId(1), 49..53) [Declared]: int
+"_v02"@(FileId(1), 69..73) [Declared]: int
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_int_err.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_int_err.snap
@@ -1,12 +1,13 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "var b : boolean\nvar r : real\n\nvar _e00 : int := b\nvar _e01 : int := r\n"
 
 ---
-"b"@(FileId(1), 4..5) [Declared]: ref_mut boolean
-"r"@(FileId(1), 20..21) [Declared]: ref_mut real
-"_e00"@(FileId(1), 34..38) [Declared]: ref_mut int
-"_e01"@(FileId(1), 54..58) [Declared]: ref_mut int
+"b"@(FileId(1), 4..5) [Declared]: boolean
+"r"@(FileId(1), 20..21) [Declared]: real
+"_e00"@(FileId(1), 34..38) [Declared]: int
+"_e01"@(FileId(1), 54..58) [Declared]: int
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 48..49: mismatched types

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_nat.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_nat.snap
@@ -1,12 +1,13 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "var i : int\nvar n : nat\n\nvar _v00 : nat := 1\nvar _v01 : nat := i\nvar _v02 : nat := n\n"
 
 ---
-"i"@(FileId(1), 4..5) [Declared]: ref_mut int
-"n"@(FileId(1), 16..17) [Declared]: ref_mut nat
-"_v00"@(FileId(1), 29..33) [Declared]: ref_mut nat
-"_v01"@(FileId(1), 49..53) [Declared]: ref_mut nat
-"_v02"@(FileId(1), 69..73) [Declared]: ref_mut nat
+"i"@(FileId(1), 4..5) [Declared]: int
+"n"@(FileId(1), 16..17) [Declared]: nat
+"_v00"@(FileId(1), 29..33) [Declared]: nat
+"_v01"@(FileId(1), 49..53) [Declared]: nat
+"_v02"@(FileId(1), 69..73) [Declared]: nat
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_nat_err.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_nat_err.snap
@@ -1,12 +1,13 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "var b : boolean\nvar r : real\n\nvar _e00 : nat := b\nvar _e01 : nat := r\n"
 
 ---
-"b"@(FileId(1), 4..5) [Declared]: ref_mut boolean
-"r"@(FileId(1), 20..21) [Declared]: ref_mut real
-"_e00"@(FileId(1), 34..38) [Declared]: ref_mut nat
-"_e01"@(FileId(1), 54..58) [Declared]: ref_mut nat
+"b"@(FileId(1), 4..5) [Declared]: boolean
+"r"@(FileId(1), 20..21) [Declared]: real
+"_e00"@(FileId(1), 34..38) [Declared]: nat
+"_e01"@(FileId(1), 54..58) [Declared]: nat
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 48..49: mismatched types

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_real.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_real.snap
@@ -1,14 +1,15 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "var r : real\nvar i : int\nvar n : nat\n\nvar _v00 : real := 1\nvar _v01 : real := i\nvar _v02 : real := n\nvar _v03 : real := r\n"
 
 ---
-"r"@(FileId(1), 4..5) [Declared]: ref_mut real
-"i"@(FileId(1), 17..18) [Declared]: ref_mut int
-"n"@(FileId(1), 29..30) [Declared]: ref_mut nat
-"_v00"@(FileId(1), 42..46) [Declared]: ref_mut real
-"_v01"@(FileId(1), 63..67) [Declared]: ref_mut real
-"_v02"@(FileId(1), 84..88) [Declared]: ref_mut real
-"_v03"@(FileId(1), 105..109) [Declared]: ref_mut real
+"r"@(FileId(1), 4..5) [Declared]: real
+"i"@(FileId(1), 17..18) [Declared]: int
+"n"@(FileId(1), 29..30) [Declared]: nat
+"_v00"@(FileId(1), 42..46) [Declared]: real
+"_v01"@(FileId(1), 63..67) [Declared]: real
+"_v02"@(FileId(1), 84..88) [Declared]: real
+"_v03"@(FileId(1), 105..109) [Declared]: real
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_real_err.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_real_err.snap
@@ -1,10 +1,11 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "var b : boolean\n\nvar _e00 : real := b\n"
 
 ---
-"b"@(FileId(1), 4..5) [Declared]: ref_mut boolean
-"_e00"@(FileId(1), 21..25) [Declared]: ref_mut real
+"b"@(FileId(1), 4..5) [Declared]: boolean
+"_e00"@(FileId(1), 21..25) [Declared]: real
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 36..37: mismatched types

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_string.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_string.snap
@@ -1,21 +1,22 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "var c : char\nvar c1 : char(1)\nvar c5 : char(5)\nvar c255 : char(255)\nvar s : string\nvar s1 : string(1)\nvar s5 : string(5)\n\nvar _v00 : string := c\nvar _v01 : string := c1\nvar _v02 : string := c5\nvar _v03 : string := c255\nvar _v04 : string := s\nvar _v05 : string := s1\nvar _v06 : string := s5\n"
 
 ---
-"c"@(FileId(1), 4..5) [Declared]: ref_mut char
-"c1"@(FileId(1), 17..19) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
-"c5"@(FileId(1), 34..36) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
-"c255"@(FileId(1), 51..55) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(2)))
-"s"@(FileId(1), 72..73) [Declared]: ref_mut string
-"s1"@(FileId(1), 87..89) [Declared]: ref_mut string_n Fixed(Unevaluated(LibraryId(0), BodyId(3)))
-"s5"@(FileId(1), 106..108) [Declared]: ref_mut string_n Fixed(Unevaluated(LibraryId(0), BodyId(4)))
-"_v00"@(FileId(1), 126..130) [Declared]: ref_mut string
-"_v01"@(FileId(1), 149..153) [Declared]: ref_mut string
-"_v02"@(FileId(1), 173..177) [Declared]: ref_mut string
-"_v03"@(FileId(1), 197..201) [Declared]: ref_mut string
-"_v04"@(FileId(1), 223..227) [Declared]: ref_mut string
-"_v05"@(FileId(1), 246..250) [Declared]: ref_mut string
-"_v06"@(FileId(1), 270..274) [Declared]: ref_mut string
+"c"@(FileId(1), 4..5) [Declared]: char
+"c1"@(FileId(1), 17..19) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
+"c5"@(FileId(1), 34..36) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
+"c255"@(FileId(1), 51..55) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(2)))
+"s"@(FileId(1), 72..73) [Declared]: string
+"s1"@(FileId(1), 87..89) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(3)))
+"s5"@(FileId(1), 106..108) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(4)))
+"_v00"@(FileId(1), 126..130) [Declared]: string
+"_v01"@(FileId(1), 149..153) [Declared]: string
+"_v02"@(FileId(1), 173..177) [Declared]: string
+"_v03"@(FileId(1), 197..201) [Declared]: string
+"_v04"@(FileId(1), 223..227) [Declared]: string
+"_v05"@(FileId(1), 246..250) [Declared]: string
+"_v06"@(FileId(1), 270..274) [Declared]: string
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_string_1.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_string_1.snap
@@ -1,18 +1,19 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "const N := 1\nvar c : char\nvar c1 : char(1)\nvar s : string\nvar s1 : string(1)\nvar s5 : string(5)\n\nvar _v00 : string(N) := c\nvar _v01 : string(N) := c1\nvar _v02 : string(N) := s % runtime checked\nvar _v03 : string(N) := s1\nvar _v04 : string(N) := s5 % runtime checked\n"
 
 ---
-"N"@(FileId(1), 6..7) [Declared]: ref int
-"c"@(FileId(1), 17..18) [Declared]: ref_mut char
-"c1"@(FileId(1), 30..32) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
-"s"@(FileId(1), 47..48) [Declared]: ref_mut string
-"s1"@(FileId(1), 62..64) [Declared]: ref_mut string_n Fixed(Unevaluated(LibraryId(0), BodyId(2)))
-"s5"@(FileId(1), 81..83) [Declared]: ref_mut string_n Fixed(Unevaluated(LibraryId(0), BodyId(3)))
-"_v00"@(FileId(1), 101..105) [Declared]: ref_mut string_n Fixed(Unevaluated(LibraryId(0), BodyId(4)))
-"_v01"@(FileId(1), 127..131) [Declared]: ref_mut string_n Fixed(Unevaluated(LibraryId(0), BodyId(6)))
-"_v02"@(FileId(1), 154..158) [Declared]: ref_mut string_n Fixed(Unevaluated(LibraryId(0), BodyId(8)))
-"_v03"@(FileId(1), 198..202) [Declared]: ref_mut string_n Fixed(Unevaluated(LibraryId(0), BodyId(10)))
-"_v04"@(FileId(1), 225..229) [Declared]: ref_mut string_n Fixed(Unevaluated(LibraryId(0), BodyId(12)))
+"N"@(FileId(1), 6..7) [Declared]: int
+"c"@(FileId(1), 17..18) [Declared]: char
+"c1"@(FileId(1), 30..32) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
+"s"@(FileId(1), 47..48) [Declared]: string
+"s1"@(FileId(1), 62..64) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(2)))
+"s5"@(FileId(1), 81..83) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(3)))
+"_v00"@(FileId(1), 101..105) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(4)))
+"_v01"@(FileId(1), 127..131) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(6)))
+"_v02"@(FileId(1), 154..158) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(8)))
+"_v03"@(FileId(1), 198..202) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(10)))
+"_v04"@(FileId(1), 225..229) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(12)))
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_string_1_err.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_string_1_err.snap
@@ -1,11 +1,12 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "const N := 1\nvar c5 : char(5)\n\nvar _e00 : string(N) := c5 % [not captured by ctc]\n"
 
 ---
-"N"@(FileId(1), 6..7) [Declared]: ref int
-"c5"@(FileId(1), 17..19) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
-"_e00"@(FileId(1), 35..39) [Declared]: ref_mut string_n Fixed(Unevaluated(LibraryId(0), BodyId(2)))
+"N"@(FileId(1), 6..7) [Declared]: int
+"c5"@(FileId(1), 17..19) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
+"_e00"@(FileId(1), 35..39) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(2)))
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 55..57: mismatched types

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_string_255.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_string_255.snap
@@ -1,20 +1,21 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "const N := 255\nvar c : char\nvar c1 : char(1)\nvar c255 : char(255)\nvar s : string\nvar s1 : string(1)\nvar s255 : string(255)\n\nvar _v00 : string(N) := c\nvar _v01 : string(N) := c1\nvar _v02 : string(N) := c255\nvar _v03 : string(N) := s % runtime checked, always good\nvar _v04 : string(N) := s1\nvar _v05 : string(N) := s255\n"
 
 ---
-"N"@(FileId(1), 6..7) [Declared]: ref int
-"c"@(FileId(1), 19..20) [Declared]: ref_mut char
-"c1"@(FileId(1), 32..34) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
-"c255"@(FileId(1), 49..53) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(2)))
-"s"@(FileId(1), 70..71) [Declared]: ref_mut string
-"s1"@(FileId(1), 85..87) [Declared]: ref_mut string_n Fixed(Unevaluated(LibraryId(0), BodyId(3)))
-"s255"@(FileId(1), 104..108) [Declared]: ref_mut string_n Fixed(Unevaluated(LibraryId(0), BodyId(4)))
-"_v00"@(FileId(1), 128..132) [Declared]: ref_mut string_n Fixed(Unevaluated(LibraryId(0), BodyId(5)))
-"_v01"@(FileId(1), 154..158) [Declared]: ref_mut string_n Fixed(Unevaluated(LibraryId(0), BodyId(7)))
-"_v02"@(FileId(1), 181..185) [Declared]: ref_mut string_n Fixed(Unevaluated(LibraryId(0), BodyId(9)))
-"_v03"@(FileId(1), 210..214) [Declared]: ref_mut string_n Fixed(Unevaluated(LibraryId(0), BodyId(11)))
-"_v04"@(FileId(1), 267..271) [Declared]: ref_mut string_n Fixed(Unevaluated(LibraryId(0), BodyId(13)))
-"_v05"@(FileId(1), 294..298) [Declared]: ref_mut string_n Fixed(Unevaluated(LibraryId(0), BodyId(15)))
+"N"@(FileId(1), 6..7) [Declared]: int
+"c"@(FileId(1), 19..20) [Declared]: char
+"c1"@(FileId(1), 32..34) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
+"c255"@(FileId(1), 49..53) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(2)))
+"s"@(FileId(1), 70..71) [Declared]: string
+"s1"@(FileId(1), 85..87) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(3)))
+"s255"@(FileId(1), 104..108) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(4)))
+"_v00"@(FileId(1), 128..132) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(5)))
+"_v01"@(FileId(1), 154..158) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(7)))
+"_v02"@(FileId(1), 181..185) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(9)))
+"_v03"@(FileId(1), 210..214) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(11)))
+"_v04"@(FileId(1), 267..271) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(13)))
+"_v05"@(FileId(1), 294..298) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(15)))
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_string_255_err.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_string_255_err.snap
@@ -1,11 +1,12 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "const N := 255\nvar c256 : char(256)\n\nvar _e00 : string(N) := c256 % [not captured by ctc]\n"
 
 ---
-"N"@(FileId(1), 6..7) [Declared]: ref int
-"c256"@(FileId(1), 19..23) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
-"_e00"@(FileId(1), 41..45) [Declared]: ref_mut string_n Fixed(Unevaluated(LibraryId(0), BodyId(2)))
+"N"@(FileId(1), 6..7) [Declared]: int
+"c256"@(FileId(1), 19..23) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
+"_e00"@(FileId(1), 41..45) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(2)))
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 61..65: mismatched types

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_string_3.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_string_3.snap
@@ -1,22 +1,23 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "const N := 3\nvar c : char\nvar c1 : char(1)\nvar c3 : char(3)\nvar s : string\nvar s1 : string(1)\nvar s3 : string(3)\nvar s5 : string(5)\n\nvar _v00 : string(N) := c\nvar _v01 : string(N) := c1\nvar _v03 : string(N) := c3\nvar _v05 : string(N) := s % runtime checked\nvar _v02 : string(N) := s1\nvar _v04 : string(N) := s3\nvar _v06 : string(N) := s5 % runtime checked\n"
 
 ---
-"N"@(FileId(1), 6..7) [Declared]: ref int
-"c"@(FileId(1), 17..18) [Declared]: ref_mut char
-"c1"@(FileId(1), 30..32) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
-"c3"@(FileId(1), 47..49) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(2)))
-"s"@(FileId(1), 64..65) [Declared]: ref_mut string
-"s1"@(FileId(1), 79..81) [Declared]: ref_mut string_n Fixed(Unevaluated(LibraryId(0), BodyId(3)))
-"s3"@(FileId(1), 98..100) [Declared]: ref_mut string_n Fixed(Unevaluated(LibraryId(0), BodyId(4)))
-"s5"@(FileId(1), 117..119) [Declared]: ref_mut string_n Fixed(Unevaluated(LibraryId(0), BodyId(5)))
-"_v00"@(FileId(1), 137..141) [Declared]: ref_mut string_n Fixed(Unevaluated(LibraryId(0), BodyId(6)))
-"_v01"@(FileId(1), 163..167) [Declared]: ref_mut string_n Fixed(Unevaluated(LibraryId(0), BodyId(8)))
-"_v03"@(FileId(1), 190..194) [Declared]: ref_mut string_n Fixed(Unevaluated(LibraryId(0), BodyId(10)))
-"_v05"@(FileId(1), 217..221) [Declared]: ref_mut string_n Fixed(Unevaluated(LibraryId(0), BodyId(12)))
-"_v02"@(FileId(1), 261..265) [Declared]: ref_mut string_n Fixed(Unevaluated(LibraryId(0), BodyId(14)))
-"_v04"@(FileId(1), 288..292) [Declared]: ref_mut string_n Fixed(Unevaluated(LibraryId(0), BodyId(16)))
-"_v06"@(FileId(1), 315..319) [Declared]: ref_mut string_n Fixed(Unevaluated(LibraryId(0), BodyId(18)))
+"N"@(FileId(1), 6..7) [Declared]: int
+"c"@(FileId(1), 17..18) [Declared]: char
+"c1"@(FileId(1), 30..32) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
+"c3"@(FileId(1), 47..49) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(2)))
+"s"@(FileId(1), 64..65) [Declared]: string
+"s1"@(FileId(1), 79..81) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(3)))
+"s3"@(FileId(1), 98..100) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(4)))
+"s5"@(FileId(1), 117..119) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(5)))
+"_v00"@(FileId(1), 137..141) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(6)))
+"_v01"@(FileId(1), 163..167) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(8)))
+"_v03"@(FileId(1), 190..194) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(10)))
+"_v05"@(FileId(1), 217..221) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(12)))
+"_v02"@(FileId(1), 261..265) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(14)))
+"_v04"@(FileId(1), 288..292) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(16)))
+"_v06"@(FileId(1), 315..319) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(18)))
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_string_3_err.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_string_3_err.snap
@@ -1,11 +1,12 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "const N := 3\nvar c5 : char(5)\n\nvar _e00 : string(N) := c5 % [not captured by ctc]\n"
 
 ---
-"N"@(FileId(1), 6..7) [Declared]: ref int
-"c5"@(FileId(1), 17..19) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
-"_e00"@(FileId(1), 35..39) [Declared]: ref_mut string_n Fixed(Unevaluated(LibraryId(0), BodyId(2)))
+"N"@(FileId(1), 6..7) [Declared]: int
+"c5"@(FileId(1), 17..19) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
+"_e00"@(FileId(1), 35..39) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(2)))
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 55..57: mismatched types

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_string_dyn_lhs.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_string_dyn_lhs.snap
@@ -1,25 +1,26 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "% all runtime checked\nvar c : char\nvar c1 : char(1)\nvar c5 : char(5)\nvar c255 : char(255)\nvar c_dyn : char(*)\nvar s : string\nvar s1 : string(1)\nvar s5 : string(5)\nvar s_dyn : string(*)\n\nvar _v00 : string(*) := c\nvar _v01 : string(*) := c1\nvar _v02 : string(*) := c5\nvar _v03 : string(*) := c255\nvar _v04 : string(*) := c_dyn\nvar _v05 : string(*) := s\nvar _v06 : string(*) := s1\nvar _v07 : string(*) := s5\nvar _v08 : string(*) := s_dyn\n"
 
 ---
-"c"@(FileId(1), 26..27) [Declared]: ref_mut char
-"c1"@(FileId(1), 39..41) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
-"c5"@(FileId(1), 56..58) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
-"c255"@(FileId(1), 73..77) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(2)))
-"c_dyn"@(FileId(1), 94..99) [Declared]: ref_mut char_n Dynamic
-"s"@(FileId(1), 114..115) [Declared]: ref_mut string
-"s1"@(FileId(1), 129..131) [Declared]: ref_mut string_n Fixed(Unevaluated(LibraryId(0), BodyId(3)))
-"s5"@(FileId(1), 148..150) [Declared]: ref_mut string_n Fixed(Unevaluated(LibraryId(0), BodyId(4)))
-"s_dyn"@(FileId(1), 167..172) [Declared]: ref_mut string_n Dynamic
-"_v00"@(FileId(1), 190..194) [Declared]: ref_mut string_n Dynamic
-"_v01"@(FileId(1), 216..220) [Declared]: ref_mut string_n Dynamic
-"_v02"@(FileId(1), 243..247) [Declared]: ref_mut string_n Dynamic
-"_v03"@(FileId(1), 270..274) [Declared]: ref_mut string_n Dynamic
-"_v04"@(FileId(1), 299..303) [Declared]: ref_mut string_n Dynamic
-"_v05"@(FileId(1), 329..333) [Declared]: ref_mut string_n Dynamic
-"_v06"@(FileId(1), 355..359) [Declared]: ref_mut string_n Dynamic
-"_v07"@(FileId(1), 382..386) [Declared]: ref_mut string_n Dynamic
-"_v08"@(FileId(1), 409..413) [Declared]: ref_mut string_n Dynamic
+"c"@(FileId(1), 26..27) [Declared]: char
+"c1"@(FileId(1), 39..41) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
+"c5"@(FileId(1), 56..58) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
+"c255"@(FileId(1), 73..77) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(2)))
+"c_dyn"@(FileId(1), 94..99) [Declared]: char_n Dynamic
+"s"@(FileId(1), 114..115) [Declared]: string
+"s1"@(FileId(1), 129..131) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(3)))
+"s5"@(FileId(1), 148..150) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(4)))
+"s_dyn"@(FileId(1), 167..172) [Declared]: string_n Dynamic
+"_v00"@(FileId(1), 190..194) [Declared]: string_n Dynamic
+"_v01"@(FileId(1), 216..220) [Declared]: string_n Dynamic
+"_v02"@(FileId(1), 243..247) [Declared]: string_n Dynamic
+"_v03"@(FileId(1), 270..274) [Declared]: string_n Dynamic
+"_v04"@(FileId(1), 299..303) [Declared]: string_n Dynamic
+"_v05"@(FileId(1), 329..333) [Declared]: string_n Dynamic
+"_v06"@(FileId(1), 355..359) [Declared]: string_n Dynamic
+"_v07"@(FileId(1), 382..386) [Declared]: string_n Dynamic
+"_v08"@(FileId(1), 409..413) [Declared]: string_n Dynamic
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_string_dyn_rhs.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_string_dyn_rhs.snap
@@ -1,18 +1,19 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "% all runtime checked\nvar s_dyn : string(*)\n\nvar _v00 : char := s_dyn\nvar _v01 : char(1) := s_dyn\nvar _v02 : char(5) := s_dyn\nvar _v03 : char(255) := s_dyn\nvar _v04 : char(256) := s_dyn\nvar _v05 : char(*) := s_dyn\nvar _v06 : string := s_dyn\nvar _v07 : string(1) := s_dyn\nvar _v08 : string(5) := s_dyn\nvar _v09 : string(*) := s_dyn\n"
 
 ---
-"s_dyn"@(FileId(1), 26..31) [Declared]: ref_mut string_n Dynamic
-"_v00"@(FileId(1), 49..53) [Declared]: ref_mut char
-"_v01"@(FileId(1), 74..78) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
-"_v02"@(FileId(1), 102..106) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(3)))
-"_v03"@(FileId(1), 130..134) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(5)))
-"_v04"@(FileId(1), 160..164) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(7)))
-"_v05"@(FileId(1), 190..194) [Declared]: ref_mut char_n Dynamic
-"_v06"@(FileId(1), 218..222) [Declared]: ref_mut string
-"_v07"@(FileId(1), 245..249) [Declared]: ref_mut string_n Fixed(Unevaluated(LibraryId(0), BodyId(11)))
-"_v08"@(FileId(1), 275..279) [Declared]: ref_mut string_n Fixed(Unevaluated(LibraryId(0), BodyId(13)))
-"_v09"@(FileId(1), 305..309) [Declared]: ref_mut string_n Dynamic
+"s_dyn"@(FileId(1), 26..31) [Declared]: string_n Dynamic
+"_v00"@(FileId(1), 49..53) [Declared]: char
+"_v01"@(FileId(1), 74..78) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
+"_v02"@(FileId(1), 102..106) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(3)))
+"_v03"@(FileId(1), 130..134) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(5)))
+"_v04"@(FileId(1), 160..164) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(7)))
+"_v05"@(FileId(1), 190..194) [Declared]: char_n Dynamic
+"_v06"@(FileId(1), 218..222) [Declared]: string
+"_v07"@(FileId(1), 245..249) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(11)))
+"_v08"@(FileId(1), 275..279) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(13)))
+"_v09"@(FileId(1), 305..309) [Declared]: string_n Dynamic
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_string_err.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_string_err.snap
@@ -1,10 +1,11 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "var cmx : char(256)\n\nvar _e00 : string := cmx % [not captured by ctc]\n"
 
 ---
-"cmx"@(FileId(1), 4..7) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
-"_e00"@(FileId(1), 25..29) [Declared]: ref_mut string
+"cmx"@(FileId(1), 4..7) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
+"_e00"@(FileId(1), 25..29) [Declared]: string
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 42..45: mismatched types

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_string_err_lhs.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_string_err_lhs.snap
@@ -1,10 +1,11 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "var cmx : char(256)\n\nvar _e00 : string(*) := cmx % [not captured by ctc]\n"
 
 ---
-"cmx"@(FileId(1), 4..7) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
-"_e00"@(FileId(1), 25..29) [Declared]: ref_mut string_n Dynamic
+"cmx"@(FileId(1), 4..7) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
+"_e00"@(FileId(1), 25..29) [Declared]: string_n Dynamic
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 45..48: mismatched types

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__bare_var_decl-2.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__bare_var_decl-2.snap
@@ -1,9 +1,10 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "const k k := 3"
 
 ---
-"k"@(FileId(1), 6..7) [Declared]: ref <error>
+"k"@(FileId(1), 6..7) [Declared]: <error>
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 10..12: cannot assign into expression

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__bare_var_decl.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__bare_var_decl.snap
@@ -1,8 +1,9 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "var k k := 3"
 
 ---
-"k"@(FileId(1), 4..5) [Declared]: ref_mut <error>
+"k"@(FileId(1), 4..5) [Declared]: <error>
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__bitwise_op_and.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__bitwise_op_and.snap
@@ -1,13 +1,14 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "\n    % Compatibility with all variant of integers\n    var i : int\n    var n : nat\n    var _ii := i and i\n    var _in := i and n\n    var _ni := n and i\n    var _nn := n and n\n"
 
 ---
-"i"@(FileId(1), 58..59) [Declared]: ref_mut int
-"n"@(FileId(1), 74..75) [Declared]: ref_mut nat
-"_ii"@(FileId(1), 90..93) [Declared]: ref_mut nat
-"_in"@(FileId(1), 113..116) [Declared]: ref_mut nat
-"_ni"@(FileId(1), 136..139) [Declared]: ref_mut nat
-"_nn"@(FileId(1), 159..162) [Declared]: ref_mut nat
+"i"@(FileId(1), 58..59) [Declared]: int
+"n"@(FileId(1), 74..75) [Declared]: nat
+"_ii"@(FileId(1), 90..93) [Declared]: nat
+"_in"@(FileId(1), 113..116) [Declared]: nat
+"_ni"@(FileId(1), 136..139) [Declared]: nat
+"_nn"@(FileId(1), 159..162) [Declared]: nat
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__bitwise_op_not.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__bitwise_op_not.snap
@@ -1,11 +1,12 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "\n    % Compatibility with all variant of integers\n    var i : int\n    var n : nat\n    var _i := not i\n    var _n := not n\n"
 
 ---
-"i"@(FileId(1), 58..59) [Declared]: ref_mut int
-"n"@(FileId(1), 74..75) [Declared]: ref_mut nat
-"_i"@(FileId(1), 90..92) [Declared]: ref_mut nat
-"_n"@(FileId(1), 110..112) [Declared]: ref_mut nat
+"i"@(FileId(1), 58..59) [Declared]: int
+"n"@(FileId(1), 74..75) [Declared]: nat
+"_i"@(FileId(1), 90..92) [Declared]: nat
+"_n"@(FileId(1), 110..112) [Declared]: nat
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__bitwise_op_or.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__bitwise_op_or.snap
@@ -1,13 +1,14 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "\n    % Compatibility with all variant of integers\n    var i : int\n    var n : nat\n    var _ii := i or i\n    var _in := i or n\n    var _ni := n or i\n    var _nn := n or n\n"
 
 ---
-"i"@(FileId(1), 58..59) [Declared]: ref_mut int
-"n"@(FileId(1), 74..75) [Declared]: ref_mut nat
-"_ii"@(FileId(1), 90..93) [Declared]: ref_mut nat
-"_in"@(FileId(1), 112..115) [Declared]: ref_mut nat
-"_ni"@(FileId(1), 134..137) [Declared]: ref_mut nat
-"_nn"@(FileId(1), 156..159) [Declared]: ref_mut nat
+"i"@(FileId(1), 58..59) [Declared]: int
+"n"@(FileId(1), 74..75) [Declared]: nat
+"_ii"@(FileId(1), 90..93) [Declared]: nat
+"_in"@(FileId(1), 112..115) [Declared]: nat
+"_ni"@(FileId(1), 134..137) [Declared]: nat
+"_nn"@(FileId(1), 156..159) [Declared]: nat
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__bitwise_op_shl.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__bitwise_op_shl.snap
@@ -1,13 +1,14 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "\n    % Compatibility with all variant of integers\n    var i : int\n    var n : nat\n    var _ii := i shl i\n    var _in := i shl n\n    var _ni := n shl i\n    var _nn := n shl n\n"
 
 ---
-"i"@(FileId(1), 58..59) [Declared]: ref_mut int
-"n"@(FileId(1), 74..75) [Declared]: ref_mut nat
-"_ii"@(FileId(1), 90..93) [Declared]: ref_mut nat
-"_in"@(FileId(1), 113..116) [Declared]: ref_mut nat
-"_ni"@(FileId(1), 136..139) [Declared]: ref_mut nat
-"_nn"@(FileId(1), 159..162) [Declared]: ref_mut nat
+"i"@(FileId(1), 58..59) [Declared]: int
+"n"@(FileId(1), 74..75) [Declared]: nat
+"_ii"@(FileId(1), 90..93) [Declared]: nat
+"_in"@(FileId(1), 113..116) [Declared]: nat
+"_ni"@(FileId(1), 136..139) [Declared]: nat
+"_nn"@(FileId(1), 159..162) [Declared]: nat
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__bitwise_op_shr.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__bitwise_op_shr.snap
@@ -1,13 +1,14 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "\n    % Compatibility with all variant of integers\n    var i : int\n    var n : nat\n    var _ii := i shr i\n    var _in := i shr n\n    var _ni := n shr i\n    var _nn := n shr n\n"
 
 ---
-"i"@(FileId(1), 58..59) [Declared]: ref_mut int
-"n"@(FileId(1), 74..75) [Declared]: ref_mut nat
-"_ii"@(FileId(1), 90..93) [Declared]: ref_mut nat
-"_in"@(FileId(1), 113..116) [Declared]: ref_mut nat
-"_ni"@(FileId(1), 136..139) [Declared]: ref_mut nat
-"_nn"@(FileId(1), 159..162) [Declared]: ref_mut nat
+"i"@(FileId(1), 58..59) [Declared]: int
+"n"@(FileId(1), 74..75) [Declared]: nat
+"_ii"@(FileId(1), 90..93) [Declared]: nat
+"_in"@(FileId(1), 113..116) [Declared]: nat
+"_ni"@(FileId(1), 136..139) [Declared]: nat
+"_nn"@(FileId(1), 159..162) [Declared]: nat
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__bitwise_op_wrong_type_and.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__bitwise_op_wrong_type_and.snap
@@ -4,18 +4,18 @@ assertion_line: 41
 expression: "\n    var b : boolean\n    var r : real\n    var i : int\n    var n : nat\n    var _bi := b and i\n    var _bn := b and n\n    var _ib := i and b\n    var _nb := n and b\n    var _ri := r and i\n    var _rn := r and n\n    var _ir := i and r\n    var _nr := n and r\n"
 
 ---
-"b"@(FileId(1), 9..10) [Declared]: ref_mut boolean
-"r"@(FileId(1), 29..30) [Declared]: ref_mut real
-"i"@(FileId(1), 46..47) [Declared]: ref_mut int
-"n"@(FileId(1), 62..63) [Declared]: ref_mut nat
-"_bi"@(FileId(1), 78..81) [Declared]: ref_mut <error>
-"_bn"@(FileId(1), 101..104) [Declared]: ref_mut <error>
-"_ib"@(FileId(1), 124..127) [Declared]: ref_mut <error>
-"_nb"@(FileId(1), 147..150) [Declared]: ref_mut <error>
-"_ri"@(FileId(1), 170..173) [Declared]: ref_mut <error>
-"_rn"@(FileId(1), 193..196) [Declared]: ref_mut <error>
-"_ir"@(FileId(1), 216..219) [Declared]: ref_mut <error>
-"_nr"@(FileId(1), 239..242) [Declared]: ref_mut <error>
+"b"@(FileId(1), 9..10) [Declared]: boolean
+"r"@(FileId(1), 29..30) [Declared]: real
+"i"@(FileId(1), 46..47) [Declared]: int
+"n"@(FileId(1), 62..63) [Declared]: nat
+"_bi"@(FileId(1), 78..81) [Declared]: <error>
+"_bn"@(FileId(1), 101..104) [Declared]: <error>
+"_ib"@(FileId(1), 124..127) [Declared]: <error>
+"_nb"@(FileId(1), 147..150) [Declared]: <error>
+"_ri"@(FileId(1), 170..173) [Declared]: <error>
+"_rn"@(FileId(1), 193..196) [Declared]: <error>
+"_ir"@(FileId(1), 216..219) [Declared]: <error>
+"_nr"@(FileId(1), 239..242) [Declared]: <error>
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 87..90: mismatched types for logical `and`

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__bitwise_op_wrong_type_not.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__bitwise_op_wrong_type_not.snap
@@ -1,10 +1,11 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "\n    var r : real\n    var _r := not r\n"
 
 ---
-"r"@(FileId(1), 9..10) [Declared]: ref_mut real
-"_r"@(FileId(1), 26..28) [Declared]: ref_mut <error>
+"r"@(FileId(1), 9..10) [Declared]: real
+"_r"@(FileId(1), 26..28) [Declared]: <error>
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 32..35: mismatched types for logical `not`

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__bitwise_op_wrong_type_or.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__bitwise_op_wrong_type_or.snap
@@ -4,18 +4,18 @@ assertion_line: 41
 expression: "\n    var b : boolean\n    var r : real\n    var i : int\n    var n : nat\n    var _bi := b or i\n    var _bn := b or n\n    var _ib := i or b\n    var _nb := n or b\n    var _ri := r or i\n    var _rn := r or n\n    var _ir := i or r\n    var _nr := n or r\n"
 
 ---
-"b"@(FileId(1), 9..10) [Declared]: ref_mut boolean
-"r"@(FileId(1), 29..30) [Declared]: ref_mut real
-"i"@(FileId(1), 46..47) [Declared]: ref_mut int
-"n"@(FileId(1), 62..63) [Declared]: ref_mut nat
-"_bi"@(FileId(1), 78..81) [Declared]: ref_mut <error>
-"_bn"@(FileId(1), 100..103) [Declared]: ref_mut <error>
-"_ib"@(FileId(1), 122..125) [Declared]: ref_mut <error>
-"_nb"@(FileId(1), 144..147) [Declared]: ref_mut <error>
-"_ri"@(FileId(1), 166..169) [Declared]: ref_mut <error>
-"_rn"@(FileId(1), 188..191) [Declared]: ref_mut <error>
-"_ir"@(FileId(1), 210..213) [Declared]: ref_mut <error>
-"_nr"@(FileId(1), 232..235) [Declared]: ref_mut <error>
+"b"@(FileId(1), 9..10) [Declared]: boolean
+"r"@(FileId(1), 29..30) [Declared]: real
+"i"@(FileId(1), 46..47) [Declared]: int
+"n"@(FileId(1), 62..63) [Declared]: nat
+"_bi"@(FileId(1), 78..81) [Declared]: <error>
+"_bn"@(FileId(1), 100..103) [Declared]: <error>
+"_ib"@(FileId(1), 122..125) [Declared]: <error>
+"_nb"@(FileId(1), 144..147) [Declared]: <error>
+"_ri"@(FileId(1), 166..169) [Declared]: <error>
+"_rn"@(FileId(1), 188..191) [Declared]: <error>
+"_ir"@(FileId(1), 210..213) [Declared]: <error>
+"_nr"@(FileId(1), 232..235) [Declared]: <error>
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 87..89: mismatched types for logical `or`

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__bitwise_op_wrong_type_shl.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__bitwise_op_wrong_type_shl.snap
@@ -4,18 +4,18 @@ assertion_line: 41
 expression: "\n    var b : boolean\n    var r : real\n    var i : int\n    var n : nat\n    var _bi := b shl i\n    var _bn := b shl n\n    var _ib := i shl b\n    var _nb := n shl b\n    var _ri := r shl i\n    var _rn := r shl n\n    var _ir := i shl r\n    var _nr := n shl r\n"
 
 ---
-"b"@(FileId(1), 9..10) [Declared]: ref_mut boolean
-"r"@(FileId(1), 29..30) [Declared]: ref_mut real
-"i"@(FileId(1), 46..47) [Declared]: ref_mut int
-"n"@(FileId(1), 62..63) [Declared]: ref_mut nat
-"_bi"@(FileId(1), 78..81) [Declared]: ref_mut <error>
-"_bn"@(FileId(1), 101..104) [Declared]: ref_mut <error>
-"_ib"@(FileId(1), 124..127) [Declared]: ref_mut <error>
-"_nb"@(FileId(1), 147..150) [Declared]: ref_mut <error>
-"_ri"@(FileId(1), 170..173) [Declared]: ref_mut <error>
-"_rn"@(FileId(1), 193..196) [Declared]: ref_mut <error>
-"_ir"@(FileId(1), 216..219) [Declared]: ref_mut <error>
-"_nr"@(FileId(1), 239..242) [Declared]: ref_mut <error>
+"b"@(FileId(1), 9..10) [Declared]: boolean
+"r"@(FileId(1), 29..30) [Declared]: real
+"i"@(FileId(1), 46..47) [Declared]: int
+"n"@(FileId(1), 62..63) [Declared]: nat
+"_bi"@(FileId(1), 78..81) [Declared]: <error>
+"_bn"@(FileId(1), 101..104) [Declared]: <error>
+"_ib"@(FileId(1), 124..127) [Declared]: <error>
+"_nb"@(FileId(1), 147..150) [Declared]: <error>
+"_ri"@(FileId(1), 170..173) [Declared]: <error>
+"_rn"@(FileId(1), 193..196) [Declared]: <error>
+"_ir"@(FileId(1), 216..219) [Declared]: <error>
+"_nr"@(FileId(1), 239..242) [Declared]: <error>
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 87..90: mismatched types for `shl`

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__bitwise_op_wrong_type_shr.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__bitwise_op_wrong_type_shr.snap
@@ -4,18 +4,18 @@ assertion_line: 41
 expression: "\n    var b : boolean\n    var r : real\n    var i : int\n    var n : nat\n    var _bi := b shr i\n    var _bn := b shr n\n    var _ib := i shr b\n    var _nb := n shr b\n    var _ri := r shr i\n    var _rn := r shr n\n    var _ir := i shr r\n    var _nr := n shr r\n"
 
 ---
-"b"@(FileId(1), 9..10) [Declared]: ref_mut boolean
-"r"@(FileId(1), 29..30) [Declared]: ref_mut real
-"i"@(FileId(1), 46..47) [Declared]: ref_mut int
-"n"@(FileId(1), 62..63) [Declared]: ref_mut nat
-"_bi"@(FileId(1), 78..81) [Declared]: ref_mut <error>
-"_bn"@(FileId(1), 101..104) [Declared]: ref_mut <error>
-"_ib"@(FileId(1), 124..127) [Declared]: ref_mut <error>
-"_nb"@(FileId(1), 147..150) [Declared]: ref_mut <error>
-"_ri"@(FileId(1), 170..173) [Declared]: ref_mut <error>
-"_rn"@(FileId(1), 193..196) [Declared]: ref_mut <error>
-"_ir"@(FileId(1), 216..219) [Declared]: ref_mut <error>
-"_nr"@(FileId(1), 239..242) [Declared]: ref_mut <error>
+"b"@(FileId(1), 9..10) [Declared]: boolean
+"r"@(FileId(1), 29..30) [Declared]: real
+"i"@(FileId(1), 46..47) [Declared]: int
+"n"@(FileId(1), 62..63) [Declared]: nat
+"_bi"@(FileId(1), 78..81) [Declared]: <error>
+"_bn"@(FileId(1), 101..104) [Declared]: <error>
+"_ib"@(FileId(1), 124..127) [Declared]: <error>
+"_nb"@(FileId(1), 147..150) [Declared]: <error>
+"_ri"@(FileId(1), 170..173) [Declared]: <error>
+"_rn"@(FileId(1), 193..196) [Declared]: <error>
+"_ir"@(FileId(1), 216..219) [Declared]: <error>
+"_nr"@(FileId(1), 239..242) [Declared]: <error>
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 87..90: mismatched types for `shr`

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__bitwise_op_wrong_type_xor.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__bitwise_op_wrong_type_xor.snap
@@ -4,18 +4,18 @@ assertion_line: 41
 expression: "\n    var b : boolean\n    var r : real\n    var i : int\n    var n : nat\n    var _bi := b xor i\n    var _bn := b xor n\n    var _ib := i xor b\n    var _nb := n xor b\n    var _ri := r xor i\n    var _rn := r xor n\n    var _ir := i xor r\n    var _nr := n xor r\n"
 
 ---
-"b"@(FileId(1), 9..10) [Declared]: ref_mut boolean
-"r"@(FileId(1), 29..30) [Declared]: ref_mut real
-"i"@(FileId(1), 46..47) [Declared]: ref_mut int
-"n"@(FileId(1), 62..63) [Declared]: ref_mut nat
-"_bi"@(FileId(1), 78..81) [Declared]: ref_mut <error>
-"_bn"@(FileId(1), 101..104) [Declared]: ref_mut <error>
-"_ib"@(FileId(1), 124..127) [Declared]: ref_mut <error>
-"_nb"@(FileId(1), 147..150) [Declared]: ref_mut <error>
-"_ri"@(FileId(1), 170..173) [Declared]: ref_mut <error>
-"_rn"@(FileId(1), 193..196) [Declared]: ref_mut <error>
-"_ir"@(FileId(1), 216..219) [Declared]: ref_mut <error>
-"_nr"@(FileId(1), 239..242) [Declared]: ref_mut <error>
+"b"@(FileId(1), 9..10) [Declared]: boolean
+"r"@(FileId(1), 29..30) [Declared]: real
+"i"@(FileId(1), 46..47) [Declared]: int
+"n"@(FileId(1), 62..63) [Declared]: nat
+"_bi"@(FileId(1), 78..81) [Declared]: <error>
+"_bn"@(FileId(1), 101..104) [Declared]: <error>
+"_ib"@(FileId(1), 124..127) [Declared]: <error>
+"_nb"@(FileId(1), 147..150) [Declared]: <error>
+"_ri"@(FileId(1), 170..173) [Declared]: <error>
+"_rn"@(FileId(1), 193..196) [Declared]: <error>
+"_ir"@(FileId(1), 216..219) [Declared]: <error>
+"_nr"@(FileId(1), 239..242) [Declared]: <error>
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 87..90: mismatched types for logical `xor`

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__bitwise_op_xor.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__bitwise_op_xor.snap
@@ -1,13 +1,14 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "\n    % Compatibility with all variant of integers\n    var i : int\n    var n : nat\n    var _ii := i xor i\n    var _in := i xor n\n    var _ni := n xor i\n    var _nn := n xor n\n"
 
 ---
-"i"@(FileId(1), 58..59) [Declared]: ref_mut int
-"n"@(FileId(1), 74..75) [Declared]: ref_mut nat
-"_ii"@(FileId(1), 90..93) [Declared]: ref_mut nat
-"_in"@(FileId(1), 113..116) [Declared]: ref_mut nat
-"_ni"@(FileId(1), 136..139) [Declared]: ref_mut nat
-"_nn"@(FileId(1), 159..162) [Declared]: ref_mut nat
+"i"@(FileId(1), 58..59) [Declared]: int
+"n"@(FileId(1), 74..75) [Declared]: nat
+"_ii"@(FileId(1), 90..93) [Declared]: nat
+"_in"@(FileId(1), 113..116) [Declared]: nat
+"_ni"@(FileId(1), 136..139) [Declared]: nat
+"_nn"@(FileId(1), 159..162) [Declared]: nat
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__block_stmt_check.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__block_stmt_check.snap
@@ -1,9 +1,10 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "begin var k : char := 'baz' end"
 
 ---
-"k"@(FileId(1), 10..11) [Declared]: ref_mut char
+"k"@(FileId(1), 10..11) [Declared]: char
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 22..27: mismatched types

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_charseqs_equal.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_charseqs_equal.snap
@@ -1,12 +1,13 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "\n    % Sized charseqs\n    var c : char\n    var c_sz : char(6)\n    var s : string\n    var s_sz : string(6)\n\n    % should all produce booleans\n    var _v_res : boolean\n\n    _v_res := c = c\n    _v_res := c = c_sz\n    _v_res := c = s\n    _v_res := c = s_sz\n\n    _v_res := c_sz = c\n    _v_res := c_sz = c_sz\n    _v_res := c_sz = s\n    _v_res := c_sz = s_sz\n\n    _v_res := s = c\n    _v_res := s = c_sz\n    _v_res := s = s\n    _v_res := s = s_sz\n\n    _v_res := s_sz = c\n    _v_res := s_sz = c_sz\n    _v_res := s_sz = s\n    _v_res := s_sz = s_sz\n    "
 
 ---
-"c"@(FileId(1), 30..31) [Declared]: ref_mut char
-"c_sz"@(FileId(1), 47..51) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
-"s"@(FileId(1), 70..71) [Declared]: ref_mut string
-"s_sz"@(FileId(1), 89..93) [Declared]: ref_mut string_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
-"_v_res"@(FileId(1), 149..155) [Declared]: ref_mut boolean
+"c"@(FileId(1), 30..31) [Declared]: char
+"c_sz"@(FileId(1), 47..51) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
+"s"@(FileId(1), 70..71) [Declared]: string
+"s_sz"@(FileId(1), 89..93) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
+"_v_res"@(FileId(1), 149..155) [Declared]: boolean
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_charseqs_greater.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_charseqs_greater.snap
@@ -1,12 +1,13 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "\n    % Sized charseqs\n    var c : char\n    var c_sz : char(6)\n    var s : string\n    var s_sz : string(6)\n\n    % should all produce booleans\n    var _v_res : boolean\n\n    _v_res := c > c\n    _v_res := c > c_sz\n    _v_res := c > s\n    _v_res := c > s_sz\n\n    _v_res := c_sz > c\n    _v_res := c_sz > c_sz\n    _v_res := c_sz > s\n    _v_res := c_sz > s_sz\n\n    _v_res := s > c\n    _v_res := s > c_sz\n    _v_res := s > s\n    _v_res := s > s_sz\n\n    _v_res := s_sz > c\n    _v_res := s_sz > c_sz\n    _v_res := s_sz > s\n    _v_res := s_sz > s_sz\n    "
 
 ---
-"c"@(FileId(1), 30..31) [Declared]: ref_mut char
-"c_sz"@(FileId(1), 47..51) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
-"s"@(FileId(1), 70..71) [Declared]: ref_mut string
-"s_sz"@(FileId(1), 89..93) [Declared]: ref_mut string_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
-"_v_res"@(FileId(1), 149..155) [Declared]: ref_mut boolean
+"c"@(FileId(1), 30..31) [Declared]: char
+"c_sz"@(FileId(1), 47..51) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
+"s"@(FileId(1), 70..71) [Declared]: string
+"s_sz"@(FileId(1), 89..93) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
+"_v_res"@(FileId(1), 149..155) [Declared]: boolean
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_charseqs_greater_eq.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_charseqs_greater_eq.snap
@@ -1,12 +1,13 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "\n    % Sized charseqs\n    var c : char\n    var c_sz : char(6)\n    var s : string\n    var s_sz : string(6)\n\n    % should all produce booleans\n    var _v_res : boolean\n\n    _v_res := c >= c\n    _v_res := c >= c_sz\n    _v_res := c >= s\n    _v_res := c >= s_sz\n\n    _v_res := c_sz >= c\n    _v_res := c_sz >= c_sz\n    _v_res := c_sz >= s\n    _v_res := c_sz >= s_sz\n\n    _v_res := s >= c\n    _v_res := s >= c_sz\n    _v_res := s >= s\n    _v_res := s >= s_sz\n\n    _v_res := s_sz >= c\n    _v_res := s_sz >= c_sz\n    _v_res := s_sz >= s\n    _v_res := s_sz >= s_sz\n    "
 
 ---
-"c"@(FileId(1), 30..31) [Declared]: ref_mut char
-"c_sz"@(FileId(1), 47..51) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
-"s"@(FileId(1), 70..71) [Declared]: ref_mut string
-"s_sz"@(FileId(1), 89..93) [Declared]: ref_mut string_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
-"_v_res"@(FileId(1), 149..155) [Declared]: ref_mut boolean
+"c"@(FileId(1), 30..31) [Declared]: char
+"c_sz"@(FileId(1), 47..51) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
+"s"@(FileId(1), 70..71) [Declared]: string
+"s_sz"@(FileId(1), 89..93) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
+"_v_res"@(FileId(1), 149..155) [Declared]: boolean
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_charseqs_less.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_charseqs_less.snap
@@ -1,12 +1,13 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "\n    % Sized charseqs\n    var c : char\n    var c_sz : char(6)\n    var s : string\n    var s_sz : string(6)\n\n    % should all produce booleans\n    var _v_res : boolean\n\n    _v_res := c < c\n    _v_res := c < c_sz\n    _v_res := c < s\n    _v_res := c < s_sz\n\n    _v_res := c_sz < c\n    _v_res := c_sz < c_sz\n    _v_res := c_sz < s\n    _v_res := c_sz < s_sz\n\n    _v_res := s < c\n    _v_res := s < c_sz\n    _v_res := s < s\n    _v_res := s < s_sz\n\n    _v_res := s_sz < c\n    _v_res := s_sz < c_sz\n    _v_res := s_sz < s\n    _v_res := s_sz < s_sz\n    "
 
 ---
-"c"@(FileId(1), 30..31) [Declared]: ref_mut char
-"c_sz"@(FileId(1), 47..51) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
-"s"@(FileId(1), 70..71) [Declared]: ref_mut string
-"s_sz"@(FileId(1), 89..93) [Declared]: ref_mut string_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
-"_v_res"@(FileId(1), 149..155) [Declared]: ref_mut boolean
+"c"@(FileId(1), 30..31) [Declared]: char
+"c_sz"@(FileId(1), 47..51) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
+"s"@(FileId(1), 70..71) [Declared]: string
+"s_sz"@(FileId(1), 89..93) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
+"_v_res"@(FileId(1), 149..155) [Declared]: boolean
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_charseqs_less_eq.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_charseqs_less_eq.snap
@@ -1,12 +1,13 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "\n    % Sized charseqs\n    var c : char\n    var c_sz : char(6)\n    var s : string\n    var s_sz : string(6)\n\n    % should all produce booleans\n    var _v_res : boolean\n\n    _v_res := c <= c\n    _v_res := c <= c_sz\n    _v_res := c <= s\n    _v_res := c <= s_sz\n\n    _v_res := c_sz <= c\n    _v_res := c_sz <= c_sz\n    _v_res := c_sz <= s\n    _v_res := c_sz <= s_sz\n\n    _v_res := s <= c\n    _v_res := s <= c_sz\n    _v_res := s <= s\n    _v_res := s <= s_sz\n\n    _v_res := s_sz <= c\n    _v_res := s_sz <= c_sz\n    _v_res := s_sz <= s\n    _v_res := s_sz <= s_sz\n    "
 
 ---
-"c"@(FileId(1), 30..31) [Declared]: ref_mut char
-"c_sz"@(FileId(1), 47..51) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
-"s"@(FileId(1), 70..71) [Declared]: ref_mut string
-"s_sz"@(FileId(1), 89..93) [Declared]: ref_mut string_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
-"_v_res"@(FileId(1), 149..155) [Declared]: ref_mut boolean
+"c"@(FileId(1), 30..31) [Declared]: char
+"c_sz"@(FileId(1), 47..51) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
+"s"@(FileId(1), 70..71) [Declared]: string
+"s_sz"@(FileId(1), 89..93) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
+"_v_res"@(FileId(1), 149..155) [Declared]: boolean
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_charseqs_not_equal.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_charseqs_not_equal.snap
@@ -1,12 +1,13 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "\n    % Sized charseqs\n    var c : char\n    var c_sz : char(6)\n    var s : string\n    var s_sz : string(6)\n\n    % should all produce booleans\n    var _v_res : boolean\n\n    _v_res := c not= c\n    _v_res := c not= c_sz\n    _v_res := c not= s\n    _v_res := c not= s_sz\n\n    _v_res := c_sz not= c\n    _v_res := c_sz not= c_sz\n    _v_res := c_sz not= s\n    _v_res := c_sz not= s_sz\n\n    _v_res := s not= c\n    _v_res := s not= c_sz\n    _v_res := s not= s\n    _v_res := s not= s_sz\n\n    _v_res := s_sz not= c\n    _v_res := s_sz not= c_sz\n    _v_res := s_sz not= s\n    _v_res := s_sz not= s_sz\n    "
 
 ---
-"c"@(FileId(1), 30..31) [Declared]: ref_mut char
-"c_sz"@(FileId(1), 47..51) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
-"s"@(FileId(1), 70..71) [Declared]: ref_mut string
-"s_sz"@(FileId(1), 89..93) [Declared]: ref_mut string_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
-"_v_res"@(FileId(1), 149..155) [Declared]: ref_mut boolean
+"c"@(FileId(1), 30..31) [Declared]: char
+"c_sz"@(FileId(1), 47..51) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
+"s"@(FileId(1), 70..71) [Declared]: string
+"s_sz"@(FileId(1), 89..93) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
+"_v_res"@(FileId(1), 149..155) [Declared]: boolean
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_numerics_equal.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_numerics_equal.snap
@@ -1,11 +1,12 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "\n    % Numerics\n    var r : real\n    var i : int\n    var n : nat\n\n    % should all produce booleans\n    var _v_res : boolean\n\n    _v_res := 1 = 1\n    _v_res := 1 = 1.0\n    _v_res := 1 = r\n    _v_res := 1 = i\n    _v_res := 1 = n\n\n    _v_res := 1.0 = 1\n    _v_res := 1.0 = 1.0\n    _v_res := 1.0 = r\n    _v_res := 1.0 = i\n    _v_res := 1.0 = n\n\n    _v_res := r = 1\n    _v_res := r = 1.0\n    _v_res := r = r\n    _v_res := r = i\n    _v_res := r = n\n\n    _v_res := i = 1\n    _v_res := i = 1.0\n    _v_res := i = r\n    _v_res := i = i\n    _v_res := i = n\n\n    _v_res := n = 1\n    _v_res := n = 1.0\n    _v_res := n = r\n    _v_res := n = i\n    _v_res := n = n\n    "
 
 ---
-"r"@(FileId(1), 24..25) [Declared]: ref_mut real
-"i"@(FileId(1), 41..42) [Declared]: ref_mut int
-"n"@(FileId(1), 57..58) [Declared]: ref_mut nat
-"_v_res"@(FileId(1), 108..114) [Declared]: ref_mut boolean
+"r"@(FileId(1), 24..25) [Declared]: real
+"i"@(FileId(1), 41..42) [Declared]: int
+"n"@(FileId(1), 57..58) [Declared]: nat
+"_v_res"@(FileId(1), 108..114) [Declared]: boolean
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_numerics_greater.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_numerics_greater.snap
@@ -1,11 +1,12 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "\n    % Numerics\n    var r : real\n    var i : int\n    var n : nat\n\n    % should all produce booleans\n    var _v_res : boolean\n\n    _v_res := 1 > 1\n    _v_res := 1 > 1.0\n    _v_res := 1 > r\n    _v_res := 1 > i\n    _v_res := 1 > n\n\n    _v_res := 1.0 > 1\n    _v_res := 1.0 > 1.0\n    _v_res := 1.0 > r\n    _v_res := 1.0 > i\n    _v_res := 1.0 > n\n\n    _v_res := r > 1\n    _v_res := r > 1.0\n    _v_res := r > r\n    _v_res := r > i\n    _v_res := r > n\n\n    _v_res := i > 1\n    _v_res := i > 1.0\n    _v_res := i > r\n    _v_res := i > i\n    _v_res := i > n\n\n    _v_res := n > 1\n    _v_res := n > 1.0\n    _v_res := n > r\n    _v_res := n > i\n    _v_res := n > n\n    "
 
 ---
-"r"@(FileId(1), 24..25) [Declared]: ref_mut real
-"i"@(FileId(1), 41..42) [Declared]: ref_mut int
-"n"@(FileId(1), 57..58) [Declared]: ref_mut nat
-"_v_res"@(FileId(1), 108..114) [Declared]: ref_mut boolean
+"r"@(FileId(1), 24..25) [Declared]: real
+"i"@(FileId(1), 41..42) [Declared]: int
+"n"@(FileId(1), 57..58) [Declared]: nat
+"_v_res"@(FileId(1), 108..114) [Declared]: boolean
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_numerics_greater_eq.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_numerics_greater_eq.snap
@@ -1,11 +1,12 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "\n    % Numerics\n    var r : real\n    var i : int\n    var n : nat\n\n    % should all produce booleans\n    var _v_res : boolean\n\n    _v_res := 1 >= 1\n    _v_res := 1 >= 1.0\n    _v_res := 1 >= r\n    _v_res := 1 >= i\n    _v_res := 1 >= n\n\n    _v_res := 1.0 >= 1\n    _v_res := 1.0 >= 1.0\n    _v_res := 1.0 >= r\n    _v_res := 1.0 >= i\n    _v_res := 1.0 >= n\n\n    _v_res := r >= 1\n    _v_res := r >= 1.0\n    _v_res := r >= r\n    _v_res := r >= i\n    _v_res := r >= n\n\n    _v_res := i >= 1\n    _v_res := i >= 1.0\n    _v_res := i >= r\n    _v_res := i >= i\n    _v_res := i >= n\n\n    _v_res := n >= 1\n    _v_res := n >= 1.0\n    _v_res := n >= r\n    _v_res := n >= i\n    _v_res := n >= n\n    "
 
 ---
-"r"@(FileId(1), 24..25) [Declared]: ref_mut real
-"i"@(FileId(1), 41..42) [Declared]: ref_mut int
-"n"@(FileId(1), 57..58) [Declared]: ref_mut nat
-"_v_res"@(FileId(1), 108..114) [Declared]: ref_mut boolean
+"r"@(FileId(1), 24..25) [Declared]: real
+"i"@(FileId(1), 41..42) [Declared]: int
+"n"@(FileId(1), 57..58) [Declared]: nat
+"_v_res"@(FileId(1), 108..114) [Declared]: boolean
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_numerics_less.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_numerics_less.snap
@@ -1,11 +1,12 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "\n    % Numerics\n    var r : real\n    var i : int\n    var n : nat\n\n    % should all produce booleans\n    var _v_res : boolean\n\n    _v_res := 1 < 1\n    _v_res := 1 < 1.0\n    _v_res := 1 < r\n    _v_res := 1 < i\n    _v_res := 1 < n\n\n    _v_res := 1.0 < 1\n    _v_res := 1.0 < 1.0\n    _v_res := 1.0 < r\n    _v_res := 1.0 < i\n    _v_res := 1.0 < n\n\n    _v_res := r < 1\n    _v_res := r < 1.0\n    _v_res := r < r\n    _v_res := r < i\n    _v_res := r < n\n\n    _v_res := i < 1\n    _v_res := i < 1.0\n    _v_res := i < r\n    _v_res := i < i\n    _v_res := i < n\n\n    _v_res := n < 1\n    _v_res := n < 1.0\n    _v_res := n < r\n    _v_res := n < i\n    _v_res := n < n\n    "
 
 ---
-"r"@(FileId(1), 24..25) [Declared]: ref_mut real
-"i"@(FileId(1), 41..42) [Declared]: ref_mut int
-"n"@(FileId(1), 57..58) [Declared]: ref_mut nat
-"_v_res"@(FileId(1), 108..114) [Declared]: ref_mut boolean
+"r"@(FileId(1), 24..25) [Declared]: real
+"i"@(FileId(1), 41..42) [Declared]: int
+"n"@(FileId(1), 57..58) [Declared]: nat
+"_v_res"@(FileId(1), 108..114) [Declared]: boolean
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_numerics_less_eq.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_numerics_less_eq.snap
@@ -1,11 +1,12 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "\n    % Numerics\n    var r : real\n    var i : int\n    var n : nat\n\n    % should all produce booleans\n    var _v_res : boolean\n\n    _v_res := 1 <= 1\n    _v_res := 1 <= 1.0\n    _v_res := 1 <= r\n    _v_res := 1 <= i\n    _v_res := 1 <= n\n\n    _v_res := 1.0 <= 1\n    _v_res := 1.0 <= 1.0\n    _v_res := 1.0 <= r\n    _v_res := 1.0 <= i\n    _v_res := 1.0 <= n\n\n    _v_res := r <= 1\n    _v_res := r <= 1.0\n    _v_res := r <= r\n    _v_res := r <= i\n    _v_res := r <= n\n\n    _v_res := i <= 1\n    _v_res := i <= 1.0\n    _v_res := i <= r\n    _v_res := i <= i\n    _v_res := i <= n\n\n    _v_res := n <= 1\n    _v_res := n <= 1.0\n    _v_res := n <= r\n    _v_res := n <= i\n    _v_res := n <= n\n    "
 
 ---
-"r"@(FileId(1), 24..25) [Declared]: ref_mut real
-"i"@(FileId(1), 41..42) [Declared]: ref_mut int
-"n"@(FileId(1), 57..58) [Declared]: ref_mut nat
-"_v_res"@(FileId(1), 108..114) [Declared]: ref_mut boolean
+"r"@(FileId(1), 24..25) [Declared]: real
+"i"@(FileId(1), 41..42) [Declared]: int
+"n"@(FileId(1), 57..58) [Declared]: nat
+"_v_res"@(FileId(1), 108..114) [Declared]: boolean
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_numerics_not_equal.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_numerics_not_equal.snap
@@ -1,11 +1,12 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "\n    % Numerics\n    var r : real\n    var i : int\n    var n : nat\n\n    % should all produce booleans\n    var _v_res : boolean\n\n    _v_res := 1 not= 1\n    _v_res := 1 not= 1.0\n    _v_res := 1 not= r\n    _v_res := 1 not= i\n    _v_res := 1 not= n\n\n    _v_res := 1.0 not= 1\n    _v_res := 1.0 not= 1.0\n    _v_res := 1.0 not= r\n    _v_res := 1.0 not= i\n    _v_res := 1.0 not= n\n\n    _v_res := r not= 1\n    _v_res := r not= 1.0\n    _v_res := r not= r\n    _v_res := r not= i\n    _v_res := r not= n\n\n    _v_res := i not= 1\n    _v_res := i not= 1.0\n    _v_res := i not= r\n    _v_res := i not= i\n    _v_res := i not= n\n\n    _v_res := n not= 1\n    _v_res := n not= 1.0\n    _v_res := n not= r\n    _v_res := n not= i\n    _v_res := n not= n\n    "
 
 ---
-"r"@(FileId(1), 24..25) [Declared]: ref_mut real
-"i"@(FileId(1), 41..42) [Declared]: ref_mut int
-"n"@(FileId(1), 57..58) [Declared]: ref_mut nat
-"_v_res"@(FileId(1), 108..114) [Declared]: ref_mut boolean
+"r"@(FileId(1), 24..25) [Declared]: real
+"i"@(FileId(1), 41..42) [Declared]: int
+"n"@(FileId(1), 57..58) [Declared]: nat
+"_v_res"@(FileId(1), 108..114) [Declared]: boolean
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_equal.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_equal.snap
@@ -4,15 +4,15 @@ assertion_line: 41
 expression: "\n    % Numerics\n    var r : real\n    var i : int\n    var n : nat\n\n    % Other scalars\n    var b : boolean\n\n    % Sized charseqs\n    var c : char\n    var c_sz : char(6)\n    var s : string\n    var s_sz : string(6)\n\n    % should all produce boolean anyway\n    var _v_res : boolean\n\n    _v_res := r = b\n    _v_res := r = c\n    _v_res := r = c_sz\n    _v_res := r = s\n    _v_res := r = s_sz\n\n    _v_res := i = b\n    _v_res := i = c\n    _v_res := i = c_sz\n    _v_res := i = s\n    _v_res := i = s_sz\n\n    _v_res := n = b\n    _v_res := n = c\n    _v_res := n = c_sz\n    _v_res := n = s\n    _v_res := n = s_sz\n\n    _v_res := b = r\n    _v_res := b = i\n    _v_res := b = n\n    _v_res := b = c\n    _v_res := b = c_sz\n    _v_res := b = s\n    _v_res := b = s_sz\n\n    _v_res := c = r\n    _v_res := c = i\n    _v_res := c = n\n    _v_res := c = b\n\n    _v_res := c_sz = r\n    _v_res := c_sz = i\n    _v_res := c_sz = n\n    _v_res := c_sz = b\n\n    _v_res := s = r\n    _v_res := s = i\n    _v_res := s = n\n    _v_res := s = b\n\n    _v_res := s_sz = r\n    _v_res := s_sz = i\n    _v_res := s_sz = n\n    _v_res := s_sz = b\n    "
 
 ---
-"r"@(FileId(1), 24..25) [Declared]: ref_mut real
-"i"@(FileId(1), 41..42) [Declared]: ref_mut int
-"n"@(FileId(1), 57..58) [Declared]: ref_mut nat
-"b"@(FileId(1), 94..95) [Declared]: ref_mut boolean
-"c"@(FileId(1), 136..137) [Declared]: ref_mut char
-"c_sz"@(FileId(1), 153..157) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
-"s"@(FileId(1), 176..177) [Declared]: ref_mut string
-"s_sz"@(FileId(1), 195..199) [Declared]: ref_mut string_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
-"_v_res"@(FileId(1), 261..267) [Declared]: ref_mut boolean
+"r"@(FileId(1), 24..25) [Declared]: real
+"i"@(FileId(1), 41..42) [Declared]: int
+"n"@(FileId(1), 57..58) [Declared]: nat
+"b"@(FileId(1), 94..95) [Declared]: boolean
+"c"@(FileId(1), 136..137) [Declared]: char
+"c_sz"@(FileId(1), 153..157) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
+"s"@(FileId(1), 176..177) [Declared]: string
+"s_sz"@(FileId(1), 195..199) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
+"_v_res"@(FileId(1), 261..267) [Declared]: boolean
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 295..296: mismatched types for `=`

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_greater.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_greater.snap
@@ -4,15 +4,15 @@ assertion_line: 41
 expression: "\n    % Numerics\n    var r : real\n    var i : int\n    var n : nat\n\n    % Other scalars\n    var b : boolean\n\n    % Sized charseqs\n    var c : char\n    var c_sz : char(6)\n    var s : string\n    var s_sz : string(6)\n\n    % should all produce boolean anyway\n    var _v_res : boolean\n\n    _v_res := r > b\n    _v_res := r > c\n    _v_res := r > c_sz\n    _v_res := r > s\n    _v_res := r > s_sz\n\n    _v_res := i > b\n    _v_res := i > c\n    _v_res := i > c_sz\n    _v_res := i > s\n    _v_res := i > s_sz\n\n    _v_res := n > b\n    _v_res := n > c\n    _v_res := n > c_sz\n    _v_res := n > s\n    _v_res := n > s_sz\n\n    _v_res := b > r\n    _v_res := b > i\n    _v_res := b > n\n    _v_res := b > c\n    _v_res := b > c_sz\n    _v_res := b > s\n    _v_res := b > s_sz\n\n    _v_res := c > r\n    _v_res := c > i\n    _v_res := c > n\n    _v_res := c > b\n\n    _v_res := c_sz > r\n    _v_res := c_sz > i\n    _v_res := c_sz > n\n    _v_res := c_sz > b\n\n    _v_res := s > r\n    _v_res := s > i\n    _v_res := s > n\n    _v_res := s > b\n\n    _v_res := s_sz > r\n    _v_res := s_sz > i\n    _v_res := s_sz > n\n    _v_res := s_sz > b\n    "
 
 ---
-"r"@(FileId(1), 24..25) [Declared]: ref_mut real
-"i"@(FileId(1), 41..42) [Declared]: ref_mut int
-"n"@(FileId(1), 57..58) [Declared]: ref_mut nat
-"b"@(FileId(1), 94..95) [Declared]: ref_mut boolean
-"c"@(FileId(1), 136..137) [Declared]: ref_mut char
-"c_sz"@(FileId(1), 153..157) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
-"s"@(FileId(1), 176..177) [Declared]: ref_mut string
-"s_sz"@(FileId(1), 195..199) [Declared]: ref_mut string_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
-"_v_res"@(FileId(1), 261..267) [Declared]: ref_mut boolean
+"r"@(FileId(1), 24..25) [Declared]: real
+"i"@(FileId(1), 41..42) [Declared]: int
+"n"@(FileId(1), 57..58) [Declared]: nat
+"b"@(FileId(1), 94..95) [Declared]: boolean
+"c"@(FileId(1), 136..137) [Declared]: char
+"c_sz"@(FileId(1), 153..157) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
+"s"@(FileId(1), 176..177) [Declared]: string
+"s_sz"@(FileId(1), 195..199) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
+"_v_res"@(FileId(1), 261..267) [Declared]: boolean
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 295..296: mismatched types for `>`

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_greater_eq.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_greater_eq.snap
@@ -4,15 +4,15 @@ assertion_line: 41
 expression: "\n    % Numerics\n    var r : real\n    var i : int\n    var n : nat\n\n    % Other scalars\n    var b : boolean\n\n    % Sized charseqs\n    var c : char\n    var c_sz : char(6)\n    var s : string\n    var s_sz : string(6)\n\n    % should all produce boolean anyway\n    var _v_res : boolean\n\n    _v_res := r >= b\n    _v_res := r >= c\n    _v_res := r >= c_sz\n    _v_res := r >= s\n    _v_res := r >= s_sz\n\n    _v_res := i >= b\n    _v_res := i >= c\n    _v_res := i >= c_sz\n    _v_res := i >= s\n    _v_res := i >= s_sz\n\n    _v_res := n >= b\n    _v_res := n >= c\n    _v_res := n >= c_sz\n    _v_res := n >= s\n    _v_res := n >= s_sz\n\n    _v_res := b >= r\n    _v_res := b >= i\n    _v_res := b >= n\n    _v_res := b >= c\n    _v_res := b >= c_sz\n    _v_res := b >= s\n    _v_res := b >= s_sz\n\n    _v_res := c >= r\n    _v_res := c >= i\n    _v_res := c >= n\n    _v_res := c >= b\n\n    _v_res := c_sz >= r\n    _v_res := c_sz >= i\n    _v_res := c_sz >= n\n    _v_res := c_sz >= b\n\n    _v_res := s >= r\n    _v_res := s >= i\n    _v_res := s >= n\n    _v_res := s >= b\n\n    _v_res := s_sz >= r\n    _v_res := s_sz >= i\n    _v_res := s_sz >= n\n    _v_res := s_sz >= b\n    "
 
 ---
-"r"@(FileId(1), 24..25) [Declared]: ref_mut real
-"i"@(FileId(1), 41..42) [Declared]: ref_mut int
-"n"@(FileId(1), 57..58) [Declared]: ref_mut nat
-"b"@(FileId(1), 94..95) [Declared]: ref_mut boolean
-"c"@(FileId(1), 136..137) [Declared]: ref_mut char
-"c_sz"@(FileId(1), 153..157) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
-"s"@(FileId(1), 176..177) [Declared]: ref_mut string
-"s_sz"@(FileId(1), 195..199) [Declared]: ref_mut string_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
-"_v_res"@(FileId(1), 261..267) [Declared]: ref_mut boolean
+"r"@(FileId(1), 24..25) [Declared]: real
+"i"@(FileId(1), 41..42) [Declared]: int
+"n"@(FileId(1), 57..58) [Declared]: nat
+"b"@(FileId(1), 94..95) [Declared]: boolean
+"c"@(FileId(1), 136..137) [Declared]: char
+"c_sz"@(FileId(1), 153..157) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
+"s"@(FileId(1), 176..177) [Declared]: string
+"s_sz"@(FileId(1), 195..199) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
+"_v_res"@(FileId(1), 261..267) [Declared]: boolean
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 295..297: mismatched types for `>=`

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_less.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_less.snap
@@ -4,15 +4,15 @@ assertion_line: 41
 expression: "\n    % Numerics\n    var r : real\n    var i : int\n    var n : nat\n\n    % Other scalars\n    var b : boolean\n\n    % Sized charseqs\n    var c : char\n    var c_sz : char(6)\n    var s : string\n    var s_sz : string(6)\n\n    % should all produce boolean anyway\n    var _v_res : boolean\n\n    _v_res := r < b\n    _v_res := r < c\n    _v_res := r < c_sz\n    _v_res := r < s\n    _v_res := r < s_sz\n\n    _v_res := i < b\n    _v_res := i < c\n    _v_res := i < c_sz\n    _v_res := i < s\n    _v_res := i < s_sz\n\n    _v_res := n < b\n    _v_res := n < c\n    _v_res := n < c_sz\n    _v_res := n < s\n    _v_res := n < s_sz\n\n    _v_res := b < r\n    _v_res := b < i\n    _v_res := b < n\n    _v_res := b < c\n    _v_res := b < c_sz\n    _v_res := b < s\n    _v_res := b < s_sz\n\n    _v_res := c < r\n    _v_res := c < i\n    _v_res := c < n\n    _v_res := c < b\n\n    _v_res := c_sz < r\n    _v_res := c_sz < i\n    _v_res := c_sz < n\n    _v_res := c_sz < b\n\n    _v_res := s < r\n    _v_res := s < i\n    _v_res := s < n\n    _v_res := s < b\n\n    _v_res := s_sz < r\n    _v_res := s_sz < i\n    _v_res := s_sz < n\n    _v_res := s_sz < b\n    "
 
 ---
-"r"@(FileId(1), 24..25) [Declared]: ref_mut real
-"i"@(FileId(1), 41..42) [Declared]: ref_mut int
-"n"@(FileId(1), 57..58) [Declared]: ref_mut nat
-"b"@(FileId(1), 94..95) [Declared]: ref_mut boolean
-"c"@(FileId(1), 136..137) [Declared]: ref_mut char
-"c_sz"@(FileId(1), 153..157) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
-"s"@(FileId(1), 176..177) [Declared]: ref_mut string
-"s_sz"@(FileId(1), 195..199) [Declared]: ref_mut string_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
-"_v_res"@(FileId(1), 261..267) [Declared]: ref_mut boolean
+"r"@(FileId(1), 24..25) [Declared]: real
+"i"@(FileId(1), 41..42) [Declared]: int
+"n"@(FileId(1), 57..58) [Declared]: nat
+"b"@(FileId(1), 94..95) [Declared]: boolean
+"c"@(FileId(1), 136..137) [Declared]: char
+"c_sz"@(FileId(1), 153..157) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
+"s"@(FileId(1), 176..177) [Declared]: string
+"s_sz"@(FileId(1), 195..199) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
+"_v_res"@(FileId(1), 261..267) [Declared]: boolean
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 295..296: mismatched types for `<`

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_less_eq.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_less_eq.snap
@@ -4,15 +4,15 @@ assertion_line: 41
 expression: "\n    % Numerics\n    var r : real\n    var i : int\n    var n : nat\n\n    % Other scalars\n    var b : boolean\n\n    % Sized charseqs\n    var c : char\n    var c_sz : char(6)\n    var s : string\n    var s_sz : string(6)\n\n    % should all produce boolean anyway\n    var _v_res : boolean\n\n    _v_res := r <= b\n    _v_res := r <= c\n    _v_res := r <= c_sz\n    _v_res := r <= s\n    _v_res := r <= s_sz\n\n    _v_res := i <= b\n    _v_res := i <= c\n    _v_res := i <= c_sz\n    _v_res := i <= s\n    _v_res := i <= s_sz\n\n    _v_res := n <= b\n    _v_res := n <= c\n    _v_res := n <= c_sz\n    _v_res := n <= s\n    _v_res := n <= s_sz\n\n    _v_res := b <= r\n    _v_res := b <= i\n    _v_res := b <= n\n    _v_res := b <= c\n    _v_res := b <= c_sz\n    _v_res := b <= s\n    _v_res := b <= s_sz\n\n    _v_res := c <= r\n    _v_res := c <= i\n    _v_res := c <= n\n    _v_res := c <= b\n\n    _v_res := c_sz <= r\n    _v_res := c_sz <= i\n    _v_res := c_sz <= n\n    _v_res := c_sz <= b\n\n    _v_res := s <= r\n    _v_res := s <= i\n    _v_res := s <= n\n    _v_res := s <= b\n\n    _v_res := s_sz <= r\n    _v_res := s_sz <= i\n    _v_res := s_sz <= n\n    _v_res := s_sz <= b\n    "
 
 ---
-"r"@(FileId(1), 24..25) [Declared]: ref_mut real
-"i"@(FileId(1), 41..42) [Declared]: ref_mut int
-"n"@(FileId(1), 57..58) [Declared]: ref_mut nat
-"b"@(FileId(1), 94..95) [Declared]: ref_mut boolean
-"c"@(FileId(1), 136..137) [Declared]: ref_mut char
-"c_sz"@(FileId(1), 153..157) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
-"s"@(FileId(1), 176..177) [Declared]: ref_mut string
-"s_sz"@(FileId(1), 195..199) [Declared]: ref_mut string_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
-"_v_res"@(FileId(1), 261..267) [Declared]: ref_mut boolean
+"r"@(FileId(1), 24..25) [Declared]: real
+"i"@(FileId(1), 41..42) [Declared]: int
+"n"@(FileId(1), 57..58) [Declared]: nat
+"b"@(FileId(1), 94..95) [Declared]: boolean
+"c"@(FileId(1), 136..137) [Declared]: char
+"c_sz"@(FileId(1), 153..157) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
+"s"@(FileId(1), 176..177) [Declared]: string
+"s_sz"@(FileId(1), 195..199) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
+"_v_res"@(FileId(1), 261..267) [Declared]: boolean
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 295..297: mismatched types for `<=`

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_not_equal.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_not_equal.snap
@@ -4,15 +4,15 @@ assertion_line: 41
 expression: "\n    % Numerics\n    var r : real\n    var i : int\n    var n : nat\n\n    % Other scalars\n    var b : boolean\n\n    % Sized charseqs\n    var c : char\n    var c_sz : char(6)\n    var s : string\n    var s_sz : string(6)\n\n    % should all produce boolean anyway\n    var _v_res : boolean\n\n    _v_res := r not= b\n    _v_res := r not= c\n    _v_res := r not= c_sz\n    _v_res := r not= s\n    _v_res := r not= s_sz\n\n    _v_res := i not= b\n    _v_res := i not= c\n    _v_res := i not= c_sz\n    _v_res := i not= s\n    _v_res := i not= s_sz\n\n    _v_res := n not= b\n    _v_res := n not= c\n    _v_res := n not= c_sz\n    _v_res := n not= s\n    _v_res := n not= s_sz\n\n    _v_res := b not= r\n    _v_res := b not= i\n    _v_res := b not= n\n    _v_res := b not= c\n    _v_res := b not= c_sz\n    _v_res := b not= s\n    _v_res := b not= s_sz\n\n    _v_res := c not= r\n    _v_res := c not= i\n    _v_res := c not= n\n    _v_res := c not= b\n\n    _v_res := c_sz not= r\n    _v_res := c_sz not= i\n    _v_res := c_sz not= n\n    _v_res := c_sz not= b\n\n    _v_res := s not= r\n    _v_res := s not= i\n    _v_res := s not= n\n    _v_res := s not= b\n\n    _v_res := s_sz not= r\n    _v_res := s_sz not= i\n    _v_res := s_sz not= n\n    _v_res := s_sz not= b\n    "
 
 ---
-"r"@(FileId(1), 24..25) [Declared]: ref_mut real
-"i"@(FileId(1), 41..42) [Declared]: ref_mut int
-"n"@(FileId(1), 57..58) [Declared]: ref_mut nat
-"b"@(FileId(1), 94..95) [Declared]: ref_mut boolean
-"c"@(FileId(1), 136..137) [Declared]: ref_mut char
-"c_sz"@(FileId(1), 153..157) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
-"s"@(FileId(1), 176..177) [Declared]: ref_mut string
-"s_sz"@(FileId(1), 195..199) [Declared]: ref_mut string_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
-"_v_res"@(FileId(1), 261..267) [Declared]: ref_mut boolean
+"r"@(FileId(1), 24..25) [Declared]: real
+"i"@(FileId(1), 41..42) [Declared]: int
+"n"@(FileId(1), 57..58) [Declared]: nat
+"b"@(FileId(1), 94..95) [Declared]: boolean
+"c"@(FileId(1), 136..137) [Declared]: char
+"c_sz"@(FileId(1), 153..157) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
+"s"@(FileId(1), 176..177) [Declared]: string
+"s_sz"@(FileId(1), 195..199) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
+"_v_res"@(FileId(1), 261..267) [Declared]: boolean
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 295..299: mismatched types for `not =`

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__do_type_coercion_comparison_ops.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__do_type_coercion_comparison_ops.snap
@@ -1,10 +1,11 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "var i1 : int1\nvar i : int\nvar _res : boolean\n_res := i < i1\n"
 
 ---
-"i1"@(FileId(1), 4..6) [Declared]: ref_mut int1
-"i"@(FileId(1), 18..19) [Declared]: ref_mut int
-"_res"@(FileId(1), 30..34) [Declared]: ref_mut boolean
+"i1"@(FileId(1), 4..6) [Declared]: int1
+"i"@(FileId(1), 18..19) [Declared]: int
+"_res"@(FileId(1), 30..34) [Declared]: boolean
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__do_type_coercion_equality_ops.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__do_type_coercion_equality_ops.snap
@@ -1,10 +1,11 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "var c1 : char(1)\nvar c : char\nvar _res : boolean\n_res := c = c1\n"
 
 ---
-"c1"@(FileId(1), 4..6) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
-"c"@(FileId(1), 21..22) [Declared]: ref_mut char
-"_res"@(FileId(1), 34..38) [Declared]: ref_mut boolean
+"c1"@(FileId(1), 4..6) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
+"c"@(FileId(1), 21..22) [Declared]: char
+"_res"@(FileId(1), 34..38) [Declared]: boolean
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__do_type_coercion_for_bounds.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__do_type_coercion_for_bounds.snap
@@ -1,10 +1,11 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "var i1 : int1\nvar i : int\nvar _res : boolean\nfor : i .. i1 end for\n"
 
 ---
-"i1"@(FileId(1), 4..6) [Declared]: ref_mut int1
-"i"@(FileId(1), 18..19) [Declared]: ref_mut int
-"_res"@(FileId(1), 30..34) [Declared]: ref_mut boolean
+"i1"@(FileId(1), 4..6) [Declared]: int1
+"i"@(FileId(1), 18..19) [Declared]: int
+"_res"@(FileId(1), 30..34) [Declared]: boolean
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__equality_op_scalars_equal.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__equality_op_scalars_equal.snap
@@ -1,9 +1,10 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "\n    % Other scalars\n    var b : boolean\n\n    % should all produce boolean\n    var _v_res : boolean\n\n    _v_res := b = b\n    "
 
 ---
-"b"@(FileId(1), 29..30) [Declared]: ref_mut boolean
-"_v_res"@(FileId(1), 83..89) [Declared]: ref_mut boolean
+"b"@(FileId(1), 29..30) [Declared]: boolean
+"_v_res"@(FileId(1), 83..89) [Declared]: boolean
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__equality_op_scalars_not_equal.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__equality_op_scalars_not_equal.snap
@@ -1,9 +1,10 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "\n    % Other scalars\n    var b : boolean\n\n    % should all produce boolean\n    var _v_res : boolean\n\n    _v_res := b not= b\n    "
 
 ---
-"b"@(FileId(1), 29..30) [Declared]: ref_mut boolean
-"_v_res"@(FileId(1), 83..89) [Declared]: ref_mut boolean
+"b"@(FileId(1), 29..30) [Declared]: boolean
+"_v_res"@(FileId(1), 83..89) [Declared]: boolean
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__equivalence_of_aliases.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__equivalence_of_aliases.snap
@@ -6,8 +6,8 @@ expression: "type a0 : int\ntype a1 : int\nvar i : int\nvar ia0 : a0\nvar ia1 : 
 ---
 "a0"@(FileId(1), 5..7) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of int
 "a1"@(FileId(1), 19..21) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(1))] of int
-"i"@(FileId(1), 32..33) [Declared]: ref_mut int
-"ia0"@(FileId(1), 44..47) [Declared]: ref_mut alias[DefId(LibraryId(0), LocalDefId(0))] of int
-"ia1"@(FileId(1), 57..60) [Declared]: ref_mut alias[DefId(LibraryId(0), LocalDefId(1))] of int
+"i"@(FileId(1), 32..33) [Declared]: int
+"ia0"@(FileId(1), 44..47) [Declared]: alias[DefId(LibraryId(0), LocalDefId(0))] of int
+"ia1"@(FileId(1), 57..60) [Declared]: alias[DefId(LibraryId(0), LocalDefId(1))] of int
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__equivalence_of_integer.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__equivalence_of_integer.snap
@@ -4,9 +4,9 @@ assertion_line: 41
 expression: "var n : nat\nvar i : int\nvar r : real\n\nfor : 1 .. n end for\nfor : 1 .. i end for\nfor : 1 .. r end for\nfor : n .. 1 end for\nfor : i .. 1 end for\nfor : r .. 1 end for\n"
 
 ---
-"n"@(FileId(1), 4..5) [Declared]: ref_mut nat
-"i"@(FileId(1), 16..17) [Declared]: ref_mut int
-"r"@(FileId(1), 28..29) [Declared]: ref_mut real
+"n"@(FileId(1), 4..5) [Declared]: nat
+"i"@(FileId(1), 16..17) [Declared]: int
+"r"@(FileId(1), 28..29) [Declared]: real
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 86..92: mismatched types

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__integer_inference_add.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__integer_inference_add.snap
@@ -1,17 +1,18 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "\n    % Inferred integer types should pass\n    % Decl should be a concrete type\n    var a := 1 + 1\n    % Types of operands should make the type concrete\n    var r : real\n    var i : int\n    var n : nat\n    var _r0 := 1 + r\n    var _r1 := r + 1\n    var _i0 := 1 + i\n    var _i1 := i + 1\n    var _n0 := 1 + n\n    var _n1 := n + 1\n"
 
 ---
-"a"@(FileId(1), 87..88) [Declared]: ref_mut int
-"r"@(FileId(1), 160..161) [Declared]: ref_mut real
-"i"@(FileId(1), 177..178) [Declared]: ref_mut int
-"n"@(FileId(1), 193..194) [Declared]: ref_mut nat
-"_r0"@(FileId(1), 209..212) [Declared]: ref_mut real
-"_r1"@(FileId(1), 230..233) [Declared]: ref_mut real
-"_i0"@(FileId(1), 251..254) [Declared]: ref_mut int
-"_i1"@(FileId(1), 272..275) [Declared]: ref_mut int
-"_n0"@(FileId(1), 293..296) [Declared]: ref_mut nat
-"_n1"@(FileId(1), 314..317) [Declared]: ref_mut nat
+"a"@(FileId(1), 87..88) [Declared]: int
+"r"@(FileId(1), 160..161) [Declared]: real
+"i"@(FileId(1), 177..178) [Declared]: int
+"n"@(FileId(1), 193..194) [Declared]: nat
+"_r0"@(FileId(1), 209..212) [Declared]: real
+"_r1"@(FileId(1), 230..233) [Declared]: real
+"_i0"@(FileId(1), 251..254) [Declared]: int
+"_i1"@(FileId(1), 272..275) [Declared]: int
+"_n0"@(FileId(1), 293..296) [Declared]: nat
+"_n1"@(FileId(1), 314..317) [Declared]: nat
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__integer_inference_exp.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__integer_inference_exp.snap
@@ -1,17 +1,18 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "\n    % Inferred integer types should pass\n    % Decl should be a concrete type\n    var a := 1 ** 1\n    % Types of operands should make the type concrete\n    var r : real\n    var i : int\n    var n : nat\n    var _r0 := 1 ** r\n    var _r1 := r ** 1\n    var _i0 := 1 ** i\n    var _i1 := i ** 1\n    var _n0 := 1 ** n\n    var _n1 := n ** 1\n"
 
 ---
-"a"@(FileId(1), 87..88) [Declared]: ref_mut int
-"r"@(FileId(1), 161..162) [Declared]: ref_mut real
-"i"@(FileId(1), 178..179) [Declared]: ref_mut int
-"n"@(FileId(1), 194..195) [Declared]: ref_mut nat
-"_r0"@(FileId(1), 210..213) [Declared]: ref_mut real
-"_r1"@(FileId(1), 232..235) [Declared]: ref_mut real
-"_i0"@(FileId(1), 254..257) [Declared]: ref_mut int
-"_i1"@(FileId(1), 276..279) [Declared]: ref_mut int
-"_n0"@(FileId(1), 298..301) [Declared]: ref_mut nat
-"_n1"@(FileId(1), 320..323) [Declared]: ref_mut nat
+"a"@(FileId(1), 87..88) [Declared]: int
+"r"@(FileId(1), 161..162) [Declared]: real
+"i"@(FileId(1), 178..179) [Declared]: int
+"n"@(FileId(1), 194..195) [Declared]: nat
+"_r0"@(FileId(1), 210..213) [Declared]: real
+"_r1"@(FileId(1), 232..235) [Declared]: real
+"_i0"@(FileId(1), 254..257) [Declared]: int
+"_i1"@(FileId(1), 276..279) [Declared]: int
+"_n0"@(FileId(1), 298..301) [Declared]: nat
+"_n1"@(FileId(1), 320..323) [Declared]: nat
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__integer_inference_identity.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__integer_inference_identity.snap
@@ -1,14 +1,15 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "\n    % Inferred integer types should pass\n    % Decl should be a concrete type\n    var a := + 1\n    % Types of operands should make the type concrete\n    var r : real\n    var i : int\n    var n : nat\n    var _r0 := + r\n    var _i0 := + i\n    var _n0 := + n\n"
 
 ---
-"a"@(FileId(1), 87..88) [Declared]: ref_mut int
-"r"@(FileId(1), 158..159) [Declared]: ref_mut real
-"i"@(FileId(1), 175..176) [Declared]: ref_mut int
-"n"@(FileId(1), 191..192) [Declared]: ref_mut nat
-"_r0"@(FileId(1), 207..210) [Declared]: ref_mut real
-"_i0"@(FileId(1), 226..229) [Declared]: ref_mut int
-"_n0"@(FileId(1), 245..248) [Declared]: ref_mut nat
+"a"@(FileId(1), 87..88) [Declared]: int
+"r"@(FileId(1), 158..159) [Declared]: real
+"i"@(FileId(1), 175..176) [Declared]: int
+"n"@(FileId(1), 191..192) [Declared]: nat
+"_r0"@(FileId(1), 207..210) [Declared]: real
+"_i0"@(FileId(1), 226..229) [Declared]: int
+"_n0"@(FileId(1), 245..248) [Declared]: nat
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__integer_inference_idiv.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__integer_inference_idiv.snap
@@ -1,17 +1,18 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "\n    % Inferred integer types should pass\n    % Decl should be a concrete type\n    var a := 1 div 1\n    % Types of operands should make the type concrete\n    var r : real\n    var i : int\n    var n : nat\n    var _r0 := 1 div r\n    var _r1 := r div 1\n    var _i0 := 1 div i\n    var _i1 := i div 1\n    var _n0 := 1 div n\n    var _n1 := n div 1\n"
 
 ---
-"a"@(FileId(1), 87..88) [Declared]: ref_mut int
-"r"@(FileId(1), 162..163) [Declared]: ref_mut real
-"i"@(FileId(1), 179..180) [Declared]: ref_mut int
-"n"@(FileId(1), 195..196) [Declared]: ref_mut nat
-"_r0"@(FileId(1), 211..214) [Declared]: ref_mut int
-"_r1"@(FileId(1), 234..237) [Declared]: ref_mut int
-"_i0"@(FileId(1), 257..260) [Declared]: ref_mut int
-"_i1"@(FileId(1), 280..283) [Declared]: ref_mut int
-"_n0"@(FileId(1), 303..306) [Declared]: ref_mut nat
-"_n1"@(FileId(1), 326..329) [Declared]: ref_mut nat
+"a"@(FileId(1), 87..88) [Declared]: int
+"r"@(FileId(1), 162..163) [Declared]: real
+"i"@(FileId(1), 179..180) [Declared]: int
+"n"@(FileId(1), 195..196) [Declared]: nat
+"_r0"@(FileId(1), 211..214) [Declared]: int
+"_r1"@(FileId(1), 234..237) [Declared]: int
+"_i0"@(FileId(1), 257..260) [Declared]: int
+"_i1"@(FileId(1), 280..283) [Declared]: int
+"_n0"@(FileId(1), 303..306) [Declared]: nat
+"_n1"@(FileId(1), 326..329) [Declared]: nat
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__integer_inference_mod.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__integer_inference_mod.snap
@@ -1,17 +1,18 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "\n    % Inferred integer types should pass\n    % Decl should be a concrete type\n    var a := 1 mod 1\n    % Types of operands should make the type concrete\n    var r : real\n    var i : int\n    var n : nat\n    var _r0 := 1 mod r\n    var _r1 := r mod 1\n    var _i0 := 1 mod i\n    var _i1 := i mod 1\n    var _n0 := 1 mod n\n    var _n1 := n mod 1\n"
 
 ---
-"a"@(FileId(1), 87..88) [Declared]: ref_mut int
-"r"@(FileId(1), 162..163) [Declared]: ref_mut real
-"i"@(FileId(1), 179..180) [Declared]: ref_mut int
-"n"@(FileId(1), 195..196) [Declared]: ref_mut nat
-"_r0"@(FileId(1), 211..214) [Declared]: ref_mut real
-"_r1"@(FileId(1), 234..237) [Declared]: ref_mut real
-"_i0"@(FileId(1), 257..260) [Declared]: ref_mut int
-"_i1"@(FileId(1), 280..283) [Declared]: ref_mut int
-"_n0"@(FileId(1), 303..306) [Declared]: ref_mut nat
-"_n1"@(FileId(1), 326..329) [Declared]: ref_mut nat
+"a"@(FileId(1), 87..88) [Declared]: int
+"r"@(FileId(1), 162..163) [Declared]: real
+"i"@(FileId(1), 179..180) [Declared]: int
+"n"@(FileId(1), 195..196) [Declared]: nat
+"_r0"@(FileId(1), 211..214) [Declared]: real
+"_r1"@(FileId(1), 234..237) [Declared]: real
+"_i0"@(FileId(1), 257..260) [Declared]: int
+"_i1"@(FileId(1), 280..283) [Declared]: int
+"_n0"@(FileId(1), 303..306) [Declared]: nat
+"_n1"@(FileId(1), 326..329) [Declared]: nat
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__integer_inference_mul.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__integer_inference_mul.snap
@@ -1,17 +1,18 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "\n    % Inferred integer types should pass\n    % Decl should be a concrete type\n    var a := 1 * 1\n    % Types of operands should make the type concrete\n    var r : real\n    var i : int\n    var n : nat\n    var _r0 := 1 * r\n    var _r1 := r * 1\n    var _i0 := 1 * i\n    var _i1 := i * 1\n    var _n0 := 1 * n\n    var _n1 := n * 1\n"
 
 ---
-"a"@(FileId(1), 87..88) [Declared]: ref_mut int
-"r"@(FileId(1), 160..161) [Declared]: ref_mut real
-"i"@(FileId(1), 177..178) [Declared]: ref_mut int
-"n"@(FileId(1), 193..194) [Declared]: ref_mut nat
-"_r0"@(FileId(1), 209..212) [Declared]: ref_mut real
-"_r1"@(FileId(1), 230..233) [Declared]: ref_mut real
-"_i0"@(FileId(1), 251..254) [Declared]: ref_mut int
-"_i1"@(FileId(1), 272..275) [Declared]: ref_mut int
-"_n0"@(FileId(1), 293..296) [Declared]: ref_mut nat
-"_n1"@(FileId(1), 314..317) [Declared]: ref_mut nat
+"a"@(FileId(1), 87..88) [Declared]: int
+"r"@(FileId(1), 160..161) [Declared]: real
+"i"@(FileId(1), 177..178) [Declared]: int
+"n"@(FileId(1), 193..194) [Declared]: nat
+"_r0"@(FileId(1), 209..212) [Declared]: real
+"_r1"@(FileId(1), 230..233) [Declared]: real
+"_i0"@(FileId(1), 251..254) [Declared]: int
+"_i1"@(FileId(1), 272..275) [Declared]: int
+"_n0"@(FileId(1), 293..296) [Declared]: nat
+"_n1"@(FileId(1), 314..317) [Declared]: nat
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__integer_inference_negate.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__integer_inference_negate.snap
@@ -1,14 +1,15 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "\n    % Inferred integer types should pass\n    % Decl should be a concrete type\n    var a := - 1\n    % Types of operands should make the type concrete\n    var r : real\n    var i : int\n    var n : nat\n    var _r0 := - r\n    var _i0 := - i\n    var _n0 := - n\n"
 
 ---
-"a"@(FileId(1), 87..88) [Declared]: ref_mut int
-"r"@(FileId(1), 158..159) [Declared]: ref_mut real
-"i"@(FileId(1), 175..176) [Declared]: ref_mut int
-"n"@(FileId(1), 191..192) [Declared]: ref_mut nat
-"_r0"@(FileId(1), 207..210) [Declared]: ref_mut real
-"_i0"@(FileId(1), 226..229) [Declared]: ref_mut int
-"_n0"@(FileId(1), 245..248) [Declared]: ref_mut nat
+"a"@(FileId(1), 87..88) [Declared]: int
+"r"@(FileId(1), 158..159) [Declared]: real
+"i"@(FileId(1), 175..176) [Declared]: int
+"n"@(FileId(1), 191..192) [Declared]: nat
+"_r0"@(FileId(1), 207..210) [Declared]: real
+"_i0"@(FileId(1), 226..229) [Declared]: int
+"_n0"@(FileId(1), 245..248) [Declared]: nat
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__integer_inference_rdiv.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__integer_inference_rdiv.snap
@@ -1,17 +1,18 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "\n    % Inferred integer types should pass\n    % Decl should be a concrete type\n    var a := 1 / 1\n    % Types of operands should make the type concrete\n    var r : real\n    var i : int\n    var n : nat\n    var _r0 := 1 / r\n    var _r1 := r / 1\n    var _i0 := 1 / i\n    var _i1 := i / 1\n    var _n0 := 1 / n\n    var _n1 := n / 1\n"
 
 ---
-"a"@(FileId(1), 87..88) [Declared]: ref_mut real
-"r"@(FileId(1), 160..161) [Declared]: ref_mut real
-"i"@(FileId(1), 177..178) [Declared]: ref_mut int
-"n"@(FileId(1), 193..194) [Declared]: ref_mut nat
-"_r0"@(FileId(1), 209..212) [Declared]: ref_mut real
-"_r1"@(FileId(1), 230..233) [Declared]: ref_mut real
-"_i0"@(FileId(1), 251..254) [Declared]: ref_mut real
-"_i1"@(FileId(1), 272..275) [Declared]: ref_mut real
-"_n0"@(FileId(1), 293..296) [Declared]: ref_mut real
-"_n1"@(FileId(1), 314..317) [Declared]: ref_mut real
+"a"@(FileId(1), 87..88) [Declared]: real
+"r"@(FileId(1), 160..161) [Declared]: real
+"i"@(FileId(1), 177..178) [Declared]: int
+"n"@(FileId(1), 193..194) [Declared]: nat
+"_r0"@(FileId(1), 209..212) [Declared]: real
+"_r1"@(FileId(1), 230..233) [Declared]: real
+"_i0"@(FileId(1), 251..254) [Declared]: real
+"_i1"@(FileId(1), 272..275) [Declared]: real
+"_n0"@(FileId(1), 293..296) [Declared]: real
+"_n1"@(FileId(1), 314..317) [Declared]: real
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__integer_inference_rem.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__integer_inference_rem.snap
@@ -1,17 +1,18 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "\n    % Inferred integer types should pass\n    % Decl should be a concrete type\n    var a := 1 rem 1\n    % Types of operands should make the type concrete\n    var r : real\n    var i : int\n    var n : nat\n    var _r0 := 1 rem r\n    var _r1 := r rem 1\n    var _i0 := 1 rem i\n    var _i1 := i rem 1\n    var _n0 := 1 rem n\n    var _n1 := n rem 1\n"
 
 ---
-"a"@(FileId(1), 87..88) [Declared]: ref_mut int
-"r"@(FileId(1), 162..163) [Declared]: ref_mut real
-"i"@(FileId(1), 179..180) [Declared]: ref_mut int
-"n"@(FileId(1), 195..196) [Declared]: ref_mut nat
-"_r0"@(FileId(1), 211..214) [Declared]: ref_mut real
-"_r1"@(FileId(1), 234..237) [Declared]: ref_mut real
-"_i0"@(FileId(1), 257..260) [Declared]: ref_mut int
-"_i1"@(FileId(1), 280..283) [Declared]: ref_mut int
-"_n0"@(FileId(1), 303..306) [Declared]: ref_mut nat
-"_n1"@(FileId(1), 326..329) [Declared]: ref_mut nat
+"a"@(FileId(1), 87..88) [Declared]: int
+"r"@(FileId(1), 162..163) [Declared]: real
+"i"@(FileId(1), 179..180) [Declared]: int
+"n"@(FileId(1), 195..196) [Declared]: nat
+"_r0"@(FileId(1), 211..214) [Declared]: real
+"_r1"@(FileId(1), 234..237) [Declared]: real
+"_i0"@(FileId(1), 257..260) [Declared]: int
+"_i1"@(FileId(1), 280..283) [Declared]: int
+"_n0"@(FileId(1), 303..306) [Declared]: nat
+"_n1"@(FileId(1), 326..329) [Declared]: nat
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__integer_inference_sub.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__integer_inference_sub.snap
@@ -1,17 +1,18 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "\n    % Inferred integer types should pass\n    % Decl should be a concrete type\n    var a := 1 - 1\n    % Types of operands should make the type concrete\n    var r : real\n    var i : int\n    var n : nat\n    var _r0 := 1 - r\n    var _r1 := r - 1\n    var _i0 := 1 - i\n    var _i1 := i - 1\n    var _n0 := 1 - n\n    var _n1 := n - 1\n"
 
 ---
-"a"@(FileId(1), 87..88) [Declared]: ref_mut int
-"r"@(FileId(1), 160..161) [Declared]: ref_mut real
-"i"@(FileId(1), 177..178) [Declared]: ref_mut int
-"n"@(FileId(1), 193..194) [Declared]: ref_mut nat
-"_r0"@(FileId(1), 209..212) [Declared]: ref_mut real
-"_r1"@(FileId(1), 230..233) [Declared]: ref_mut real
-"_i0"@(FileId(1), 251..254) [Declared]: ref_mut int
-"_i1"@(FileId(1), 272..275) [Declared]: ref_mut int
-"_n0"@(FileId(1), 293..296) [Declared]: ref_mut nat
-"_n1"@(FileId(1), 314..317) [Declared]: ref_mut nat
+"a"@(FileId(1), 87..88) [Declared]: int
+"r"@(FileId(1), 160..161) [Declared]: real
+"i"@(FileId(1), 177..178) [Declared]: int
+"n"@(FileId(1), 193..194) [Declared]: nat
+"_r0"@(FileId(1), 209..212) [Declared]: real
+"_r1"@(FileId(1), 230..233) [Declared]: real
+"_i0"@(FileId(1), 251..254) [Declared]: int
+"_i1"@(FileId(1), 272..275) [Declared]: int
+"_n0"@(FileId(1), 293..296) [Declared]: nat
+"_n1"@(FileId(1), 314..317) [Declared]: nat
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__logical_op_and.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__logical_op_and.snap
@@ -1,9 +1,10 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "\n    % Compatibility with booleans\n    var b : boolean\n    var _bb := b and b\n"
 
 ---
-"b"@(FileId(1), 43..44) [Declared]: ref_mut boolean
-"_bb"@(FileId(1), 63..66) [Declared]: ref_mut boolean
+"b"@(FileId(1), 43..44) [Declared]: boolean
+"_bb"@(FileId(1), 63..66) [Declared]: boolean
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__logical_op_imply.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__logical_op_imply.snap
@@ -1,9 +1,10 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "\n    % Compatibility with booleans\n    var b : boolean\n    var _bb := b => b\n"
 
 ---
-"b"@(FileId(1), 43..44) [Declared]: ref_mut boolean
-"_bb"@(FileId(1), 63..66) [Declared]: ref_mut boolean
+"b"@(FileId(1), 43..44) [Declared]: boolean
+"_bb"@(FileId(1), 63..66) [Declared]: boolean
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__logical_op_not.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__logical_op_not.snap
@@ -1,9 +1,10 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "\n    % Compatibility with booleans\n    var b : boolean\n    var _b := not b\n"
 
 ---
-"b"@(FileId(1), 43..44) [Declared]: ref_mut boolean
-"_b"@(FileId(1), 63..65) [Declared]: ref_mut boolean
+"b"@(FileId(1), 43..44) [Declared]: boolean
+"_b"@(FileId(1), 63..65) [Declared]: boolean
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__logical_op_or.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__logical_op_or.snap
@@ -1,9 +1,10 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "\n    % Compatibility with booleans\n    var b : boolean\n    var _bb := b or b\n"
 
 ---
-"b"@(FileId(1), 43..44) [Declared]: ref_mut boolean
-"_bb"@(FileId(1), 63..66) [Declared]: ref_mut boolean
+"b"@(FileId(1), 43..44) [Declared]: boolean
+"_bb"@(FileId(1), 63..66) [Declared]: boolean
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__logical_op_wrong_type_and.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__logical_op_wrong_type_and.snap
@@ -4,18 +4,18 @@ assertion_line: 41
 expression: "\n    var b : boolean\n    var r : real\n    var i : int\n    var n : nat\n    var _bi := b and i\n    var _bn := b and n\n    var _ib := i and b\n    var _nb := n and b\n    var _ri := r and i\n    var _rn := r and n\n    var _ir := i and r\n    var _nr := n and r\n"
 
 ---
-"b"@(FileId(1), 9..10) [Declared]: ref_mut boolean
-"r"@(FileId(1), 29..30) [Declared]: ref_mut real
-"i"@(FileId(1), 46..47) [Declared]: ref_mut int
-"n"@(FileId(1), 62..63) [Declared]: ref_mut nat
-"_bi"@(FileId(1), 78..81) [Declared]: ref_mut <error>
-"_bn"@(FileId(1), 101..104) [Declared]: ref_mut <error>
-"_ib"@(FileId(1), 124..127) [Declared]: ref_mut <error>
-"_nb"@(FileId(1), 147..150) [Declared]: ref_mut <error>
-"_ri"@(FileId(1), 170..173) [Declared]: ref_mut <error>
-"_rn"@(FileId(1), 193..196) [Declared]: ref_mut <error>
-"_ir"@(FileId(1), 216..219) [Declared]: ref_mut <error>
-"_nr"@(FileId(1), 239..242) [Declared]: ref_mut <error>
+"b"@(FileId(1), 9..10) [Declared]: boolean
+"r"@(FileId(1), 29..30) [Declared]: real
+"i"@(FileId(1), 46..47) [Declared]: int
+"n"@(FileId(1), 62..63) [Declared]: nat
+"_bi"@(FileId(1), 78..81) [Declared]: <error>
+"_bn"@(FileId(1), 101..104) [Declared]: <error>
+"_ib"@(FileId(1), 124..127) [Declared]: <error>
+"_nb"@(FileId(1), 147..150) [Declared]: <error>
+"_ri"@(FileId(1), 170..173) [Declared]: <error>
+"_rn"@(FileId(1), 193..196) [Declared]: <error>
+"_ir"@(FileId(1), 216..219) [Declared]: <error>
+"_nr"@(FileId(1), 239..242) [Declared]: <error>
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 87..90: mismatched types for logical `and`

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__logical_op_wrong_type_imply.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__logical_op_wrong_type_imply.snap
@@ -4,18 +4,18 @@ assertion_line: 41
 expression: "\n    var b : boolean\n    var r : real\n    var i : int\n    var n : nat\n    var _bi := b => i\n    var _bn := b => n\n    var _ib := i => b\n    var _nb := n => b\n    var _ri := r => i\n    var _rn := r => n\n    var _ir := i => r\n    var _nr := n => r\n"
 
 ---
-"b"@(FileId(1), 9..10) [Declared]: ref_mut boolean
-"r"@(FileId(1), 29..30) [Declared]: ref_mut real
-"i"@(FileId(1), 46..47) [Declared]: ref_mut int
-"n"@(FileId(1), 62..63) [Declared]: ref_mut nat
-"_bi"@(FileId(1), 78..81) [Declared]: ref_mut <error>
-"_bn"@(FileId(1), 100..103) [Declared]: ref_mut <error>
-"_ib"@(FileId(1), 122..125) [Declared]: ref_mut <error>
-"_nb"@(FileId(1), 144..147) [Declared]: ref_mut <error>
-"_ri"@(FileId(1), 166..169) [Declared]: ref_mut <error>
-"_rn"@(FileId(1), 188..191) [Declared]: ref_mut <error>
-"_ir"@(FileId(1), 210..213) [Declared]: ref_mut <error>
-"_nr"@(FileId(1), 232..235) [Declared]: ref_mut <error>
+"b"@(FileId(1), 9..10) [Declared]: boolean
+"r"@(FileId(1), 29..30) [Declared]: real
+"i"@(FileId(1), 46..47) [Declared]: int
+"n"@(FileId(1), 62..63) [Declared]: nat
+"_bi"@(FileId(1), 78..81) [Declared]: <error>
+"_bn"@(FileId(1), 100..103) [Declared]: <error>
+"_ib"@(FileId(1), 122..125) [Declared]: <error>
+"_nb"@(FileId(1), 144..147) [Declared]: <error>
+"_ri"@(FileId(1), 166..169) [Declared]: <error>
+"_rn"@(FileId(1), 188..191) [Declared]: <error>
+"_ir"@(FileId(1), 210..213) [Declared]: <error>
+"_nr"@(FileId(1), 232..235) [Declared]: <error>
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 87..89: mismatched types for `=>`

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__logical_op_wrong_type_or.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__logical_op_wrong_type_or.snap
@@ -4,18 +4,18 @@ assertion_line: 41
 expression: "\n    var b : boolean\n    var r : real\n    var i : int\n    var n : nat\n    var _bi := b or i\n    var _bn := b or n\n    var _ib := i or b\n    var _nb := n or b\n    var _ri := r or i\n    var _rn := r or n\n    var _ir := i or r\n    var _nr := n or r\n"
 
 ---
-"b"@(FileId(1), 9..10) [Declared]: ref_mut boolean
-"r"@(FileId(1), 29..30) [Declared]: ref_mut real
-"i"@(FileId(1), 46..47) [Declared]: ref_mut int
-"n"@(FileId(1), 62..63) [Declared]: ref_mut nat
-"_bi"@(FileId(1), 78..81) [Declared]: ref_mut <error>
-"_bn"@(FileId(1), 100..103) [Declared]: ref_mut <error>
-"_ib"@(FileId(1), 122..125) [Declared]: ref_mut <error>
-"_nb"@(FileId(1), 144..147) [Declared]: ref_mut <error>
-"_ri"@(FileId(1), 166..169) [Declared]: ref_mut <error>
-"_rn"@(FileId(1), 188..191) [Declared]: ref_mut <error>
-"_ir"@(FileId(1), 210..213) [Declared]: ref_mut <error>
-"_nr"@(FileId(1), 232..235) [Declared]: ref_mut <error>
+"b"@(FileId(1), 9..10) [Declared]: boolean
+"r"@(FileId(1), 29..30) [Declared]: real
+"i"@(FileId(1), 46..47) [Declared]: int
+"n"@(FileId(1), 62..63) [Declared]: nat
+"_bi"@(FileId(1), 78..81) [Declared]: <error>
+"_bn"@(FileId(1), 100..103) [Declared]: <error>
+"_ib"@(FileId(1), 122..125) [Declared]: <error>
+"_nb"@(FileId(1), 144..147) [Declared]: <error>
+"_ri"@(FileId(1), 166..169) [Declared]: <error>
+"_rn"@(FileId(1), 188..191) [Declared]: <error>
+"_ir"@(FileId(1), 210..213) [Declared]: <error>
+"_nr"@(FileId(1), 232..235) [Declared]: <error>
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 87..89: mismatched types for logical `or`

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__peel_ref_in_assign.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__peel_ref_in_assign.snap
@@ -1,9 +1,10 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "var a : int var k : int := a"
 
 ---
-"a"@(FileId(1), 4..5) [Declared]: ref_mut int
-"k"@(FileId(1), 16..17) [Declared]: ref_mut int
+"a"@(FileId(1), 4..5) [Declared]: int
+"k"@(FileId(1), 16..17) [Declared]: int
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__peel_ref_in_binary_expr.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__peel_ref_in_binary_expr.snap
@@ -1,9 +1,10 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "var a : int var k := a + a"
 
 ---
-"a"@(FileId(1), 4..5) [Declared]: ref_mut int
-"k"@(FileId(1), 16..17) [Declared]: ref_mut int
+"a"@(FileId(1), 4..5) [Declared]: int
+"k"@(FileId(1), 16..17) [Declared]: int
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__peel_ref_in_for_bound.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__peel_ref_in_for_bound.snap
@@ -1,8 +1,9 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "var a : int for : a .. a end for"
 
 ---
-"a"@(FileId(1), 4..5) [Declared]: ref_mut int
+"a"@(FileId(1), 4..5) [Declared]: int
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__peel_ref_in_get_arg.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__peel_ref_in_get_arg.snap
@@ -4,7 +4,7 @@ assertion_line: 41
 expression: "var a : int var s : string get s : a"
 
 ---
-"a"@(FileId(1), 4..5) [Declared]: ref_mut int
-"s"@(FileId(1), 16..17) [Declared]: ref_mut string
+"a"@(FileId(1), 4..5) [Declared]: int
+"s"@(FileId(1), 16..17) [Declared]: string
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__peel_ref_in_inferred_ty.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__peel_ref_in_inferred_ty.snap
@@ -1,9 +1,10 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "var a : int var k := a"
 
 ---
-"a"@(FileId(1), 4..5) [Declared]: ref_mut int
-"k"@(FileId(1), 16..17) [Declared]: ref_mut int
+"a"@(FileId(1), 4..5) [Declared]: int
+"k"@(FileId(1), 16..17) [Declared]: int
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__peel_ref_in_put_stmt.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__peel_ref_in_put_stmt.snap
@@ -1,8 +1,9 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "var a : int put a : 0 : 0 : 0"
 
 ---
-"a"@(FileId(1), 4..5) [Declared]: ref_mut int
+"a"@(FileId(1), 4..5) [Declared]: int
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__peel_ref_in_unary_expr.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__peel_ref_in_unary_expr.snap
@@ -1,9 +1,10 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "var a : int var k := -a"
 
 ---
-"a"@(FileId(1), 4..5) [Declared]: ref_mut int
-"k"@(FileId(1), 16..17) [Declared]: ref_mut int
+"a"@(FileId(1), 4..5) [Declared]: int
+"k"@(FileId(1), 16..17) [Declared]: int
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__report_aliased_type_in_assign.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__report_aliased_type_in_assign.snap
@@ -6,8 +6,8 @@ expression: "type a0 : real\ntype a1 : int\nvar k : a0\nvar i : a1\ni := k"
 ---
 "a0"@(FileId(1), 5..7) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of real
 "a1"@(FileId(1), 20..22) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(1))] of int
-"k"@(FileId(1), 33..34) [Declared]: ref_mut alias[DefId(LibraryId(0), LocalDefId(0))] of real
-"i"@(FileId(1), 44..45) [Declared]: ref_mut alias[DefId(LibraryId(0), LocalDefId(1))] of int
+"k"@(FileId(1), 33..34) [Declared]: alias[DefId(LibraryId(0), LocalDefId(0))] of real
+"i"@(FileId(1), 44..45) [Declared]: alias[DefId(LibraryId(0), LocalDefId(1))] of int
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 53..55: mismatched types

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__report_aliased_type_in_binary_expr.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__report_aliased_type_in_binary_expr.snap
@@ -6,8 +6,8 @@ expression: "type a0 : real\ntype a1 : int\nvar k : a0\nvar i : int\ni := i + k 
 ---
 "a0"@(FileId(1), 5..7) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of real
 "a1"@(FileId(1), 20..22) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(1))] of int
-"k"@(FileId(1), 33..34) [Declared]: ref_mut alias[DefId(LibraryId(0), LocalDefId(0))] of real
-"i"@(FileId(1), 44..45) [Declared]: ref_mut int
+"k"@(FileId(1), 33..34) [Declared]: alias[DefId(LibraryId(0), LocalDefId(0))] of real
+"i"@(FileId(1), 44..45) [Declared]: int
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 54..56: mismatched types

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__report_aliased_type_in_case.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__report_aliased_type_in_case.snap
@@ -6,8 +6,8 @@ expression: "type a0 : char\ntype a1 : char(6)\nvar ca0 : a0\nconst cna1 : a1 :=
 ---
 "a0"@(FileId(1), 5..7) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of char
 "a1"@(FileId(1), 20..22) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(1))] of char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
-"ca0"@(FileId(1), 37..40) [Declared]: ref_mut alias[DefId(LibraryId(0), LocalDefId(0))] of char
-"cna1"@(FileId(1), 52..56) [Declared]: ref alias[DefId(LibraryId(0), LocalDefId(1))] of char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
+"ca0"@(FileId(1), 37..40) [Declared]: alias[DefId(LibraryId(0), LocalDefId(0))] of char
+"cna1"@(FileId(1), 52..56) [Declared]: alias[DefId(LibraryId(0), LocalDefId(1))] of char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 93..97: mismatched types

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__report_aliased_type_in_for.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__report_aliased_type_in_for.snap
@@ -5,8 +5,8 @@ expression: "type a0 : string\nvar sa0 : a0\nvar s : string\n\nfor : sa0 .. sa0 
 
 ---
 "a0"@(FileId(1), 5..7) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of string
-"sa0"@(FileId(1), 21..24) [Declared]: ref_mut alias[DefId(LibraryId(0), LocalDefId(0))] of string
-"s"@(FileId(1), 34..35) [Declared]: ref_mut string
+"sa0"@(FileId(1), 21..24) [Declared]: alias[DefId(LibraryId(0), LocalDefId(0))] of string
+"s"@(FileId(1), 34..35) [Declared]: string
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 52..62: mismatched types

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__report_aliased_type_in_inferred_ty.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__report_aliased_type_in_inferred_ty.snap
@@ -6,8 +6,8 @@ expression: "type a0 : real\ntype a1 : int\nvar k : a0\nvar i : a1 := k"
 ---
 "a0"@(FileId(1), 5..7) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of real
 "a1"@(FileId(1), 20..22) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(1))] of int
-"k"@(FileId(1), 33..34) [Declared]: ref_mut alias[DefId(LibraryId(0), LocalDefId(0))] of real
-"i"@(FileId(1), 44..45) [Declared]: ref_mut alias[DefId(LibraryId(0), LocalDefId(1))] of int
+"k"@(FileId(1), 33..34) [Declared]: alias[DefId(LibraryId(0), LocalDefId(0))] of real
+"i"@(FileId(1), 44..45) [Declared]: alias[DefId(LibraryId(0), LocalDefId(1))] of int
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 54..55: mismatched types

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__report_aliased_type_in_unary_expr.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__report_aliased_type_in_unary_expr.snap
@@ -5,8 +5,8 @@ expression: "type a0 : real\nvar k : a0\nvar _ := not k % unchanged\n"
 
 ---
 "a0"@(FileId(1), 5..7) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of real
-"k"@(FileId(1), 19..20) [Declared]: ref_mut alias[DefId(LibraryId(0), LocalDefId(0))] of real
-"_"@(FileId(1), 30..31) [Declared]: ref_mut <error>
+"k"@(FileId(1), 19..20) [Declared]: alias[DefId(LibraryId(0), LocalDefId(0))] of real
+"_"@(FileId(1), 30..31) [Declared]: <error>
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 35..38: mismatched types for logical `not`

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__require_resolved_type_in_constvar.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__require_resolved_type_in_constvar.snap
@@ -5,7 +5,7 @@ expression: "type fowo : forward var _ : fowo"
 
 ---
 "fowo"@(FileId(1), 5..9) [Forward(Type, None)]: alias[DefId(LibraryId(0), LocalDefId(0))] of forward
-"_"@(FileId(1), 24..25) [Declared]: ref_mut <error>
+"_"@(FileId(1), 24..25) [Declared]: <error>
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 28..32: `fowo` has not been resolved at this point

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__sized_char_const_err.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__sized_char_const_err.snap
@@ -4,7 +4,7 @@ assertion_line: 41
 expression: "var _ : char(1.0 div 0.0)"
 
 ---
-"_"@(FileId(1), 4..5) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
+"_"@(FileId(1), 4..5) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 17..20: cannot compute expression at compile-time

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__sized_char_indirect_expr.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__sized_char_indirect_expr.snap
@@ -1,9 +1,10 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "const N := 1\nvar _ : char(N)\n"
 
 ---
-"N"@(FileId(1), 6..7) [Declared]: ref int
-"_"@(FileId(1), 17..18) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
+"N"@(FileId(1), 6..7) [Declared]: int
+"_"@(FileId(1), 17..18) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__sized_char_literal.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__sized_char_literal.snap
@@ -1,8 +1,9 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "var _ : char(1)"
 
 ---
-"_"@(FileId(1), 4..5) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
+"_"@(FileId(1), 4..5) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__sized_char_max_sized.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__sized_char_max_sized.snap
@@ -1,9 +1,10 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "var _ : char(32768)"
 
 ---
-"_"@(FileId(1), 4..5) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
+"_"@(FileId(1), 4..5) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 13..18: invalid character count size

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__sized_char_simple_expr.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__sized_char_simple_expr.snap
@@ -1,8 +1,9 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "var _ : char(1 - 1 * 1 + 2)"
 
 ---
-"_"@(FileId(1), 4..5) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
+"_"@(FileId(1), 4..5) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__sized_char_wrong_type.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__sized_char_wrong_type.snap
@@ -1,9 +1,10 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "var _ : char(1.0)"
 
 ---
-"_"@(FileId(1), 4..5) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
+"_"@(FileId(1), 4..5) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 13..16: mismatched types

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__sized_char_wrong_type_bool.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__sized_char_wrong_type_bool.snap
@@ -1,9 +1,10 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "var _ : char(true)"
 
 ---
-"_"@(FileId(1), 4..5) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
+"_"@(FileId(1), 4..5) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 13..17: mismatched types

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__sized_char_zero_sized.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__sized_char_zero_sized.snap
@@ -1,9 +1,10 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "var _ : char(0)"
 
 ---
-"_"@(FileId(1), 4..5) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
+"_"@(FileId(1), 4..5) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 13..14: invalid character count size

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__sized_string_const_err.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__sized_string_const_err.snap
@@ -4,7 +4,7 @@ assertion_line: 41
 expression: "var _ : string(1.0 div 0.0)"
 
 ---
-"_"@(FileId(1), 4..5) [Declared]: ref_mut string_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
+"_"@(FileId(1), 4..5) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 19..22: cannot compute expression at compile-time

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__sized_string_indirect_expr.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__sized_string_indirect_expr.snap
@@ -1,9 +1,10 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "const N := 1\nvar _ : string(N)\n"
 
 ---
-"N"@(FileId(1), 6..7) [Declared]: ref int
-"_"@(FileId(1), 17..18) [Declared]: ref_mut string_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
+"N"@(FileId(1), 6..7) [Declared]: int
+"_"@(FileId(1), 17..18) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__sized_string_literal.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__sized_string_literal.snap
@@ -1,8 +1,9 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "var _ : string(1)"
 
 ---
-"_"@(FileId(1), 4..5) [Declared]: ref_mut string_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
+"_"@(FileId(1), 4..5) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__sized_string_max_sized.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__sized_string_max_sized.snap
@@ -1,9 +1,10 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "var _ : string(256)"
 
 ---
-"_"@(FileId(1), 4..5) [Declared]: ref_mut string_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
+"_"@(FileId(1), 4..5) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 15..18: invalid character count size

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__sized_string_over_sized.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__sized_string_over_sized.snap
@@ -1,9 +1,10 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "var _ : string(512)"
 
 ---
-"_"@(FileId(1), 4..5) [Declared]: ref_mut string_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
+"_"@(FileId(1), 4..5) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 15..18: invalid character count size

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__sized_string_simple_expr.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__sized_string_simple_expr.snap
@@ -1,8 +1,9 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "var _ : string(1 - 1 * 1 + 2)"
 
 ---
-"_"@(FileId(1), 4..5) [Declared]: ref_mut string_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
+"_"@(FileId(1), 4..5) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__sized_string_wrong_type.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__sized_string_wrong_type.snap
@@ -1,9 +1,10 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "var _ : string(1.0)"
 
 ---
-"_"@(FileId(1), 4..5) [Declared]: ref_mut string_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
+"_"@(FileId(1), 4..5) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 15..18: mismatched types

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__sized_string_wrong_type_bool.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__sized_string_wrong_type_bool.snap
@@ -1,9 +1,10 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "var _ : string(true)"
 
 ---
-"_"@(FileId(1), 4..5) [Declared]: ref_mut string_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
+"_"@(FileId(1), 4..5) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 15..19: mismatched types

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__sized_string_zero_sized.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__sized_string_zero_sized.snap
@@ -1,9 +1,10 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "var _ : string(0)"
 
 ---
-"_"@(FileId(1), 4..5) [Declared]: ref_mut string_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
+"_"@(FileId(1), 4..5) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 15..16: invalid character count size

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__string_manip_op_concat.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__string_manip_op_concat.snap
@@ -1,49 +1,50 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "\n    var c : char\n    var c_dyn : char(*)\n    var c_sz : char(6)\n    var s : string\n    var s_dyn : string(*)\n    var s_sz : string(6)\n\n    % special cases first\n    var _t00 := c + c\n    var _t02 := c + c_sz\n    var _t20 := c_sz + c\n    var _t22 := c_sz + c_sz\n\n    % the rest of them down here (should produce string)\n    var _t01 := c + c_dyn\n    var _t03 := c + s\n    var _t04 := c + s_dyn\n    var _t05 := c + s_sz\n\n    var _t10 := c_dyn + c\n    var _t30 := s + c\n    var _t40 := s_dyn + c\n    var _t50 := s_sz + c\n\n    var _t11 := c_dyn + c_dyn\n    var _t12 := c_dyn + c_sz\n    var _t13 := c_dyn + s\n    var _t14 := c_dyn + s_dyn\n    var _t15 := c_dyn + s_sz\n\n    var _t21 := c_sz + c_dyn\n    var _t31 := s + c_dyn\n    var _t41 := s_dyn + c_dyn\n    var _t51 := s_sz + c_dyn\n\n    var _t23 := c_sz + s\n    var _t24 := c_sz + s_dyn\n    var _t25 := c_sz + s_sz\n\n    var _t32 := s + c_sz\n    var _t42 := s_dyn + c_sz\n    var _t52 := s_sz + c_sz\n\n    var _t33 := s + s\n    var _t34 := s + s_dyn\n    var _t35 := s + s_sz\n\n    var _t43 := s_dyn + s\n    var _t53 := s_sz + s\n\n    var _t44 := s_dyn + s_dyn\n    var _t45 := s_dyn + s_sz\n\n    var _t54 := s_sz + s_dyn\n\n    var _t55 := s_sz + s_sz\n    "
 
 ---
-"c"@(FileId(1), 9..10) [Declared]: ref_mut char
-"c_dyn"@(FileId(1), 26..31) [Declared]: ref_mut char_n Dynamic
-"c_sz"@(FileId(1), 50..54) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
-"s"@(FileId(1), 73..74) [Declared]: ref_mut string
-"s_dyn"@(FileId(1), 92..97) [Declared]: ref_mut string_n Dynamic
-"s_sz"@(FileId(1), 118..122) [Declared]: ref_mut string_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
-"_t00"@(FileId(1), 170..174) [Declared]: ref_mut string
-"_t02"@(FileId(1), 192..196) [Declared]: ref_mut string
-"_t20"@(FileId(1), 217..221) [Declared]: ref_mut string
-"_t22"@(FileId(1), 242..246) [Declared]: ref_mut string
-"_t01"@(FileId(1), 328..332) [Declared]: ref_mut string
-"_t03"@(FileId(1), 354..358) [Declared]: ref_mut string
-"_t04"@(FileId(1), 376..380) [Declared]: ref_mut string
-"_t05"@(FileId(1), 402..406) [Declared]: ref_mut string
-"_t10"@(FileId(1), 428..432) [Declared]: ref_mut string
-"_t30"@(FileId(1), 454..458) [Declared]: ref_mut string
-"_t40"@(FileId(1), 476..480) [Declared]: ref_mut string
-"_t50"@(FileId(1), 502..506) [Declared]: ref_mut string
-"_t11"@(FileId(1), 528..532) [Declared]: ref_mut string
-"_t12"@(FileId(1), 558..562) [Declared]: ref_mut string
-"_t13"@(FileId(1), 587..591) [Declared]: ref_mut string
-"_t14"@(FileId(1), 613..617) [Declared]: ref_mut string
-"_t15"@(FileId(1), 643..647) [Declared]: ref_mut string
-"_t21"@(FileId(1), 673..677) [Declared]: ref_mut string
-"_t31"@(FileId(1), 702..706) [Declared]: ref_mut string
-"_t41"@(FileId(1), 728..732) [Declared]: ref_mut string
-"_t51"@(FileId(1), 758..762) [Declared]: ref_mut string
-"_t23"@(FileId(1), 788..792) [Declared]: ref_mut string
-"_t24"@(FileId(1), 813..817) [Declared]: ref_mut string
-"_t25"@(FileId(1), 842..846) [Declared]: ref_mut string
-"_t32"@(FileId(1), 871..875) [Declared]: ref_mut string
-"_t42"@(FileId(1), 896..900) [Declared]: ref_mut string
-"_t52"@(FileId(1), 925..929) [Declared]: ref_mut string
-"_t33"@(FileId(1), 954..958) [Declared]: ref_mut string
-"_t34"@(FileId(1), 976..980) [Declared]: ref_mut string
-"_t35"@(FileId(1), 1002..1006) [Declared]: ref_mut string
-"_t43"@(FileId(1), 1028..1032) [Declared]: ref_mut string
-"_t53"@(FileId(1), 1054..1058) [Declared]: ref_mut string
-"_t44"@(FileId(1), 1080..1084) [Declared]: ref_mut string
-"_t45"@(FileId(1), 1110..1114) [Declared]: ref_mut string
-"_t54"@(FileId(1), 1140..1144) [Declared]: ref_mut string
-"_t55"@(FileId(1), 1170..1174) [Declared]: ref_mut string
+"c"@(FileId(1), 9..10) [Declared]: char
+"c_dyn"@(FileId(1), 26..31) [Declared]: char_n Dynamic
+"c_sz"@(FileId(1), 50..54) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
+"s"@(FileId(1), 73..74) [Declared]: string
+"s_dyn"@(FileId(1), 92..97) [Declared]: string_n Dynamic
+"s_sz"@(FileId(1), 118..122) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
+"_t00"@(FileId(1), 170..174) [Declared]: string
+"_t02"@(FileId(1), 192..196) [Declared]: string
+"_t20"@(FileId(1), 217..221) [Declared]: string
+"_t22"@(FileId(1), 242..246) [Declared]: string
+"_t01"@(FileId(1), 328..332) [Declared]: string
+"_t03"@(FileId(1), 354..358) [Declared]: string
+"_t04"@(FileId(1), 376..380) [Declared]: string
+"_t05"@(FileId(1), 402..406) [Declared]: string
+"_t10"@(FileId(1), 428..432) [Declared]: string
+"_t30"@(FileId(1), 454..458) [Declared]: string
+"_t40"@(FileId(1), 476..480) [Declared]: string
+"_t50"@(FileId(1), 502..506) [Declared]: string
+"_t11"@(FileId(1), 528..532) [Declared]: string
+"_t12"@(FileId(1), 558..562) [Declared]: string
+"_t13"@(FileId(1), 587..591) [Declared]: string
+"_t14"@(FileId(1), 613..617) [Declared]: string
+"_t15"@(FileId(1), 643..647) [Declared]: string
+"_t21"@(FileId(1), 673..677) [Declared]: string
+"_t31"@(FileId(1), 702..706) [Declared]: string
+"_t41"@(FileId(1), 728..732) [Declared]: string
+"_t51"@(FileId(1), 758..762) [Declared]: string
+"_t23"@(FileId(1), 788..792) [Declared]: string
+"_t24"@(FileId(1), 813..817) [Declared]: string
+"_t25"@(FileId(1), 842..846) [Declared]: string
+"_t32"@(FileId(1), 871..875) [Declared]: string
+"_t42"@(FileId(1), 896..900) [Declared]: string
+"_t52"@(FileId(1), 925..929) [Declared]: string
+"_t33"@(FileId(1), 954..958) [Declared]: string
+"_t34"@(FileId(1), 976..980) [Declared]: string
+"_t35"@(FileId(1), 1002..1006) [Declared]: string
+"_t43"@(FileId(1), 1028..1032) [Declared]: string
+"_t53"@(FileId(1), 1054..1058) [Declared]: string
+"_t44"@(FileId(1), 1080..1084) [Declared]: string
+"_t45"@(FileId(1), 1110..1114) [Declared]: string
+"_t54"@(FileId(1), 1140..1144) [Declared]: string
+"_t55"@(FileId(1), 1170..1174) [Declared]: string
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__string_manip_op_wrong_type_concat.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__string_manip_op_wrong_type_concat.snap
@@ -4,25 +4,25 @@ assertion_line: 41
 expression: "\n    var c : char\n    var c_dyn : char(*)\n    var c_sz : char(6)\n    var s : string\n    var s_dyn : string(*)\n    var s_sz : string(6)\n    var i : int\n\n    var _e00 := c + i\n    var _e01 := c_dyn + i\n    var _e02 := c_sz + i\n    var _e03 := s + i\n    var _e04 := s_dyn + i\n    var _e05 := s_sz + i\n\n    var _e10 := i + c\n    var _e11 := i + c_dyn\n    var _e12 := i + c_sz\n    var _e13 := i + s\n    var _e14 := i + s_dyn\n    var _e15 := i + s_sz\n\n    % TODO: Uncomment to verify incompatible types\n    /*\n    var _e20 : char(13) := c_sz + c_sz\n    var _e21 : char(8) := c_sz + c\n    var _e22 : char(8) := c + c_sz\n    var _e23 : char(3) := c + c\n    var _e24 : char := c + c\n    */\n    "
 
 ---
-"c"@(FileId(1), 9..10) [Declared]: ref_mut char
-"c_dyn"@(FileId(1), 26..31) [Declared]: ref_mut char_n Dynamic
-"c_sz"@(FileId(1), 50..54) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
-"s"@(FileId(1), 73..74) [Declared]: ref_mut string
-"s_dyn"@(FileId(1), 92..97) [Declared]: ref_mut string_n Dynamic
-"s_sz"@(FileId(1), 118..122) [Declared]: ref_mut string_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
-"i"@(FileId(1), 143..144) [Declared]: ref_mut int
-"_e00"@(FileId(1), 160..164) [Declared]: ref_mut <error>
-"_e01"@(FileId(1), 182..186) [Declared]: ref_mut <error>
-"_e02"@(FileId(1), 208..212) [Declared]: ref_mut <error>
-"_e03"@(FileId(1), 233..237) [Declared]: ref_mut <error>
-"_e04"@(FileId(1), 255..259) [Declared]: ref_mut <error>
-"_e05"@(FileId(1), 281..285) [Declared]: ref_mut <error>
-"_e10"@(FileId(1), 307..311) [Declared]: ref_mut <error>
-"_e11"@(FileId(1), 329..333) [Declared]: ref_mut <error>
-"_e12"@(FileId(1), 355..359) [Declared]: ref_mut <error>
-"_e13"@(FileId(1), 380..384) [Declared]: ref_mut <error>
-"_e14"@(FileId(1), 402..406) [Declared]: ref_mut <error>
-"_e15"@(FileId(1), 428..432) [Declared]: ref_mut <error>
+"c"@(FileId(1), 9..10) [Declared]: char
+"c_dyn"@(FileId(1), 26..31) [Declared]: char_n Dynamic
+"c_sz"@(FileId(1), 50..54) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
+"s"@(FileId(1), 73..74) [Declared]: string
+"s_dyn"@(FileId(1), 92..97) [Declared]: string_n Dynamic
+"s_sz"@(FileId(1), 118..122) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
+"i"@(FileId(1), 143..144) [Declared]: int
+"_e00"@(FileId(1), 160..164) [Declared]: <error>
+"_e01"@(FileId(1), 182..186) [Declared]: <error>
+"_e02"@(FileId(1), 208..212) [Declared]: <error>
+"_e03"@(FileId(1), 233..237) [Declared]: <error>
+"_e04"@(FileId(1), 255..259) [Declared]: <error>
+"_e05"@(FileId(1), 281..285) [Declared]: <error>
+"_e10"@(FileId(1), 307..311) [Declared]: <error>
+"_e11"@(FileId(1), 329..333) [Declared]: <error>
+"_e12"@(FileId(1), 355..359) [Declared]: <error>
+"_e13"@(FileId(1), 380..384) [Declared]: <error>
+"_e14"@(FileId(1), 402..406) [Declared]: <error>
+"_e15"@(FileId(1), 428..432) [Declared]: <error>
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 170..171: mismatched types for string concatenation

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typecheck_error_prop.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typecheck_error_prop.snap
@@ -4,10 +4,10 @@ assertion_line: 41
 expression: "var a : int\nvar b : string\nvar c := a + b\nvar j := c + a\n"
 
 ---
-"a"@(FileId(1), 4..5) [Declared]: ref_mut int
-"b"@(FileId(1), 16..17) [Declared]: ref_mut string
-"c"@(FileId(1), 31..32) [Declared]: ref_mut <error>
-"j"@(FileId(1), 46..47) [Declared]: ref_mut <error>
+"a"@(FileId(1), 4..5) [Declared]: int
+"b"@(FileId(1), 16..17) [Declared]: string
+"c"@(FileId(1), 31..32) [Declared]: <error>
+"j"@(FileId(1), 46..47) [Declared]: <error>
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 38..39: mismatched types for string concatenation

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typecheck_missing_exprs.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typecheck_missing_exprs.snap
@@ -1,8 +1,9 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "const ke : int := ()"
 
 ---
-"ke"@(FileId(1), 6..8) [Declared]: ref int
+"ke"@(FileId(1), 6..8) [Declared]: int
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_assignment_invalid_compound_add.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_assignment_invalid_compound_add.snap
@@ -4,8 +4,8 @@ assertion_line: 41
 expression: "var lhs : real\nvar rhs : boolean\nlhs += rhs\n"
 
 ---
-"lhs"@(FileId(1), 4..7) [Declared]: ref_mut real
-"rhs"@(FileId(1), 19..22) [Declared]: ref_mut boolean
+"lhs"@(FileId(1), 4..7) [Declared]: real
+"rhs"@(FileId(1), 19..22) [Declared]: boolean
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 37..39: mismatched types for addition

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_assignment_lhs_not_mut_is_const.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_assignment_lhs_not_mut_is_const.snap
@@ -1,10 +1,11 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "const j : int := 2\nconst k : int := 3\nk := j\n"
 
 ---
-"j"@(FileId(1), 6..7) [Declared]: ref int
-"k"@(FileId(1), 25..26) [Declared]: ref int
+"j"@(FileId(1), 6..7) [Declared]: int
+"k"@(FileId(1), 25..26) [Declared]: int
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 40..42: cannot assign into expression

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_assignment_lhs_not_mut_missing_rhs.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_assignment_lhs_not_mut_missing_rhs.snap
@@ -1,9 +1,10 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "const j : int := 1\nj := \n"
 
 ---
-"j"@(FileId(1), 6..7) [Declared]: ref int
+"j"@(FileId(1), 6..7) [Declared]: int
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 21..23: cannot assign into expression

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_assignment_mismatched_types.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_assignment_mismatched_types.snap
@@ -1,9 +1,10 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "var lhs : int\nlhs := 1 + 1.0\n"
 
 ---
-"lhs"@(FileId(1), 4..7) [Declared]: ref_mut int
+"lhs"@(FileId(1), 4..7) [Declared]: int
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 18..20: mismatched types

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_assignment_valid.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_assignment_valid.snap
@@ -1,9 +1,10 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "const j : int := 2\nvar k : int := 1\nk := j\n"
 
 ---
-"j"@(FileId(1), 6..7) [Declared]: ref int
-"k"@(FileId(1), 23..24) [Declared]: ref_mut int
+"j"@(FileId(1), 6..7) [Declared]: int
+"k"@(FileId(1), 23..24) [Declared]: int
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_assignment_valid_compound_add.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_assignment_valid_compound_add.snap
@@ -1,9 +1,10 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "var lhs : real\nvar rhs : int\nlhs += rhs\n"
 
 ---
-"lhs"@(FileId(1), 4..7) [Declared]: ref_mut real
-"rhs"@(FileId(1), 19..22) [Declared]: ref_mut int
+"lhs"@(FileId(1), 4..7) [Declared]: real
+"rhs"@(FileId(1), 19..22) [Declared]: int
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_case_non_comptime_selector_expr.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_case_non_comptime_selector_expr.snap
@@ -1,9 +1,10 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "var k : int\ncase 1 of label k + 1: end case\n"
 
 ---
-"k"@(FileId(1), 4..5) [Declared]: ref_mut int
+"k"@(FileId(1), 4..5) [Declared]: int
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 28..29: reference cannot be computed at compile-time

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_const_compatible.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_const_compatible.snap
@@ -1,8 +1,9 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "const k : int := 100"
 
 ---
-"k"@(FileId(1), 6..7) [Declared]: ref int
+"k"@(FileId(1), 6..7) [Declared]: int
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_const_error_prop.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_const_error_prop.snap
@@ -4,8 +4,8 @@ assertion_line: 41
 expression: "const k := 20 + false\nconst l : int := k   % Nothing reported here\n"
 
 ---
-"k"@(FileId(1), 6..7) [Declared]: ref <error>
-"l"@(FileId(1), 28..29) [Declared]: ref int
+"k"@(FileId(1), 6..7) [Declared]: <error>
+"l"@(FileId(1), 28..29) [Declared]: int
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 14..15: mismatched types for addition

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_const_incompatible.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_const_incompatible.snap
@@ -1,9 +1,10 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "const k : char := 20"
 
 ---
-"k"@(FileId(1), 6..7) [Declared]: ref char
+"k"@(FileId(1), 6..7) [Declared]: char
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 18..20: mismatched types

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_for_immut_counter.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_for_immut_counter.snap
@@ -1,9 +1,10 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "for i : false .. true i := false end for"
 
 ---
-"i"@(FileId(1), 4..5) [Declared]: ref boolean
+"i"@(FileId(1), 4..5) [Declared]: boolean
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 24..26: cannot assign into expression

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_for_infer_concrete_counter_ty.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_for_infer_concrete_counter_ty.snap
@@ -4,10 +4,10 @@ assertion_line: 41
 expression: "% Both should fail\nfor c : 1.0 .. 1 var k : int := c end for\nfor c : 1 .. 1.0 var k : int := c end for\n"
 
 ---
-"c"@(FileId(1), 23..24) [Declared]: ref real
-"k"@(FileId(1), 40..41) [Declared]: ref_mut int
-"c"@(FileId(1), 65..66) [Declared]: ref real
-"k"@(FileId(1), 82..83) [Declared]: ref_mut int
+"c"@(FileId(1), 23..24) [Declared]: real
+"k"@(FileId(1), 40..41) [Declared]: int
+"c"@(FileId(1), 65..66) [Declared]: real
+"k"@(FileId(1), 82..83) [Declared]: int
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 27..35: mismatched types

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_for_infer_counter_ty.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_for_infer_counter_ty.snap
@@ -1,9 +1,10 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "for a : 1 .. 10\n    var q : int := a\nend for\n"
 
 ---
-"a"@(FileId(1), 4..5) [Declared]: ref int
-"q"@(FileId(1), 24..25) [Declared]: ref_mut int
+"a"@(FileId(1), 4..5) [Declared]: int
+"q"@(FileId(1), 24..25) [Declared]: int
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_for_unsupported_implicit_bounds.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_for_unsupported_implicit_bounds.snap
@@ -1,9 +1,10 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "var implied : int for : implied end for"
 
 ---
-"implied"@(FileId(1), 4..11) [Declared]: ref_mut int
+"implied"@(FileId(1), 4..11) [Declared]: int
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 24..31: unsupported expression

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_for_wrong_types_bounds_concrete_integer.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_for_wrong_types_bounds_concrete_integer.snap
@@ -4,7 +4,7 @@ assertion_line: 41
 expression: "var r : real for : r .. 1 end for"
 
 ---
-"r"@(FileId(1), 4..5) [Declared]: ref_mut real
+"r"@(FileId(1), 4..5) [Declared]: real
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 19..25: mismatched types

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_for_wrong_types_bounds_integer_concrete.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_for_wrong_types_bounds_integer_concrete.snap
@@ -4,7 +4,7 @@ assertion_line: 41
 expression: "var r : real for : 1 .. r end for"
 
 ---
-"r"@(FileId(1), 4..5) [Declared]: ref_mut real
+"r"@(FileId(1), 4..5) [Declared]: real
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 19..25: mismatched types

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_get_stmt_invalid_opts_chars.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_get_stmt_invalid_opts_chars.snap
@@ -4,11 +4,11 @@ assertion_line: 41
 expression: "var i : int\nvar n : nat\nvar r : real\nvar c : char\nvar b: boolean\n%type en: enum(a, b) var ef : en\n\nget i : 0\nget n : 0\nget r : 0\nget c : 0\nget b : 0\n%get ef : 0\n"
 
 ---
-"i"@(FileId(1), 4..5) [Declared]: ref_mut int
-"n"@(FileId(1), 16..17) [Declared]: ref_mut nat
-"r"@(FileId(1), 28..29) [Declared]: ref_mut real
-"c"@(FileId(1), 41..42) [Declared]: ref_mut char
-"b"@(FileId(1), 54..55) [Declared]: ref_mut boolean
+"i"@(FileId(1), 4..5) [Declared]: int
+"n"@(FileId(1), 16..17) [Declared]: nat
+"r"@(FileId(1), 28..29) [Declared]: real
+"c"@(FileId(1), 41..42) [Declared]: char
+"b"@(FileId(1), 54..55) [Declared]: boolean
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 107..108: invalid get option

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_get_stmt_invalid_opts_lines.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_get_stmt_invalid_opts_lines.snap
@@ -4,12 +4,12 @@ assertion_line: 41
 expression: "var i : int\nvar n : nat\nvar r : real\nvar c : char\nvar b: boolean\nvar cn : char(4)\n%type en: enum(a, b) var ef : en\n\nget i : *\nget n : *\nget r : *\nget c : *\nget b : *\nget cn : *\n%get ef : *\n"
 
 ---
-"i"@(FileId(1), 4..5) [Declared]: ref_mut int
-"n"@(FileId(1), 16..17) [Declared]: ref_mut nat
-"r"@(FileId(1), 28..29) [Declared]: ref_mut real
-"c"@(FileId(1), 41..42) [Declared]: ref_mut char
-"b"@(FileId(1), 54..55) [Declared]: ref_mut boolean
-"cn"@(FileId(1), 69..71) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
+"i"@(FileId(1), 4..5) [Declared]: int
+"n"@(FileId(1), 16..17) [Declared]: nat
+"r"@(FileId(1), 28..29) [Declared]: real
+"c"@(FileId(1), 41..42) [Declared]: char
+"b"@(FileId(1), 54..55) [Declared]: boolean
+"cn"@(FileId(1), 69..71) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 120..121: invalid get option used

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_get_stmt_normal_items.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_get_stmt_normal_items.snap
@@ -4,13 +4,13 @@ assertion_line: 41
 expression: "var i : int\nvar n : nat\nvar r : real\nvar c : char\nvar b: boolean\nvar cn : char(4)\nvar s : string\nvar sn : string(4)\n%type en: enum(a, b) var ef : en\n\nget i\nget n\nget r\nget c\nget b\nget cn\nget s\nget sn\n%get ef\n"
 
 ---
-"i"@(FileId(1), 4..5) [Declared]: ref_mut int
-"n"@(FileId(1), 16..17) [Declared]: ref_mut nat
-"r"@(FileId(1), 28..29) [Declared]: ref_mut real
-"c"@(FileId(1), 41..42) [Declared]: ref_mut char
-"b"@(FileId(1), 54..55) [Declared]: ref_mut boolean
-"cn"@(FileId(1), 69..71) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
-"s"@(FileId(1), 86..87) [Declared]: ref_mut string
-"sn"@(FileId(1), 101..103) [Declared]: ref_mut string_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
+"i"@(FileId(1), 4..5) [Declared]: int
+"n"@(FileId(1), 16..17) [Declared]: nat
+"r"@(FileId(1), 28..29) [Declared]: real
+"c"@(FileId(1), 41..42) [Declared]: char
+"b"@(FileId(1), 54..55) [Declared]: boolean
+"cn"@(FileId(1), 69..71) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
+"s"@(FileId(1), 86..87) [Declared]: string
+"sn"@(FileId(1), 101..103) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_get_stmt_valid_opts.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_get_stmt_valid_opts.snap
@@ -4,8 +4,8 @@ assertion_line: 41
 expression: "var cn : char(4)\nvar s : string\nvar sn : string(4)\n\n% chars\nget cn : 0\nget s : 0\nget sn : 0\n\n% lines\nget s : *\nget sn : *\n"
 
 ---
-"cn"@(FileId(1), 4..6) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
-"s"@(FileId(1), 21..22) [Declared]: ref_mut string
-"sn"@(FileId(1), 36..38) [Declared]: ref_mut string_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
+"cn"@(FileId(1), 4..6) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
+"s"@(FileId(1), 21..22) [Declared]: string
+"sn"@(FileId(1), 36..38) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_get_stmt_wrong_ref_const.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_get_stmt_wrong_ref_const.snap
@@ -1,9 +1,10 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "const i : int := 1\nget i\n"
 
 ---
-"i"@(FileId(1), 6..7) [Declared]: ref int
+"i"@(FileId(1), 6..7) [Declared]: int
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 23..24: cannot assign into expression

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_get_stmt_wrong_ref_value.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_get_stmt_wrong_ref_value.snap
@@ -1,9 +1,10 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "var i : int := 1\nget i + i\n"
 
 ---
-"i"@(FileId(1), 4..5) [Declared]: ref_mut int
+"i"@(FileId(1), 4..5) [Declared]: int
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 21..26: cannot assign into expression

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_get_stmt_wrong_type_stream.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_get_stmt_wrong_type_stream.snap
@@ -1,9 +1,10 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "var s : real\nget : s, skip\n"
 
 ---
-"s"@(FileId(1), 4..5) [Declared]: ref_mut real
+"s"@(FileId(1), 4..5) [Declared]: real
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 19..20: mismatched types

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_get_stmt_wrong_type_width.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_get_stmt_wrong_type_width.snap
@@ -4,8 +4,8 @@ assertion_line: 41
 expression: "var w : real\nvar s : string\nget s : w\n"
 
 ---
-"w"@(FileId(1), 4..5) [Declared]: ref_mut real
-"s"@(FileId(1), 17..18) [Declared]: ref_mut string
+"w"@(FileId(1), 4..5) [Declared]: real
+"s"@(FileId(1), 17..18) [Declared]: string
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 36..37: mismatched types

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_put_stmt_invalid_extended_opts.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_put_stmt_invalid_extended_opts.snap
@@ -1,12 +1,13 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "% TODO: Uncomment enum lines once enum types are lowered & checked\nvar c : char\nvar cn : char(4)\nvar s : string\nvar sn : string(4)\n%type en: enum(a, b) var ef : en\n\nput c : 0 : 0 : 0\nput cn : 0 : 0 : 0\nput s : 0 : 0 : 0\nput sn : 0 : 0 : 0\n%put ef : 0 : 0 : 0\n"
 
 ---
-"c"@(FileId(1), 71..72) [Declared]: ref_mut char
-"cn"@(FileId(1), 84..86) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
-"s"@(FileId(1), 101..102) [Declared]: ref_mut string
-"sn"@(FileId(1), 116..118) [Declared]: ref_mut string_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
+"c"@(FileId(1), 71..72) [Declared]: char
+"cn"@(FileId(1), 84..86) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
+"s"@(FileId(1), 101..102) [Declared]: string
+"sn"@(FileId(1), 116..118) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 177..178: invalid put option

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_put_stmt_normal_items.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_put_stmt_normal_items.snap
@@ -1,14 +1,15 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "% TODO: Uncomment enum lines once enum types are lowered & checked\nvar i : int\nvar n : nat\nvar r : real\nvar c : char\nvar cn : char(4)\nvar s : string\nvar sn : string(4)\n%type en: enum(a, b) var ef : en\n\nput i : 0\nput n : 0\nput r : 0\nput c : 0\nput cn : 0\nput s : 0\nput sn : 0\n%put ef : 0\n"
 
 ---
-"i"@(FileId(1), 71..72) [Declared]: ref_mut int
-"n"@(FileId(1), 83..84) [Declared]: ref_mut nat
-"r"@(FileId(1), 95..96) [Declared]: ref_mut real
-"c"@(FileId(1), 108..109) [Declared]: ref_mut char
-"cn"@(FileId(1), 121..123) [Declared]: ref_mut char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
-"s"@(FileId(1), 138..139) [Declared]: ref_mut string
-"sn"@(FileId(1), 153..155) [Declared]: ref_mut string_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
+"i"@(FileId(1), 71..72) [Declared]: int
+"n"@(FileId(1), 83..84) [Declared]: nat
+"r"@(FileId(1), 95..96) [Declared]: real
+"c"@(FileId(1), 108..109) [Declared]: char
+"cn"@(FileId(1), 121..123) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
+"s"@(FileId(1), 138..139) [Declared]: string
+"sn"@(FileId(1), 153..155) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_put_stmt_valid_extended_opts.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_put_stmt_valid_extended_opts.snap
@@ -1,10 +1,11 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "var i : int\nvar n : nat\nvar r : real\n\nput i : 0 : 0 : 0\nput n : 0 : 0 : 0\nput r : 0 : 0 : 0\n"
 
 ---
-"i"@(FileId(1), 4..5) [Declared]: ref_mut int
-"n"@(FileId(1), 16..17) [Declared]: ref_mut nat
-"r"@(FileId(1), 28..29) [Declared]: ref_mut real
+"i"@(FileId(1), 4..5) [Declared]: int
+"n"@(FileId(1), 16..17) [Declared]: nat
+"r"@(FileId(1), 28..29) [Declared]: real
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_put_stmt_wrong_type_exp_width.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_put_stmt_wrong_type_exp_width.snap
@@ -1,9 +1,10 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "var e : real\nput 1 : 0 : 0 : e\n"
 
 ---
-"e"@(FileId(1), 4..5) [Declared]: ref_mut real
+"e"@(FileId(1), 4..5) [Declared]: real
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 29..30: mismatched types

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_put_stmt_wrong_type_fract.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_put_stmt_wrong_type_fract.snap
@@ -1,9 +1,10 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "var f : real\nput 1 : 0 : f\n"
 
 ---
-"f"@(FileId(1), 4..5) [Declared]: ref_mut real
+"f"@(FileId(1), 4..5) [Declared]: real
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 25..26: mismatched types

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_put_stmt_wrong_type_stream.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_put_stmt_wrong_type_stream.snap
@@ -1,9 +1,10 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "var s : real\nput : s,  1\n"
 
 ---
-"s"@(FileId(1), 4..5) [Declared]: ref_mut real
+"s"@(FileId(1), 4..5) [Declared]: real
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 19..20: mismatched types

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_put_stmt_wrong_type_width.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_put_stmt_wrong_type_width.snap
@@ -1,9 +1,10 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "var w : real\nput 1 : w\n"
 
 ---
-"w"@(FileId(1), 4..5) [Declared]: ref_mut real
+"w"@(FileId(1), 4..5) [Declared]: real
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 21..22: mismatched types

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_type_alias_as_expr.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_type_alias_as_expr.snap
@@ -5,7 +5,7 @@ expression: "type k : int var a := k"
 
 ---
 "k"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of int
-"a"@(FileId(1), 17..18) [Declared]: ref_mut alias[DefId(LibraryId(0), LocalDefId(0))] of int
+"a"@(FileId(1), 17..18) [Declared]: alias[DefId(LibraryId(0), LocalDefId(0))] of int
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 22..23: cannot use `k` as an expression

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_type_alias_normal.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_type_alias_normal.snap
@@ -5,6 +5,6 @@ expression: "type a : int var _ : a"
 
 ---
 "a"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of int
-"_"@(FileId(1), 17..18) [Declared]: ref_mut alias[DefId(LibraryId(0), LocalDefId(0))] of int
+"_"@(FileId(1), 17..18) [Declared]: alias[DefId(LibraryId(0), LocalDefId(0))] of int
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_type_alias_resolved_forward.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_type_alias_resolved_forward.snap
@@ -6,6 +6,6 @@ expression: "type fowo : forward\ntype fowo : int\nvar _ : fowo"
 ---
 "fowo"@(FileId(1), 5..9) [Forward(Type, Some(LocalDefId(1)))]: alias[DefId(LibraryId(0), LocalDefId(0))] of forward
 "fowo"@(FileId(1), 25..29) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(1))] of int
-"_"@(FileId(1), 40..41) [Declared]: ref_mut alias[DefId(LibraryId(0), LocalDefId(1))] of int
+"_"@(FileId(1), 40..41) [Declared]: alias[DefId(LibraryId(0), LocalDefId(1))] of int
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_undecl_def_in_lvalue.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_undecl_def_in_lvalue.snap
@@ -1,9 +1,9 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
 assertion_line: 41
-expression: "var a : int put a : a : a : a"
+expression: "undecl := 1"
 
 ---
-"a"@(FileId(1), 4..5) [Declared]: int
+"undecl"@(FileId(1), 0..6) [Undeclared]: <error>
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_undecl_def_in_rvalue.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_undecl_def_in_rvalue.snap
@@ -1,0 +1,10 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
+expression: "var lvalue := undecl"
+
+---
+"undecl"@(FileId(1), 14..20) [Undeclared]: <error>
+"lvalue"@(FileId(1), 4..10) [Declared]: <error>
+"<root>"@(dummy) [Declared]: <error>
+

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_var_compatible.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_var_compatible.snap
@@ -1,8 +1,9 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "var k : int := 100"
 
 ---
-"k"@(FileId(1), 4..5) [Declared]: ref_mut int
+"k"@(FileId(1), 4..5) [Declared]: int
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_var_error_prop.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_var_error_prop.snap
@@ -4,8 +4,8 @@ assertion_line: 41
 expression: "var k := 20 + false\nvar l : int := k   % Nothing reported here\n"
 
 ---
-"k"@(FileId(1), 4..5) [Declared]: ref_mut <error>
-"l"@(FileId(1), 24..25) [Declared]: ref_mut int
+"k"@(FileId(1), 4..5) [Declared]: <error>
+"l"@(FileId(1), 24..25) [Declared]: int
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 12..13: mismatched types for addition

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_var_incompatible.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_var_incompatible.snap
@@ -1,9 +1,10 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "var k : char := 20"
 
 ---
-"k"@(FileId(1), 4..5) [Declared]: ref_mut char
+"k"@(FileId(1), 4..5) [Declared]: char
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 16..18: mismatched types

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__var_decl_inference-2.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__var_decl_inference-2.snap
@@ -1,8 +1,9 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "var k := 'oe'"
 
 ---
-"k"@(FileId(1), 4..5) [Declared]: ref_mut char_n Fixed(Value(Integer(ConstInt { magnitude: 2, sign: Positive, width: As32 })))
+"k"@(FileId(1), 4..5) [Declared]: char_n Fixed(Value(Integer(ConstInt { magnitude: 2, sign: Positive, width: As32 })))
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__var_decl_inference-3.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__var_decl_inference-3.snap
@@ -1,8 +1,9 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "var k := 'o'"
 
 ---
-"k"@(FileId(1), 4..5) [Declared]: ref_mut char
+"k"@(FileId(1), 4..5) [Declared]: char
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__var_decl_inference.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__var_decl_inference.snap
@@ -1,8 +1,9 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "var k := \"oeuf\""
 
 ---
-"k"@(FileId(1), 4..5) [Declared]: ref_mut string
+"k"@(FileId(1), 4..5) [Declared]: string
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__var_decl_init_typecheck.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__var_decl_init_typecheck.snap
@@ -1,8 +1,9 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "var k : string := \"oeuf\""
 
 ---
-"k"@(FileId(1), 4..5) [Declared]: ref_mut string
+"k"@(FileId(1), 4..5) [Declared]: string
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__var_decl_type_spec.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__var_decl_type_spec.snap
@@ -1,8 +1,9 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
 expression: "var k : string"
 
 ---
-"k"@(FileId(1), 4..5) [Declared]: ref_mut string
+"k"@(FileId(1), 4..5) [Declared]: string
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/test.rs
+++ b/compiler/toc_analysis/src/typeck/test.rs
@@ -1423,6 +1423,14 @@ test_named_group! { report_aliased_type,
     ]
 }
 
+test_named_group! { typeck_undecl_def,
+    [
+        // don't produce an error
+        in_lvalue => "undecl := 1",
+        in_rvalue => "var lvalue := undecl",
+    ]
+}
+
 test_named_group! { peel_ref,
     [
         in_assign => r#"var a : int var k : int := a"#,

--- a/compiler/toc_hir/src/item.rs
+++ b/compiler/toc_hir/src/item.rs
@@ -58,6 +58,7 @@ pub enum ItemKind {
     Module(Module),
 }
 
+// TODO: Move `Mutability` into `symbol`
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Mutability {
     Const,

--- a/compiler/toc_hir/src/symbol.rs
+++ b/compiler/toc_hir/src/symbol.rs
@@ -68,9 +68,32 @@ pub enum DefOwner {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BindingKind {
+    /// A binding to a storage location (e.g. from [`ConstVar`](crate::item::ConstVar))
     Storage(Mutability),
+    /// Binding to a type
     Type,
+    /// Binding to a module
     Module,
+    /// A binding that isn't attached to anything
+    Undeclared,
+}
+
+impl BindingKind {
+    // Undeclared bindings are treated as equivalent to all of the
+    // other binding types, for error reporting purposes.
+    //
+    // While it's still an invalid state, it can theoretically be
+    // any valid binding kind.
+
+    /// If this is a binding to a storage location (mut or immutable)
+    pub fn is_ref(self) -> bool {
+        matches!(self, Self::Undeclared | Self::Storage(_))
+    }
+
+    /// If this is a binding to a mutable storage location
+    pub fn is_ref_mut(self) -> bool {
+        matches!(self, Self::Undeclared | Self::Storage(Mutability::Var))
+    }
 }
 
 /// Mapping between a [`LocalDefId`] and the corresponding [`DefOwner`]

--- a/compiler/toc_hir/src/symbol.rs
+++ b/compiler/toc_hir/src/symbol.rs
@@ -5,6 +5,7 @@ use la_arena::ArenaMap;
 use toc_span::Spanned;
 
 pub use crate::ids::{DefId, LocalDefId};
+use crate::item::Mutability;
 use crate::{
     ids::{ItemId, LocalDefIndex},
     stmt::BodyStmt,
@@ -13,7 +14,7 @@ use crate::{
 /// Information associated with a `LocalDefId` or `DefId`.
 #[derive(Debug, PartialEq, Eq)]
 pub struct DefInfo {
-    /// The name of the definition, along with the span of the identifer.
+    /// The name of the definition, along with the span of the identifier.
     pub name: Spanned<String>,
     /// The kind of symbol.
     pub kind: SymbolKind,
@@ -63,6 +64,13 @@ pub enum ForwardKind {
 pub enum DefOwner {
     Item(ItemId),
     Stmt(BodyStmt),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BindingKind {
+    Storage(Mutability),
+    Type,
+    Module,
 }
 
 /// Mapping between a [`LocalDefId`] and the corresponding [`DefOwner`]

--- a/compiler/toc_hir_codegen/src/lib.rs
+++ b/compiler/toc_hir_codegen/src/lib.rs
@@ -929,13 +929,11 @@ impl BodyCodeGenerator<'_> {
             .db
             .type_of((self.library_id, self.body_id, stmt.lhs).into())
             .in_db(self.db)
-            .peel_ref()
             .to_base_type();
         let rhs_ty = self
             .db
             .type_of((self.library_id, self.body_id, stmt.rhs).into())
             .in_db(self.db)
-            .peel_ref()
             .to_base_type();
 
         // Evaluation order is important, side effects from the rhs are visible when looking at lhs
@@ -950,7 +948,7 @@ impl BodyCodeGenerator<'_> {
     }
 
     fn generate_coerced_assignment(&mut self, lhs_ty: ty::TypeId, rhs_ty: ty::TypeId) {
-        let lhs_ty = lhs_ty.in_db(self.db).peel_ref().to_base_type();
+        let lhs_ty = lhs_ty.in_db(self.db).to_base_type();
 
         let coerce_to = match lhs_ty.kind() {
             ty::TypeKind::Real(_) => Some(CoerceTo::Real),
@@ -994,7 +992,6 @@ impl BodyCodeGenerator<'_> {
                 .db
                 .type_of((self.library_id, self.body_id, item.expr).into())
                 .in_db(self.db)
-                .peel_ref()
                 .to_base_type();
 
             let put_kind = match put_ty.kind() {
@@ -1095,7 +1092,6 @@ impl BodyCodeGenerator<'_> {
                 .db
                 .type_of((self.library_id, self.body_id, item.expr).into())
                 .in_db(self.db)
-                .peel_ref()
                 .to_base_type();
             let ty_size = get_ty.size_of().expect("type must be concrete") as u32;
 
@@ -1329,7 +1325,6 @@ impl BodyCodeGenerator<'_> {
             .db
             .type_of((self.library_id, self.body_id, stmt.discriminant).into())
             .in_db(self.db)
-            .peel_ref()
             .to_base_type();
 
         let coerce_to = match discrim_ty.kind() {
@@ -1359,7 +1354,6 @@ impl BodyCodeGenerator<'_> {
                             .db
                             .type_of((self.library_id, self.body_id, *expr).into())
                             .in_db(self.db)
-                            .peel_ref()
                             .to_base_type();
 
                         self.generate_coerced_expr(*expr, coerce_to);
@@ -1432,7 +1426,6 @@ impl BodyCodeGenerator<'_> {
             .db
             .type_of(DefId(self.library_id, item.def_id).into())
             .in_db(self.db)
-            .peel_ref()
             .to_base_type();
         self.code_fragment.allocate_local(
             self.db,
@@ -1473,7 +1466,7 @@ impl BodyCodeGenerator<'_> {
     }
 
     fn coerce_expr_into(&mut self, from_ty: ty::TypeId, coerce_to: Option<CoerceTo>) {
-        let expr_ty = from_ty.in_db(self.db).peel_ref().to_base_type();
+        let expr_ty = from_ty.in_db(self.db).to_base_type();
 
         let coerce_op = coerce_to.and_then(|coerce_to| match (coerce_to, expr_ty.kind()) {
             (CoerceTo::Real, ty::TypeKind::Nat(_)) => Some(Opcode::NATREAL()),
@@ -1611,13 +1604,11 @@ impl BodyCodeGenerator<'_> {
             .db
             .type_of((self.library_id, self.body_id, expr.lhs).into())
             .in_db(self.db)
-            .peel_ref()
             .to_base_type();
         let rhs_ty = self
             .db
             .type_of((self.library_id, self.body_id, expr.rhs).into())
             .in_db(self.db)
-            .peel_ref()
             .to_base_type();
 
         let opcode = match expr.op.item() {
@@ -1946,7 +1937,6 @@ impl BodyCodeGenerator<'_> {
             .db
             .type_of((self.library_id, self.body_id, expr.rhs).into())
             .in_db(self.db)
-            .peel_ref()
             .to_base_type();
 
         self.generate_expr(expr.rhs);
@@ -1985,7 +1975,6 @@ impl BodyCodeGenerator<'_> {
                     .db
                     .type_of(DefId(self.library_id, *def_id).into())
                     .in_db(self.db)
-                    .peel_ref()
                     .to_base_type();
 
                 self.code_fragment
@@ -2166,10 +2155,9 @@ impl CodeFragment {
                 self.emit_opcode(Opcode::PUSHINT(char_len.into_u32().expect("not a u32")));
                 Opcode::ASNSTRINV()
             }
-            ty::TypeKind::Ref(_, _)
-            | ty::TypeKind::Error
-            | ty::TypeKind::Forward
-            | ty::TypeKind::Alias(_, _) => unreachable!(),
+            ty::TypeKind::Error | ty::TypeKind::Forward | ty::TypeKind::Alias(_, _) => {
+                unreachable!()
+            }
         };
 
         self.emit_opcode(opcode);
@@ -2211,10 +2199,9 @@ impl CodeFragment {
                 self.emit_opcode(Opcode::PUSHINT(char_len.into_u32().expect("not a u32")));
                 Opcode::ASNSTR()
             }
-            ty::TypeKind::Ref(_, _)
-            | ty::TypeKind::Error
-            | ty::TypeKind::Forward
-            | ty::TypeKind::Alias(_, _) => unreachable!(),
+            ty::TypeKind::Error | ty::TypeKind::Forward | ty::TypeKind::Alias(_, _) => {
+                unreachable!()
+            }
         };
 
         self.emit_opcode(opcode);
@@ -2254,10 +2241,9 @@ impl CodeFragment {
             ty::TypeKind::Char => Opcode::FETCHNAT1(), // chars are equivalent to nat1 on regular Turing backend
             ty::TypeKind::String | ty::TypeKind::StringN(_) => Opcode::FETCHSTR(),
             ty::TypeKind::CharN(_) => return, // don't need to dereference the pointer to storage
-            ty::TypeKind::Ref(_, _)
-            | ty::TypeKind::Error
-            | ty::TypeKind::Forward
-            | ty::TypeKind::Alias(_, _) => unreachable!(),
+            ty::TypeKind::Error | ty::TypeKind::Forward | ty::TypeKind::Alias(_, _) => {
+                unreachable!()
+            }
         };
 
         self.emit_opcode(opcode);

--- a/compiler/toc_hir_db/src/query.rs
+++ b/compiler/toc_hir_db/src/query.rs
@@ -3,6 +3,9 @@
 use std::cell::RefCell;
 use std::sync::Arc;
 
+use toc_hir::expr;
+use toc_hir::item::Mutability;
+use toc_hir::symbol::BindingKind;
 use toc_hir::{
     body, item,
     library::{InLibrary, LibraryId, LoweredLibrary},
@@ -12,7 +15,7 @@ use toc_hir::{
     visitor::HirVisitor,
 };
 
-use crate::db::HirDatabase;
+use crate::db::{BindingSource, HirDatabase};
 
 pub fn library_query(db: &dyn HirDatabase, library: LibraryId) -> LoweredLibrary {
     let file = db.library_graph().file_of(library);
@@ -49,6 +52,45 @@ pub fn lookup_item(db: &dyn HirDatabase, def_id: DefId) -> Option<InLibrary<item
 pub fn lookup_bodies(db: &dyn HirDatabase, library: LibraryId) -> Arc<Vec<body::BodyId>> {
     let library = db.library(library);
     Arc::new(library.body_ids())
+}
+
+pub(crate) fn binding_kind(db: &dyn HirDatabase, ref_src: BindingSource) -> Option<BindingKind> {
+    match ref_src {
+        BindingSource::DefId(def_id) => {
+            // Take the binding kind from the def owner
+            let def_owner = db.def_owner(def_id)?;
+            let library = db.library(def_id.0);
+
+            match def_owner {
+                DefOwner::Item(item_id) => match &library.item(item_id).kind {
+                    item::ItemKind::ConstVar(item) => Some(BindingKind::Storage(item.mutability)),
+                    item::ItemKind::Type(_) => Some(BindingKind::Type),
+                    item::ItemKind::Module(_) => Some(BindingKind::Module),
+                },
+                DefOwner::Stmt(stmt_id) => match &library.body(stmt_id.0).stmt(stmt_id.1).kind {
+                    stmt::StmtKind::Item(_) => {
+                        unreachable!("item def owners shouldn't be stmt def owners")
+                    }
+                    // for-loop counter var is an immut ref
+                    stmt::StmtKind::For(_) => Some(BindingKind::Storage(Mutability::Const)),
+                    _ => None,
+                },
+            }
+        }
+        BindingSource::BodyExpr(lib_id, expr) => {
+            // Traverse nodes until we encounter a valid binding kind
+            let library = db.library(lib_id);
+
+            // For now, only name exprs can produce a binding kind
+            match &library.body(expr.0).expr(expr.1).kind {
+                expr::ExprKind::Name(name) => match name {
+                    expr::Name::Name(def_id) => db.binding_kind(DefId(lib_id, *def_id).into()),
+                    expr::Name::Self_ => todo!(),
+                },
+                _ => None,
+            }
+        }
+    }
 }
 
 #[derive(Default)]


### PR DESCRIPTION
Always having to peel `Ref`s is not nice ergonomically, and is not an actual type from the HIR representation of the type system.
(Im)mutable refs are now deduced by a new facility `HirDatabase::binding_kind`, which also includes distinguishing between type bindings and module bindings.