### PR TITLE
Improve "not a reference to" errors

### DIFF
--- a/compiler/toc_analysis/src/const_eval/snapshots/toc_analysis__const_eval__test__error_no_const_expr-2.snap
+++ b/compiler/toc_analysis/src/const_eval/snapshots/toc_analysis__const_eval__test__error_no_const_expr-2.snap
@@ -1,5 +1,6 @@
 ---
 source: compiler/toc_analysis/src/const_eval/test.rs
+assertion_line: 13
 expression: "var a := 1\nconst b := a\nconst c := b\n"
 
 ---
@@ -7,6 +8,7 @@ expression: "var a := 1\nconst b := a\nconst c := b\n"
 "b"@(FileId(1), 17..18) -> ConstError { kind: NotConstExpr(Some(DefId(LibraryId(0), LocalDefId(0)))), span: (FileId(1), 22..23) }
 "c"@(FileId(1), 30..31) -> ConstError { kind: NotConstExpr(Some(DefId(LibraryId(0), LocalDefId(0)))), span: (FileId(1), 22..23) }
 
-error in file FileId(1) at 22..23: reference cannot be computed at compile-time
+error in file FileId(1) at 22..23: cannot compute `a` at compile-time
+| error in file FileId(1) for 22..23: `a` is a reference to a variable, not a constant
 | note in file FileId(1) for 4..5: `a` declared here
 

--- a/compiler/toc_analysis/src/const_eval/snapshots/toc_analysis__const_eval__test__error_no_const_expr-3.snap
+++ b/compiler/toc_analysis/src/const_eval/snapshots/toc_analysis__const_eval__test__error_no_const_expr-3.snap
@@ -1,0 +1,12 @@
+---
+source: compiler/toc_analysis/src/const_eval/test.rs
+assertion_line: 13
+expression: "type a : int\nconst b := a\n"
+
+---
+"b"@(FileId(1), 19..20) -> ConstError { kind: NotConstExpr(Some(DefId(LibraryId(0), LocalDefId(0)))), span: (FileId(1), 24..25) }
+
+error in file FileId(1) at 24..25: cannot compute `a` at compile-time
+| error in file FileId(1) for 24..25: `a` is a reference to a type, not a constant
+| note in file FileId(1) for 5..6: `a` declared here
+

--- a/compiler/toc_analysis/src/const_eval/snapshots/toc_analysis__const_eval__test__error_no_const_expr.snap
+++ b/compiler/toc_analysis/src/const_eval/snapshots/toc_analysis__const_eval__test__error_no_const_expr.snap
@@ -1,11 +1,13 @@
 ---
 source: compiler/toc_analysis/src/const_eval/test.rs
+assertion_line: 13
 expression: "var a := 1\nconst b := a\n"
 
 ---
 "a"@(FileId(1), 4..5) -> Integer(ConstInt { magnitude: 1, sign: Positive, width: As32 })
 "b"@(FileId(1), 17..18) -> ConstError { kind: NotConstExpr(Some(DefId(LibraryId(0), LocalDefId(0)))), span: (FileId(1), 22..23) }
 
-error in file FileId(1) at 22..23: reference cannot be computed at compile-time
+error in file FileId(1) at 22..23: cannot compute `a` at compile-time
+| error in file FileId(1) for 22..23: `a` is a reference to a variable, not a constant
 | note in file FileId(1) for 4..5: `a` declared here
 

--- a/compiler/toc_analysis/src/const_eval/test.rs
+++ b/compiler/toc_analysis/src/const_eval/test.rs
@@ -690,6 +690,14 @@ fn error_no_const_expr() {
     "#,
     ));
 
+    // Referencing a type
+    assert_const_eval(&unindent(
+        r#"
+    type a : int
+    const b := a
+    "#,
+    ));
+
     // Referencing `self`
     // TODO: Uncomment when `self` is lowered again
     /*

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__bare_var_decl-2.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__bare_var_decl-2.snap
@@ -7,5 +7,6 @@ expression: "const k k := 3"
 "k"@(FileId(1), 6..7) [Declared]: <error>
 "<root>"@(dummy) [Declared]: <error>
 
-error in file FileId(1) at 10..12: cannot assign into expression
-| note in file FileId(1) for 8..9: not a reference to a variable
+error in file FileId(1) at 10..12: cannot assign into `k`
+| error in file FileId(1) for 8..9: `k` is a reference to a constant, not a variable
+| note in file FileId(1) for 6..7: `k` declared here

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_assignment_lhs_not_mut_is_const.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_assignment_lhs_not_mut_is_const.snap
@@ -8,5 +8,6 @@ expression: "const j : int := 2\nconst k : int := 3\nk := j\n"
 "k"@(FileId(1), 25..26) [Declared]: int
 "<root>"@(dummy) [Declared]: <error>
 
-error in file FileId(1) at 40..42: cannot assign into expression
-| note in file FileId(1) for 38..39: not a reference to a variable
+error in file FileId(1) at 40..42: cannot assign into `k`
+| error in file FileId(1) for 38..39: `k` is a reference to a constant, not a variable
+| note in file FileId(1) for 25..26: `k` declared here

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_assignment_lhs_not_mut_missing_rhs.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_assignment_lhs_not_mut_missing_rhs.snap
@@ -7,5 +7,6 @@ expression: "const j : int := 1\nj := \n"
 "j"@(FileId(1), 6..7) [Declared]: int
 "<root>"@(dummy) [Declared]: <error>
 
-error in file FileId(1) at 21..23: cannot assign into expression
-| note in file FileId(1) for 19..20: not a reference to a variable
+error in file FileId(1) at 21..23: cannot assign into `j`
+| error in file FileId(1) for 19..20: `j` is a reference to a constant, not a variable
+| note in file FileId(1) for 6..7: `j` declared here

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_case_non_comptime_selector_expr.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_case_non_comptime_selector_expr.snap
@@ -7,5 +7,6 @@ expression: "var k : int\ncase 1 of label k + 1: end case\n"
 "k"@(FileId(1), 4..5) [Declared]: int
 "<root>"@(dummy) [Declared]: <error>
 
-error in file FileId(1) at 28..29: reference cannot be computed at compile-time
+error in file FileId(1) at 28..29: cannot compute `k` at compile-time
+| error in file FileId(1) for 28..29: `k` is a reference to a variable, not a constant
 | note in file FileId(1) for 4..5: `k` declared here

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_for_immut_counter.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_for_immut_counter.snap
@@ -7,5 +7,6 @@ expression: "for i : false .. true i := false end for"
 "i"@(FileId(1), 4..5) [Declared]: boolean
 "<root>"@(dummy) [Declared]: <error>
 
-error in file FileId(1) at 24..26: cannot assign into expression
-| note in file FileId(1) for 22..23: not a reference to a variable
+error in file FileId(1) at 24..26: cannot assign into `i`
+| error in file FileId(1) for 22..23: `i` is a reference to a constant, not a variable
+| note in file FileId(1) for 4..5: `i` declared here

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_get_stmt_wrong_ref_const.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_get_stmt_wrong_ref_const.snap
@@ -7,5 +7,6 @@ expression: "const i : int := 1\nget i\n"
 "i"@(FileId(1), 6..7) [Declared]: int
 "<root>"@(dummy) [Declared]: <error>
 
-error in file FileId(1) at 23..24: cannot assign into expression
-| error in file FileId(1) for 23..24: not a reference to a variable
+error in file FileId(1) at 23..24: cannot assign into `i`
+| error in file FileId(1) for 23..24: `i` is a reference to a constant, not a variable
+| note in file FileId(1) for 6..7: `i` declared here

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_type_alias_from_const.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_type_alias_from_const.snap
@@ -8,5 +8,6 @@ expression: "const a : int type k : a"
 "k"@(FileId(1), 19..20) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(1))] of <error>
 "<root>"@(dummy) [Declared]: <error>
 
-error in file FileId(1) at 23..24: cannot use `a` as a type
-| error in file FileId(1) for 23..24: `a` is a reference to a constant
+error in file FileId(1) at 23..24: cannot use `a` as a type alias
+| error in file FileId(1) for 23..24: `a` is a reference to a constant, not a type
+| note in file FileId(1) for 6..7: `a` declared here

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_type_alias_from_var.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_type_alias_from_var.snap
@@ -8,5 +8,6 @@ expression: "var a : int type k : a"
 "k"@(FileId(1), 17..18) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(1))] of <error>
 "<root>"@(dummy) [Declared]: <error>
 
-error in file FileId(1) at 21..22: cannot use `a` as a type
-| error in file FileId(1) for 21..22: `a` is a reference to a variable
+error in file FileId(1) at 21..22: cannot use `a` as a type alias
+| error in file FileId(1) for 21..22: `a` is a reference to a variable, not a type
+| note in file FileId(1) for 4..5: `a` declared here

--- a/compiler/toc_hir/src/symbol.rs
+++ b/compiler/toc_hir/src/symbol.rs
@@ -101,6 +101,20 @@ impl BindingKind {
     }
 }
 
+impl std::fmt::Display for BindingKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let name = match self {
+            BindingKind::Undeclared => unreachable!("undecl bindings should never be reported"),
+            BindingKind::Storage(Mutability::Var) => "a variable",
+            BindingKind::Storage(Mutability::Const) => "a constant",
+            BindingKind::Type => "a type",
+            BindingKind::Module => "a module",
+        };
+
+        f.write_str(name)
+    }
+}
+
 /// Mapping between a [`LocalDefId`] and the corresponding [`DefOwner`]
 #[derive(Debug, Default, PartialEq, Eq)]
 pub struct DefTable {

--- a/compiler/toc_hir_db/src/db.rs
+++ b/compiler/toc_hir_db/src/db.rs
@@ -44,6 +44,10 @@ pub trait HirDatabase: toc_hir_lowering::LoweringDb {
     #[salsa::invoke(query::lookup_bodies)]
     fn bodies_of(&self, library: LibraryId) -> Arc<Vec<body::BodyId>>;
 
+    /// Gets the corresponding definition from the given [`BindingSource`], or `None` if there isn't one.
+    #[salsa::invoke(query::binding_to)]
+    fn binding_to(&self, ref_src: BindingSource) -> Option<DefId>;
+
     /// Gets the binding kind of a [`BindingSource`], or `None` if it isn't one.
     #[salsa::invoke(query::binding_kind)]
     fn binding_kind(&self, ref_src: BindingSource) -> Option<symbol::BindingKind>;

--- a/compiler/toc_hir_db/src/query.rs
+++ b/compiler/toc_hir_db/src/query.rs
@@ -54,46 +54,52 @@ pub fn lookup_bodies(db: &dyn HirDatabase, library: LibraryId) -> Arc<Vec<body::
     Arc::new(library.body_ids())
 }
 
-pub(crate) fn binding_kind(db: &dyn HirDatabase, ref_src: BindingSource) -> Option<BindingKind> {
+pub(crate) fn binding_to(db: &dyn HirDatabase, ref_src: BindingSource) -> Option<DefId> {
     match ref_src {
-        BindingSource::DefId(def_id) => {
-            // Take the binding kind from the def owner
-            let def_owner = db.def_owner(def_id);
-            let library = db.library(def_id.0);
-
-            match def_owner {
-                Some(DefOwner::Item(item_id)) => match &library.item(item_id).kind {
-                    item::ItemKind::ConstVar(item) => Some(BindingKind::Storage(item.mutability)),
-                    item::ItemKind::Type(_) => Some(BindingKind::Type),
-                    item::ItemKind::Module(_) => Some(BindingKind::Module),
-                },
-                Some(DefOwner::Stmt(stmt_id)) => {
-                    match &library.body(stmt_id.0).stmt(stmt_id.1).kind {
-                        stmt::StmtKind::Item(_) => {
-                            unreachable!("item def owners shouldn't be stmt def owners")
-                        }
-                        // for-loop counter var is an immutable ref
-                        stmt::StmtKind::For(_) => Some(BindingKind::Storage(Mutability::Const)),
-                        _ => None,
-                    }
-                }
-                // From an undeclared identifier, technically produces a binding
-                None => Some(BindingKind::Undeclared),
-            }
-        }
+        // Trivial, def bindings are bindings to themselves
+        // ???: Do we want to perform canonicalization / symbol resolution here?
+        BindingSource::DefId(it) => Some(it),
         BindingSource::BodyExpr(lib_id, expr) => {
-            // Traverse nodes until we encounter a valid binding kind
+            // Traverse nodes until we encounter a valid binding
             let library = db.library(lib_id);
 
-            // For now, only name exprs can produce a binding kind
+            // For now, only name exprs can produce a binding
             match &library.body(expr.0).expr(expr.1).kind {
                 expr::ExprKind::Name(name) => match name {
-                    expr::Name::Name(def_id) => db.binding_kind(DefId(lib_id, *def_id).into()),
+                    expr::Name::Name(def_id) => Some(DefId(lib_id, *def_id)),
                     expr::Name::Self_ => todo!(),
                 },
                 _ => None,
             }
         }
+    }
+}
+
+pub(crate) fn binding_kind(db: &dyn HirDatabase, ref_src: BindingSource) -> Option<BindingKind> {
+    let def_id = db.binding_to(ref_src)?;
+
+    // Take the binding kind from the def owner
+    let def_owner = db.def_owner(def_id);
+    let library = db.library(def_id.0);
+
+    match def_owner {
+        Some(DefOwner::Item(item_id)) => match &library.item(item_id).kind {
+            item::ItemKind::ConstVar(item) => Some(BindingKind::Storage(item.mutability)),
+            item::ItemKind::Type(_) => Some(BindingKind::Type),
+            item::ItemKind::Module(_) => Some(BindingKind::Module),
+        },
+        Some(DefOwner::Stmt(stmt_id)) => {
+            match &library.body(stmt_id.0).stmt(stmt_id.1).kind {
+                stmt::StmtKind::Item(_) => {
+                    unreachable!("item def owners shouldn't be stmt def owners")
+                }
+                // for-loop counter var is an immutable ref
+                stmt::StmtKind::For(_) => Some(BindingKind::Storage(Mutability::Const)),
+                _ => None,
+            }
+        }
+        // From an undeclared identifier, technically produces a binding
+        None => Some(BindingKind::Undeclared),
     }
 }
 


### PR DESCRIPTION
If it's a binding, then the declaration location is also included