### PR TITLE
Alter how undeclared bindings are dealt with

### DIFF
--- a/compiler/toc_analysis/src/const_eval/errors.rs
+++ b/compiler/toc_analysis/src/const_eval/errors.rs
@@ -61,7 +61,7 @@ impl ConstError {
                 // Report at the reference's definition spot
                 let bind_kind = match db.binding_kind((*def_id).into()) {
                     Ok(kind) => kind,
-                    Err(NotBinding::Undeclared) => return, // taken from an undeclared ident
+                    Err(NotBinding::Undeclared | NotBinding::Missing) => return, // taken from an undeclared ident or missing expr
                     Err(NotBinding::NotReference) => unreachable!("taken from a def"),
                 };
                 let library = db.library(def_id.0);

--- a/compiler/toc_analysis/src/const_eval/errors.rs
+++ b/compiler/toc_analysis/src/const_eval/errors.rs
@@ -1,5 +1,5 @@
 //! Errors during constant evaluation
-use toc_hir::symbol::DefId;
+use toc_hir::symbol::{DefId, NotBinding};
 use toc_span::Span;
 
 use crate::const_eval::db;
@@ -59,7 +59,11 @@ impl ConstError {
         match &self.kind {
             ErrorKind::NotConstExpr(Some(def_id)) => {
                 // Report at the reference's definition spot
-                let bind_kind = db.binding_kind((*def_id).into()).expect("is a def");
+                let bind_kind = match db.binding_kind((*def_id).into()) {
+                    Ok(kind) => kind,
+                    Err(NotBinding::Undeclared) => return, // taken from an undeclared ident
+                    Err(NotBinding::NotReference) => unreachable!("taken from a def"),
+                };
                 let library = db.library(def_id.0);
                 let def_info = library.local_def(def_id.1);
                 let name = def_info.name.item();

--- a/compiler/toc_analysis/src/const_eval/snapshots/toc_analysis__const_eval__test__error_no_const_expr-4.snap
+++ b/compiler/toc_analysis/src/const_eval/snapshots/toc_analysis__const_eval__test__error_no_const_expr-4.snap
@@ -1,0 +1,9 @@
+---
+source: compiler/toc_analysis/src/const_eval/test.rs
+assertion_line: 13
+expression: "const b := a"
+
+---
+"b"@(FileId(1), 6..7) -> ConstError { kind: NotConstExpr(Some(DefId(LibraryId(0), LocalDefId(0)))), span: (FileId(1), 11..12) }
+
+

--- a/compiler/toc_analysis/src/const_eval/snapshots/toc_analysis__const_eval__test__error_no_const_expr-5.snap
+++ b/compiler/toc_analysis/src/const_eval/snapshots/toc_analysis__const_eval__test__error_no_const_expr-5.snap
@@ -1,0 +1,9 @@
+---
+source: compiler/toc_analysis/src/const_eval/test.rs
+assertion_line: 13
+expression: "const b := ()"
+
+---
+"b"@(FileId(1), 6..7) -> ConstError { kind: MissingExpr, span: (dummy) }
+
+

--- a/compiler/toc_analysis/src/const_eval/test.rs
+++ b/compiler/toc_analysis/src/const_eval/test.rs
@@ -698,6 +698,12 @@ fn error_no_const_expr() {
     "#,
     ));
 
+    // Referencing an undeclared def
+    assert_const_eval("const b := a");
+
+    // Using a missing expression
+    assert_const_eval("const b := ()");
+
     // Referencing `self`
     // TODO: Uncomment when `self` is lowered again
     /*

--- a/compiler/toc_analysis/src/ty/lower.rs
+++ b/compiler/toc_analysis/src/ty/lower.rs
@@ -3,7 +3,7 @@
 use std::convert::TryInto;
 
 use toc_hir::library::{LibraryId, WrapInLibrary};
-use toc_hir::symbol::{self, BindingKind, LocalDefId};
+use toc_hir::symbol::{self, BindingKind, BindingResultExt, LocalDefId};
 use toc_hir::{body, expr, stmt};
 use toc_hir::{item, library::InLibrary, symbol::DefId, ty as hir_ty};
 
@@ -67,7 +67,11 @@ fn alias_ty(
 ) -> TypeId {
     let def_id = DefId(hir_id.0, ty.0);
 
-    if Some(true) == db.binding_kind(def_id.into()).map(BindingKind::is_type) {
+    if db
+        .binding_kind(def_id.into())
+        .map(BindingKind::is_type)
+        .or_undeclared()
+    {
         // Defer to the type's definition
         db.type_of(def_id.into())
     } else {

--- a/compiler/toc_hir/src/symbol.rs
+++ b/compiler/toc_hir/src/symbol.rs
@@ -160,7 +160,9 @@ impl std::fmt::Display for BindingKind {
 pub enum NotBinding {
     /// Refers to an undeclared definition
     Undeclared,
-    /// Not a reference to a binding (e.g. a plain value, an error expression)
+    /// Is an error expression
+    Missing,
+    /// Not a reference to a binding (e.g. a plain value)
     NotReference,
 }
 
@@ -173,9 +175,13 @@ pub trait BindingResultExt: seal_me::Sealed {
 }
 
 impl BindingResultExt for Result<bool, NotBinding> {
+    // Treat error exprs as the same as error
+    // It can be any kind of expression
+
     fn or_undeclared(self) -> bool {
         self.unwrap_or_else(|err| match err {
             NotBinding::Undeclared => true,
+            NotBinding::Missing => true,
             NotBinding::NotReference => false,
         })
     }
@@ -183,6 +189,7 @@ impl BindingResultExt for Result<bool, NotBinding> {
     fn or_value(self) -> bool {
         self.unwrap_or_else(|err| match err {
             NotBinding::Undeclared => true,
+            NotBinding::Missing => true,
             NotBinding::NotReference => true,
         })
     }

--- a/compiler/toc_hir/src/symbol.rs
+++ b/compiler/toc_hir/src/symbol.rs
@@ -96,9 +96,6 @@ pub enum BindingKind {
     Module,
     /// Binding to a subprogram
     Subprogram(SubprogramKind),
-
-    /// A binding that isn't attached to anything
-    Undeclared,
 }
 
 impl BindingKind {
@@ -112,7 +109,7 @@ impl BindingKind {
     pub fn is_ref(self) -> bool {
         matches!(
             self,
-            Self::Undeclared | Self::Storage(_) | Self::Register(_) | Self::Subprogram(_)
+            Self::Storage(_) | Self::Register(_) | Self::Subprogram(_)
         )
     }
 
@@ -120,30 +117,29 @@ impl BindingKind {
     pub fn is_ref_mut(self) -> bool {
         matches!(
             self,
-            Self::Undeclared | Self::Storage(Mutability::Var) | Self::Register(Mutability::Var)
+            Self::Storage(Mutability::Var) | Self::Register(Mutability::Var)
         )
     }
 
     /// If this is a binding to a storage location (mut or immutable)
     pub fn is_storage(self) -> bool {
-        matches!(self, Self::Undeclared | Self::Storage(_))
+        matches!(self, Self::Storage(_))
     }
 
     /// If this is a binding to a mutable storage location
     pub fn is_storage_mut(self) -> bool {
-        matches!(self, Self::Undeclared | Self::Storage(Mutability::Var))
+        matches!(self, Self::Storage(Mutability::Var))
     }
 
     /// If this is a binding to a type
     pub fn is_type(self) -> bool {
-        matches!(self, Self::Undeclared | Self::Type)
+        matches!(self, Self::Type)
     }
 }
 
 impl std::fmt::Display for BindingKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let name = match self {
-            BindingKind::Undeclared => unreachable!("undecl bindings should never be reported"),
             BindingKind::Storage(Mutability::Var) => "a variable",
             BindingKind::Storage(Mutability::Const) => "a constant",
             BindingKind::Register(Mutability::Var) => "a register",
@@ -157,6 +153,44 @@ impl std::fmt::Display for BindingKind {
 
         f.write_str(name)
     }
+}
+
+/// From a failed binding lookup
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NotBinding {
+    /// Refers to an undeclared definition
+    Undeclared,
+    /// Not a reference to a binding (e.g. a plain value, an error expression)
+    NotReference,
+}
+
+/// Helper trait to deal with [`NotBinding`] kind narrowing
+pub trait BindingResultExt: seal_me::Sealed {
+    /// Allows an undeclared identifier to match the previous predicate
+    fn or_undeclared(self) -> bool;
+    /// Allows any value to match the previous predicate
+    fn or_value(self) -> bool;
+}
+
+impl BindingResultExt for Result<bool, NotBinding> {
+    fn or_undeclared(self) -> bool {
+        self.unwrap_or_else(|err| match err {
+            NotBinding::Undeclared => true,
+            NotBinding::NotReference => false,
+        })
+    }
+
+    fn or_value(self) -> bool {
+        self.unwrap_or_else(|err| match err {
+            NotBinding::Undeclared => true,
+            NotBinding::NotReference => true,
+        })
+    }
+}
+
+mod seal_me {
+    pub trait Sealed {}
+    impl Sealed for Result<bool, super::NotBinding> {}
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/compiler/toc_hir_db/src/db.rs
+++ b/compiler/toc_hir_db/src/db.rs
@@ -58,9 +58,12 @@ pub trait HirDatabase: toc_hir_lowering::LoweringDb {
     #[salsa::invoke(query::binding_to)]
     fn binding_to(&self, ref_src: BindingSource) -> Option<DefId>;
 
-    /// Gets the binding kind of a [`BindingSource`], or `None` if it isn't one.
+    /// Gets the binding kind of a [`BindingSource`], or a [`NotBinding`](symbol::NotBinding) if it isn't one.
     #[salsa::invoke(query::binding_kind)]
-    fn binding_kind(&self, ref_src: BindingSource) -> Option<symbol::BindingKind>;
+    fn binding_kind(
+        &self,
+        ref_src: BindingSource,
+    ) -> Result<symbol::BindingKind, symbol::NotBinding>;
 }
 
 /// Salsa-backed type interner

--- a/compiler/toc_hir_db/src/query.rs
+++ b/compiler/toc_hir_db/src/query.rs
@@ -175,7 +175,7 @@ fn lookup_binding_def(db: &dyn HirDatabase, ref_src: BindingSource) -> Result<De
 
             // For now, only name exprs can produce a binding
             match &library.body(expr.0).expr(expr.1).kind {
-                expr::ExprKind::Missing => Err(NotBinding::NotReference),
+                expr::ExprKind::Missing => Err(NotBinding::Missing),
                 expr::ExprKind::Name(name) => match name {
                     expr::Name::Name(def_id) => Ok(DefId(lib_id, *def_id)),
                     expr::Name::Self_ => todo!(),


### PR DESCRIPTION
Pushes undeclared bindings towards the error side of error-handling.

Fixes #49