### PR TITLE
Correctly handle missing spans

### DIFF
--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typecheck_missing_exprs-2.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typecheck_missing_exprs-2.snap
@@ -1,0 +1,8 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 41
+expression: get ()
+
+---
+"<root>"@(dummy) [Declared]: <error>
+

--- a/compiler/toc_analysis/src/typeck/test.rs
+++ b/compiler/toc_analysis/src/typeck/test.rs
@@ -118,6 +118,10 @@ fn typecheck_error_prop() {
 fn typecheck_missing_exprs() {
     // Be resilient against missing expressions
     assert_typecheck("const ke : int := ()");
+
+    assert_typecheck("get ()");
+
+    // FIXME: use bind exprs to test for missing bodies
 }
 
 #[test]


### PR DESCRIPTION
Unfortunately, we encouter cases where finding a representable span isn't possible.

## What generates bad spans?

Ultimately, anything reliant on `lower_required_*` generates a bad span.

For exprs: `lower_required_expr`.
For bodies: `lower_required_expr_body`
The most reliable way for exprs and expr bodies is to use `()`.

For types: `lower_required_type`
The most reliable way is to just omit the type spec.

## Dealing with bad spans

The best way to deal with bad spans is to not report them in the first place.
The second best way is to be resiliant against them.

For types, since the only situation that generates bad spans is from a missing type, and since missing types always
produce `TypeKind::Error`, the best way to deal with them is to not report them at all.
This is achieved by always accepting `TypeKind::Error`s as acceptable types in all situations.

The situation with exprs and bodies is harder, though most cases are guarded by `TypeKind::Error`.
`for` typeck explicitly checks for a failing span merge, which handles that special case appropriately.

The rest of the cases are dealing with bindings, which (in their current state) fail spectacularly.
This is because `binding_to` currently treats `ExprKind::Missing` as not being a binding (which is true),
but doing so results in reporting cases falling ultimately fetching invalid spans, and that causes Issues.
These bad spans *will* propagate to the compiler drivers (`toc_lsp` and `toc_driver`), and they must be handled appropriately.

The last resort is explicitly handling missing spans by not including them in the normal pipeline and (rightly) reporting them as bugs.

## Fixing the oopsies

Technically, an `ExprKind::Missing` generated from a `()` does have a span.
Therefore, we can always associate a span with an `ExprKind` generated from `()` (though this isn't particularly useful, so we don't do this).

The binding situation can be resolved by treating `ExprKind::Missing` as an undeclared binding.
Though semantically false, it's a good default to fall back on as there's a certainty that an error is already close to that location.

In the future, new interfaces that touch `ExprKind::Missing` and `TypeKind::Missing` (e.g. `binding_kind`) must be careful to gracefully handle bad spans.