### PR TITLE
Proper value kind handling

### DIFF
--- a/compiler/toc_analysis/src/ty/db.rs
+++ b/compiler/toc_analysis/src/ty/db.rs
@@ -164,15 +164,8 @@ pub enum NotValue {
 /// Anything that can produce a value
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ValueSource {
-    DefId(DefId),
     Body(LibraryId, BodyId),
     BodyExpr(LibraryId, BodyExpr),
-}
-
-impl From<symbol::DefId> for ValueSource {
-    fn from(def_id: symbol::DefId) -> Self {
-        Self::DefId(def_id)
-    }
 }
 
 impl From<(LibraryId, BodyId)> for ValueSource {

--- a/compiler/toc_analysis/src/typeck.rs
+++ b/compiler/toc_analysis/src/typeck.rs
@@ -1227,7 +1227,9 @@ impl TypeCheck<'_> {
             _ => return,
         };
 
-        self.expect_integer_value((self.library_id, expr_body).into());
+        if !self.expect_integer_value((self.library_id, expr_body).into()) {
+            return;
+        }
 
         // Check resultant size
         let (seq_size, size_limit, allow_dyn_size) = match ty.kind() {

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__common_op_wrong_value_add.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__common_op_wrong_value_add.snap
@@ -1,0 +1,25 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "\n    type t : int\n    var k : int\n\n    % Type operand prevents checking of type compatibility\n    var _tt := t + t\n    var _tk := t + k\n    var _kt := k + t\n    "
+
+---
+"t"@(FileId(1), 10..11) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of int
+"k"@(FileId(1), 26..27) [Declared]: int
+"_tt"@(FileId(1), 102..105) [Declared]: int
+"_tk"@(FileId(1), 123..126) [Declared]: int
+"_kt"@(FileId(1), 144..147) [Declared]: int
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 109..110: cannot use `t` as an expression
+| error in file FileId(1) for 109..110: `t` is a reference to a type, not a variable
+| note in file FileId(1) for 10..11: `t` declared here
+error in file FileId(1) at 113..114: cannot use `t` as an expression
+| error in file FileId(1) for 113..114: `t` is a reference to a type, not a variable
+| note in file FileId(1) for 10..11: `t` declared here
+error in file FileId(1) at 130..131: cannot use `t` as an expression
+| error in file FileId(1) for 130..131: `t` is a reference to a type, not a variable
+| note in file FileId(1) for 10..11: `t` declared here
+error in file FileId(1) at 155..156: cannot use `t` as an expression
+| error in file FileId(1) for 155..156: `t` is a reference to a type, not a variable
+| note in file FileId(1) for 10..11: `t` declared here

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__common_op_wrong_value_and.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__common_op_wrong_value_and.snap
@@ -1,0 +1,25 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "\n    type t : int\n    var k : int\n\n    % Type operand prevents checking of type compatibility\n    var _tt := t and t\n    var _tk := t and k\n    var _kt := k and t\n    "
+
+---
+"t"@(FileId(1), 10..11) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of int
+"k"@(FileId(1), 26..27) [Declared]: int
+"_tt"@(FileId(1), 102..105) [Declared]: nat
+"_tk"@(FileId(1), 125..128) [Declared]: nat
+"_kt"@(FileId(1), 148..151) [Declared]: nat
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 109..110: cannot use `t` as an expression
+| error in file FileId(1) for 109..110: `t` is a reference to a type, not a variable
+| note in file FileId(1) for 10..11: `t` declared here
+error in file FileId(1) at 115..116: cannot use `t` as an expression
+| error in file FileId(1) for 115..116: `t` is a reference to a type, not a variable
+| note in file FileId(1) for 10..11: `t` declared here
+error in file FileId(1) at 132..133: cannot use `t` as an expression
+| error in file FileId(1) for 132..133: `t` is a reference to a type, not a variable
+| note in file FileId(1) for 10..11: `t` declared here
+error in file FileId(1) at 161..162: cannot use `t` as an expression
+| error in file FileId(1) for 161..162: `t` is a reference to a type, not a variable
+| note in file FileId(1) for 10..11: `t` declared here

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__common_op_wrong_value_equal.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__common_op_wrong_value_equal.snap
@@ -1,0 +1,25 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "\n    type t : int\n    var k : int\n\n    % Type operand prevents checking of type compatibility\n    var _tt := t = t\n    var _tk := t = k\n    var _kt := k = t\n    "
+
+---
+"t"@(FileId(1), 10..11) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of int
+"k"@(FileId(1), 26..27) [Declared]: int
+"_tt"@(FileId(1), 102..105) [Declared]: boolean
+"_tk"@(FileId(1), 123..126) [Declared]: boolean
+"_kt"@(FileId(1), 144..147) [Declared]: boolean
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 109..110: cannot use `t` as an expression
+| error in file FileId(1) for 109..110: `t` is a reference to a type, not a variable
+| note in file FileId(1) for 10..11: `t` declared here
+error in file FileId(1) at 113..114: cannot use `t` as an expression
+| error in file FileId(1) for 113..114: `t` is a reference to a type, not a variable
+| note in file FileId(1) for 10..11: `t` declared here
+error in file FileId(1) at 130..131: cannot use `t` as an expression
+| error in file FileId(1) for 130..131: `t` is a reference to a type, not a variable
+| note in file FileId(1) for 10..11: `t` declared here
+error in file FileId(1) at 155..156: cannot use `t` as an expression
+| error in file FileId(1) for 155..156: `t` is a reference to a type, not a variable
+| note in file FileId(1) for 10..11: `t` declared here

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__common_op_wrong_value_exp.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__common_op_wrong_value_exp.snap
@@ -1,0 +1,25 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "\n    type t : int\n    var k : int\n\n    % Type operand prevents checking of type compatibility\n    var _tt := t ** t\n    var _tk := t ** k\n    var _kt := k ** t\n    "
+
+---
+"t"@(FileId(1), 10..11) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of int
+"k"@(FileId(1), 26..27) [Declared]: int
+"_tt"@(FileId(1), 102..105) [Declared]: int
+"_tk"@(FileId(1), 124..127) [Declared]: int
+"_kt"@(FileId(1), 146..149) [Declared]: int
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 109..110: cannot use `t` as an expression
+| error in file FileId(1) for 109..110: `t` is a reference to a type, not a variable
+| note in file FileId(1) for 10..11: `t` declared here
+error in file FileId(1) at 114..115: cannot use `t` as an expression
+| error in file FileId(1) for 114..115: `t` is a reference to a type, not a variable
+| note in file FileId(1) for 10..11: `t` declared here
+error in file FileId(1) at 131..132: cannot use `t` as an expression
+| error in file FileId(1) for 131..132: `t` is a reference to a type, not a variable
+| note in file FileId(1) for 10..11: `t` declared here
+error in file FileId(1) at 158..159: cannot use `t` as an expression
+| error in file FileId(1) for 158..159: `t` is a reference to a type, not a variable
+| note in file FileId(1) for 10..11: `t` declared here

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__common_op_wrong_value_greater.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__common_op_wrong_value_greater.snap
@@ -1,0 +1,25 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "\n    type t : int\n    var k : int\n\n    % Type operand prevents checking of type compatibility\n    var _tt := t > t\n    var _tk := t > k\n    var _kt := k > t\n    "
+
+---
+"t"@(FileId(1), 10..11) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of int
+"k"@(FileId(1), 26..27) [Declared]: int
+"_tt"@(FileId(1), 102..105) [Declared]: boolean
+"_tk"@(FileId(1), 123..126) [Declared]: boolean
+"_kt"@(FileId(1), 144..147) [Declared]: boolean
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 109..110: cannot use `t` as an expression
+| error in file FileId(1) for 109..110: `t` is a reference to a type, not a variable
+| note in file FileId(1) for 10..11: `t` declared here
+error in file FileId(1) at 113..114: cannot use `t` as an expression
+| error in file FileId(1) for 113..114: `t` is a reference to a type, not a variable
+| note in file FileId(1) for 10..11: `t` declared here
+error in file FileId(1) at 130..131: cannot use `t` as an expression
+| error in file FileId(1) for 130..131: `t` is a reference to a type, not a variable
+| note in file FileId(1) for 10..11: `t` declared here
+error in file FileId(1) at 155..156: cannot use `t` as an expression
+| error in file FileId(1) for 155..156: `t` is a reference to a type, not a variable
+| note in file FileId(1) for 10..11: `t` declared here

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__common_op_wrong_value_greater_eq.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__common_op_wrong_value_greater_eq.snap
@@ -1,0 +1,25 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "\n    type t : int\n    var k : int\n\n    % Type operand prevents checking of type compatibility\n    var _tt := t >= t\n    var _tk := t >= k\n    var _kt := k >= t\n    "
+
+---
+"t"@(FileId(1), 10..11) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of int
+"k"@(FileId(1), 26..27) [Declared]: int
+"_tt"@(FileId(1), 102..105) [Declared]: boolean
+"_tk"@(FileId(1), 124..127) [Declared]: boolean
+"_kt"@(FileId(1), 146..149) [Declared]: boolean
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 109..110: cannot use `t` as an expression
+| error in file FileId(1) for 109..110: `t` is a reference to a type, not a variable
+| note in file FileId(1) for 10..11: `t` declared here
+error in file FileId(1) at 114..115: cannot use `t` as an expression
+| error in file FileId(1) for 114..115: `t` is a reference to a type, not a variable
+| note in file FileId(1) for 10..11: `t` declared here
+error in file FileId(1) at 131..132: cannot use `t` as an expression
+| error in file FileId(1) for 131..132: `t` is a reference to a type, not a variable
+| note in file FileId(1) for 10..11: `t` declared here
+error in file FileId(1) at 158..159: cannot use `t` as an expression
+| error in file FileId(1) for 158..159: `t` is a reference to a type, not a variable
+| note in file FileId(1) for 10..11: `t` declared here

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__common_op_wrong_value_identity.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__common_op_wrong_value_identity.snap
@@ -1,0 +1,13 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "\n    type t : boolean\n\n    % Type operand prevents checking of type compatibility\n    var _t := + t\n    "
+
+---
+"t"@(FileId(1), 10..11) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of boolean
+"_t"@(FileId(1), 90..92) [Declared]: <error>
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 98..99: cannot use `t` as an expression
+| error in file FileId(1) for 98..99: `t` is a reference to a type, not a variable
+| note in file FileId(1) for 10..11: `t` declared here

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__common_op_wrong_value_idiv.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__common_op_wrong_value_idiv.snap
@@ -1,0 +1,25 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "\n    type t : int\n    var k : int\n\n    % Type operand prevents checking of type compatibility\n    var _tt := t div t\n    var _tk := t div k\n    var _kt := k div t\n    "
+
+---
+"t"@(FileId(1), 10..11) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of int
+"k"@(FileId(1), 26..27) [Declared]: int
+"_tt"@(FileId(1), 102..105) [Declared]: int
+"_tk"@(FileId(1), 125..128) [Declared]: int
+"_kt"@(FileId(1), 148..151) [Declared]: int
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 109..110: cannot use `t` as an expression
+| error in file FileId(1) for 109..110: `t` is a reference to a type, not a variable
+| note in file FileId(1) for 10..11: `t` declared here
+error in file FileId(1) at 115..116: cannot use `t` as an expression
+| error in file FileId(1) for 115..116: `t` is a reference to a type, not a variable
+| note in file FileId(1) for 10..11: `t` declared here
+error in file FileId(1) at 132..133: cannot use `t` as an expression
+| error in file FileId(1) for 132..133: `t` is a reference to a type, not a variable
+| note in file FileId(1) for 10..11: `t` declared here
+error in file FileId(1) at 161..162: cannot use `t` as an expression
+| error in file FileId(1) for 161..162: `t` is a reference to a type, not a variable
+| note in file FileId(1) for 10..11: `t` declared here

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__common_op_wrong_value_imply.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__common_op_wrong_value_imply.snap
@@ -1,0 +1,25 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "\n    type t : int\n    var k : int\n\n    % Type operand prevents checking of type compatibility\n    var _tt := t => t\n    var _tk := t => k\n    var _kt := k => t\n    "
+
+---
+"t"@(FileId(1), 10..11) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of int
+"k"@(FileId(1), 26..27) [Declared]: int
+"_tt"@(FileId(1), 102..105) [Declared]: <error>
+"_tk"@(FileId(1), 124..127) [Declared]: <error>
+"_kt"@(FileId(1), 146..149) [Declared]: <error>
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 109..110: cannot use `t` as an expression
+| error in file FileId(1) for 109..110: `t` is a reference to a type, not a variable
+| note in file FileId(1) for 10..11: `t` declared here
+error in file FileId(1) at 114..115: cannot use `t` as an expression
+| error in file FileId(1) for 114..115: `t` is a reference to a type, not a variable
+| note in file FileId(1) for 10..11: `t` declared here
+error in file FileId(1) at 131..132: cannot use `t` as an expression
+| error in file FileId(1) for 131..132: `t` is a reference to a type, not a variable
+| note in file FileId(1) for 10..11: `t` declared here
+error in file FileId(1) at 158..159: cannot use `t` as an expression
+| error in file FileId(1) for 158..159: `t` is a reference to a type, not a variable
+| note in file FileId(1) for 10..11: `t` declared here

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__common_op_wrong_value_less.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__common_op_wrong_value_less.snap
@@ -1,0 +1,25 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "\n    type t : int\n    var k : int\n\n    % Type operand prevents checking of type compatibility\n    var _tt := t < t\n    var _tk := t < k\n    var _kt := k < t\n    "
+
+---
+"t"@(FileId(1), 10..11) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of int
+"k"@(FileId(1), 26..27) [Declared]: int
+"_tt"@(FileId(1), 102..105) [Declared]: boolean
+"_tk"@(FileId(1), 123..126) [Declared]: boolean
+"_kt"@(FileId(1), 144..147) [Declared]: boolean
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 109..110: cannot use `t` as an expression
+| error in file FileId(1) for 109..110: `t` is a reference to a type, not a variable
+| note in file FileId(1) for 10..11: `t` declared here
+error in file FileId(1) at 113..114: cannot use `t` as an expression
+| error in file FileId(1) for 113..114: `t` is a reference to a type, not a variable
+| note in file FileId(1) for 10..11: `t` declared here
+error in file FileId(1) at 130..131: cannot use `t` as an expression
+| error in file FileId(1) for 130..131: `t` is a reference to a type, not a variable
+| note in file FileId(1) for 10..11: `t` declared here
+error in file FileId(1) at 155..156: cannot use `t` as an expression
+| error in file FileId(1) for 155..156: `t` is a reference to a type, not a variable
+| note in file FileId(1) for 10..11: `t` declared here

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__common_op_wrong_value_less_eq.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__common_op_wrong_value_less_eq.snap
@@ -1,0 +1,25 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "\n    type t : int\n    var k : int\n\n    % Type operand prevents checking of type compatibility\n    var _tt := t <= t\n    var _tk := t <= k\n    var _kt := k <= t\n    "
+
+---
+"t"@(FileId(1), 10..11) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of int
+"k"@(FileId(1), 26..27) [Declared]: int
+"_tt"@(FileId(1), 102..105) [Declared]: boolean
+"_tk"@(FileId(1), 124..127) [Declared]: boolean
+"_kt"@(FileId(1), 146..149) [Declared]: boolean
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 109..110: cannot use `t` as an expression
+| error in file FileId(1) for 109..110: `t` is a reference to a type, not a variable
+| note in file FileId(1) for 10..11: `t` declared here
+error in file FileId(1) at 114..115: cannot use `t` as an expression
+| error in file FileId(1) for 114..115: `t` is a reference to a type, not a variable
+| note in file FileId(1) for 10..11: `t` declared here
+error in file FileId(1) at 131..132: cannot use `t` as an expression
+| error in file FileId(1) for 131..132: `t` is a reference to a type, not a variable
+| note in file FileId(1) for 10..11: `t` declared here
+error in file FileId(1) at 158..159: cannot use `t` as an expression
+| error in file FileId(1) for 158..159: `t` is a reference to a type, not a variable
+| note in file FileId(1) for 10..11: `t` declared here

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__common_op_wrong_value_mod.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__common_op_wrong_value_mod.snap
@@ -1,0 +1,25 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "\n    type t : int\n    var k : int\n\n    % Type operand prevents checking of type compatibility\n    var _tt := t mod t\n    var _tk := t mod k\n    var _kt := k mod t\n    "
+
+---
+"t"@(FileId(1), 10..11) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of int
+"k"@(FileId(1), 26..27) [Declared]: int
+"_tt"@(FileId(1), 102..105) [Declared]: int
+"_tk"@(FileId(1), 125..128) [Declared]: int
+"_kt"@(FileId(1), 148..151) [Declared]: int
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 109..110: cannot use `t` as an expression
+| error in file FileId(1) for 109..110: `t` is a reference to a type, not a variable
+| note in file FileId(1) for 10..11: `t` declared here
+error in file FileId(1) at 115..116: cannot use `t` as an expression
+| error in file FileId(1) for 115..116: `t` is a reference to a type, not a variable
+| note in file FileId(1) for 10..11: `t` declared here
+error in file FileId(1) at 132..133: cannot use `t` as an expression
+| error in file FileId(1) for 132..133: `t` is a reference to a type, not a variable
+| note in file FileId(1) for 10..11: `t` declared here
+error in file FileId(1) at 161..162: cannot use `t` as an expression
+| error in file FileId(1) for 161..162: `t` is a reference to a type, not a variable
+| note in file FileId(1) for 10..11: `t` declared here

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__common_op_wrong_value_mul.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__common_op_wrong_value_mul.snap
@@ -1,0 +1,25 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "\n    type t : int\n    var k : int\n\n    % Type operand prevents checking of type compatibility\n    var _tt := t * t\n    var _tk := t * k\n    var _kt := k * t\n    "
+
+---
+"t"@(FileId(1), 10..11) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of int
+"k"@(FileId(1), 26..27) [Declared]: int
+"_tt"@(FileId(1), 102..105) [Declared]: int
+"_tk"@(FileId(1), 123..126) [Declared]: int
+"_kt"@(FileId(1), 144..147) [Declared]: int
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 109..110: cannot use `t` as an expression
+| error in file FileId(1) for 109..110: `t` is a reference to a type, not a variable
+| note in file FileId(1) for 10..11: `t` declared here
+error in file FileId(1) at 113..114: cannot use `t` as an expression
+| error in file FileId(1) for 113..114: `t` is a reference to a type, not a variable
+| note in file FileId(1) for 10..11: `t` declared here
+error in file FileId(1) at 130..131: cannot use `t` as an expression
+| error in file FileId(1) for 130..131: `t` is a reference to a type, not a variable
+| note in file FileId(1) for 10..11: `t` declared here
+error in file FileId(1) at 155..156: cannot use `t` as an expression
+| error in file FileId(1) for 155..156: `t` is a reference to a type, not a variable
+| note in file FileId(1) for 10..11: `t` declared here

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__common_op_wrong_value_negate.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__common_op_wrong_value_negate.snap
@@ -1,0 +1,13 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "\n    type t : boolean\n\n    % Type operand prevents checking of type compatibility\n    var _t := - t\n    "
+
+---
+"t"@(FileId(1), 10..11) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of boolean
+"_t"@(FileId(1), 90..92) [Declared]: <error>
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 98..99: cannot use `t` as an expression
+| error in file FileId(1) for 98..99: `t` is a reference to a type, not a variable
+| note in file FileId(1) for 10..11: `t` declared here

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__common_op_wrong_value_not.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__common_op_wrong_value_not.snap
@@ -1,0 +1,13 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "\n    type t : boolean\n\n    % Type operand prevents checking of type compatibility\n    var _t := not t\n    "
+
+---
+"t"@(FileId(1), 10..11) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of boolean
+"_t"@(FileId(1), 90..92) [Declared]: boolean
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 100..101: cannot use `t` as an expression
+| error in file FileId(1) for 100..101: `t` is a reference to a type, not a variable
+| note in file FileId(1) for 10..11: `t` declared here

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__common_op_wrong_value_not_equal.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__common_op_wrong_value_not_equal.snap
@@ -1,0 +1,25 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "\n    type t : int\n    var k : int\n\n    % Type operand prevents checking of type compatibility\n    var _tt := t not= t\n    var _tk := t not= k\n    var _kt := k not= t\n    "
+
+---
+"t"@(FileId(1), 10..11) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of int
+"k"@(FileId(1), 26..27) [Declared]: int
+"_tt"@(FileId(1), 102..105) [Declared]: boolean
+"_tk"@(FileId(1), 126..129) [Declared]: boolean
+"_kt"@(FileId(1), 150..153) [Declared]: boolean
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 109..110: cannot use `t` as an expression
+| error in file FileId(1) for 109..110: `t` is a reference to a type, not a variable
+| note in file FileId(1) for 10..11: `t` declared here
+error in file FileId(1) at 116..117: cannot use `t` as an expression
+| error in file FileId(1) for 116..117: `t` is a reference to a type, not a variable
+| note in file FileId(1) for 10..11: `t` declared here
+error in file FileId(1) at 133..134: cannot use `t` as an expression
+| error in file FileId(1) for 133..134: `t` is a reference to a type, not a variable
+| note in file FileId(1) for 10..11: `t` declared here
+error in file FileId(1) at 164..165: cannot use `t` as an expression
+| error in file FileId(1) for 164..165: `t` is a reference to a type, not a variable
+| note in file FileId(1) for 10..11: `t` declared here

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__common_op_wrong_value_or.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__common_op_wrong_value_or.snap
@@ -1,0 +1,25 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "\n    type t : int\n    var k : int\n\n    % Type operand prevents checking of type compatibility\n    var _tt := t or t\n    var _tk := t or k\n    var _kt := k or t\n    "
+
+---
+"t"@(FileId(1), 10..11) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of int
+"k"@(FileId(1), 26..27) [Declared]: int
+"_tt"@(FileId(1), 102..105) [Declared]: nat
+"_tk"@(FileId(1), 124..127) [Declared]: nat
+"_kt"@(FileId(1), 146..149) [Declared]: nat
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 109..110: cannot use `t` as an expression
+| error in file FileId(1) for 109..110: `t` is a reference to a type, not a variable
+| note in file FileId(1) for 10..11: `t` declared here
+error in file FileId(1) at 114..115: cannot use `t` as an expression
+| error in file FileId(1) for 114..115: `t` is a reference to a type, not a variable
+| note in file FileId(1) for 10..11: `t` declared here
+error in file FileId(1) at 131..132: cannot use `t` as an expression
+| error in file FileId(1) for 131..132: `t` is a reference to a type, not a variable
+| note in file FileId(1) for 10..11: `t` declared here
+error in file FileId(1) at 158..159: cannot use `t` as an expression
+| error in file FileId(1) for 158..159: `t` is a reference to a type, not a variable
+| note in file FileId(1) for 10..11: `t` declared here

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__common_op_wrong_value_rdiv.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__common_op_wrong_value_rdiv.snap
@@ -1,0 +1,25 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "\n    type t : int\n    var k : int\n\n    % Type operand prevents checking of type compatibility\n    var _tt := t / t\n    var _tk := t / k\n    var _kt := k / t\n    "
+
+---
+"t"@(FileId(1), 10..11) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of int
+"k"@(FileId(1), 26..27) [Declared]: int
+"_tt"@(FileId(1), 102..105) [Declared]: real
+"_tk"@(FileId(1), 123..126) [Declared]: real
+"_kt"@(FileId(1), 144..147) [Declared]: real
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 109..110: cannot use `t` as an expression
+| error in file FileId(1) for 109..110: `t` is a reference to a type, not a variable
+| note in file FileId(1) for 10..11: `t` declared here
+error in file FileId(1) at 113..114: cannot use `t` as an expression
+| error in file FileId(1) for 113..114: `t` is a reference to a type, not a variable
+| note in file FileId(1) for 10..11: `t` declared here
+error in file FileId(1) at 130..131: cannot use `t` as an expression
+| error in file FileId(1) for 130..131: `t` is a reference to a type, not a variable
+| note in file FileId(1) for 10..11: `t` declared here
+error in file FileId(1) at 155..156: cannot use `t` as an expression
+| error in file FileId(1) for 155..156: `t` is a reference to a type, not a variable
+| note in file FileId(1) for 10..11: `t` declared here

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__common_op_wrong_value_rem.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__common_op_wrong_value_rem.snap
@@ -1,0 +1,25 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "\n    type t : int\n    var k : int\n\n    % Type operand prevents checking of type compatibility\n    var _tt := t rem t\n    var _tk := t rem k\n    var _kt := k rem t\n    "
+
+---
+"t"@(FileId(1), 10..11) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of int
+"k"@(FileId(1), 26..27) [Declared]: int
+"_tt"@(FileId(1), 102..105) [Declared]: int
+"_tk"@(FileId(1), 125..128) [Declared]: int
+"_kt"@(FileId(1), 148..151) [Declared]: int
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 109..110: cannot use `t` as an expression
+| error in file FileId(1) for 109..110: `t` is a reference to a type, not a variable
+| note in file FileId(1) for 10..11: `t` declared here
+error in file FileId(1) at 115..116: cannot use `t` as an expression
+| error in file FileId(1) for 115..116: `t` is a reference to a type, not a variable
+| note in file FileId(1) for 10..11: `t` declared here
+error in file FileId(1) at 132..133: cannot use `t` as an expression
+| error in file FileId(1) for 132..133: `t` is a reference to a type, not a variable
+| note in file FileId(1) for 10..11: `t` declared here
+error in file FileId(1) at 161..162: cannot use `t` as an expression
+| error in file FileId(1) for 161..162: `t` is a reference to a type, not a variable
+| note in file FileId(1) for 10..11: `t` declared here

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__common_op_wrong_value_shl.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__common_op_wrong_value_shl.snap
@@ -1,0 +1,25 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "\n    type t : int\n    var k : int\n\n    % Type operand prevents checking of type compatibility\n    var _tt := t shl t\n    var _tk := t shl k\n    var _kt := k shl t\n    "
+
+---
+"t"@(FileId(1), 10..11) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of int
+"k"@(FileId(1), 26..27) [Declared]: int
+"_tt"@(FileId(1), 102..105) [Declared]: nat
+"_tk"@(FileId(1), 125..128) [Declared]: nat
+"_kt"@(FileId(1), 148..151) [Declared]: nat
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 109..110: cannot use `t` as an expression
+| error in file FileId(1) for 109..110: `t` is a reference to a type, not a variable
+| note in file FileId(1) for 10..11: `t` declared here
+error in file FileId(1) at 115..116: cannot use `t` as an expression
+| error in file FileId(1) for 115..116: `t` is a reference to a type, not a variable
+| note in file FileId(1) for 10..11: `t` declared here
+error in file FileId(1) at 132..133: cannot use `t` as an expression
+| error in file FileId(1) for 132..133: `t` is a reference to a type, not a variable
+| note in file FileId(1) for 10..11: `t` declared here
+error in file FileId(1) at 161..162: cannot use `t` as an expression
+| error in file FileId(1) for 161..162: `t` is a reference to a type, not a variable
+| note in file FileId(1) for 10..11: `t` declared here

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__common_op_wrong_value_shr.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__common_op_wrong_value_shr.snap
@@ -1,0 +1,25 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "\n    type t : int\n    var k : int\n\n    % Type operand prevents checking of type compatibility\n    var _tt := t shr t\n    var _tk := t shr k\n    var _kt := k shr t\n    "
+
+---
+"t"@(FileId(1), 10..11) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of int
+"k"@(FileId(1), 26..27) [Declared]: int
+"_tt"@(FileId(1), 102..105) [Declared]: nat
+"_tk"@(FileId(1), 125..128) [Declared]: nat
+"_kt"@(FileId(1), 148..151) [Declared]: nat
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 109..110: cannot use `t` as an expression
+| error in file FileId(1) for 109..110: `t` is a reference to a type, not a variable
+| note in file FileId(1) for 10..11: `t` declared here
+error in file FileId(1) at 115..116: cannot use `t` as an expression
+| error in file FileId(1) for 115..116: `t` is a reference to a type, not a variable
+| note in file FileId(1) for 10..11: `t` declared here
+error in file FileId(1) at 132..133: cannot use `t` as an expression
+| error in file FileId(1) for 132..133: `t` is a reference to a type, not a variable
+| note in file FileId(1) for 10..11: `t` declared here
+error in file FileId(1) at 161..162: cannot use `t` as an expression
+| error in file FileId(1) for 161..162: `t` is a reference to a type, not a variable
+| note in file FileId(1) for 10..11: `t` declared here

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__common_op_wrong_value_sub.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__common_op_wrong_value_sub.snap
@@ -1,0 +1,25 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "\n    type t : int\n    var k : int\n\n    % Type operand prevents checking of type compatibility\n    var _tt := t - t\n    var _tk := t - k\n    var _kt := k - t\n    "
+
+---
+"t"@(FileId(1), 10..11) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of int
+"k"@(FileId(1), 26..27) [Declared]: int
+"_tt"@(FileId(1), 102..105) [Declared]: int
+"_tk"@(FileId(1), 123..126) [Declared]: int
+"_kt"@(FileId(1), 144..147) [Declared]: int
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 109..110: cannot use `t` as an expression
+| error in file FileId(1) for 109..110: `t` is a reference to a type, not a variable
+| note in file FileId(1) for 10..11: `t` declared here
+error in file FileId(1) at 113..114: cannot use `t` as an expression
+| error in file FileId(1) for 113..114: `t` is a reference to a type, not a variable
+| note in file FileId(1) for 10..11: `t` declared here
+error in file FileId(1) at 130..131: cannot use `t` as an expression
+| error in file FileId(1) for 130..131: `t` is a reference to a type, not a variable
+| note in file FileId(1) for 10..11: `t` declared here
+error in file FileId(1) at 155..156: cannot use `t` as an expression
+| error in file FileId(1) for 155..156: `t` is a reference to a type, not a variable
+| note in file FileId(1) for 10..11: `t` declared here

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__common_op_wrong_value_xor.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__common_op_wrong_value_xor.snap
@@ -1,0 +1,25 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "\n    type t : int\n    var k : int\n\n    % Type operand prevents checking of type compatibility\n    var _tt := t xor t\n    var _tk := t xor k\n    var _kt := k xor t\n    "
+
+---
+"t"@(FileId(1), 10..11) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of int
+"k"@(FileId(1), 26..27) [Declared]: int
+"_tt"@(FileId(1), 102..105) [Declared]: nat
+"_tk"@(FileId(1), 125..128) [Declared]: nat
+"_kt"@(FileId(1), 148..151) [Declared]: nat
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 109..110: cannot use `t` as an expression
+| error in file FileId(1) for 109..110: `t` is a reference to a type, not a variable
+| note in file FileId(1) for 10..11: `t` declared here
+error in file FileId(1) at 115..116: cannot use `t` as an expression
+| error in file FileId(1) for 115..116: `t` is a reference to a type, not a variable
+| note in file FileId(1) for 10..11: `t` declared here
+error in file FileId(1) at 132..133: cannot use `t` as an expression
+| error in file FileId(1) for 132..133: `t` is a reference to a type, not a variable
+| note in file FileId(1) for 10..11: `t` declared here
+error in file FileId(1) at 161..162: cannot use `t` as an expression
+| error in file FileId(1) for 161..162: `t` is a reference to a type, not a variable
+| note in file FileId(1) for 10..11: `t` declared here

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_assignment_lhs_not_value.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_assignment_lhs_not_value.snap
@@ -1,0 +1,12 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "type k : int k := 1"
+
+---
+"k"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of int
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 15..17: cannot assign into `k`
+| error in file FileId(1) for 13..14: `k` is a reference to a type, not a variable
+| note in file FileId(1) for 5..6: `k` declared here

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_assignment_rhs_not_value.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_assignment_rhs_not_value.snap
@@ -1,0 +1,13 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "type j : int var k : int k := j"
+
+---
+"j"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of int
+"k"@(FileId(1), 17..18) [Declared]: int
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 30..31: cannot use `j` as an expression
+| error in file FileId(1) for 30..31: `j` is a reference to a type, not a variable
+| note in file FileId(1) for 5..6: `j` declared here

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_bind_decl_from_ty.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_bind_decl_from_ty.snap
@@ -1,6 +1,6 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-assertion_line: 41
+assertion_line: 42
 expression: "begin\ntype no : int\nbind you to no\nend"
 
 ---
@@ -9,8 +9,5 @@ expression: "begin\ntype no : int\nbind you to no\nend"
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 25..34: cannot bind `you` to `no`
-| error in file FileId(1) for 32..34: `no` is a reference to a type, not a variable
-| note in file FileId(1) for 11..13: `no` declared here
-error in file FileId(1) at 32..34: cannot use `no` as an expression
 | error in file FileId(1) for 32..34: `no` is a reference to a type, not a variable
 | note in file FileId(1) for 11..13: `no` declared here

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_case_alias_discriminant_ty.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_case_alias_discriminant_ty.snap
@@ -1,0 +1,13 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "type c : char\nvar d : c\ncase c of label 'c': end case\n"
+
+---
+"c"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of char
+"d"@(FileId(1), 18..19) [Declared]: alias[DefId(LibraryId(0), LocalDefId(0))] of char
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 29..30: cannot use `c` as an expression
+| error in file FileId(1) for 29..30: `c` is a reference to a type, not a variable
+| note in file FileId(1) for 5..6: `c` declared here

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_case_alias_selector_ty.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_case_alias_selector_ty.snap
@@ -1,0 +1,10 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "type c : char\nconst k : c := 'c'\ncase 'k' of label k: end case\n"
+
+---
+"c"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of char
+"k"@(FileId(1), 20..21) [Declared]: alias[DefId(LibraryId(0), LocalDefId(0))] of char
+"<root>"@(dummy) [Declared]: <error>
+

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_case_wrong_value_discriminant.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_case_wrong_value_discriminant.snap
@@ -1,0 +1,12 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "type c : char\ncase c of label : end case\n"
+
+---
+"c"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of char
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 19..20: cannot use `c` as an expression
+| error in file FileId(1) for 19..20: `c` is a reference to a type, not a variable
+| note in file FileId(1) for 5..6: `c` declared here

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_case_wrong_value_selectors.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_case_wrong_value_selectors.snap
@@ -1,0 +1,12 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "type c : char\ncase 'k' of label c: end case\n"
+
+---
+"c"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of char
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 32..33: cannot use `c` as an expression
+| error in file FileId(1) for 32..33: `c` is a reference to a type, not a variable
+| note in file FileId(1) for 5..6: `c` declared here

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_charn_ty_any_size.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_charn_ty_any_size.snap
@@ -1,0 +1,9 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "type _ : char(*)"
+
+---
+"_"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of char_n Any
+"<root>"@(dummy) [Declared]: <error>
+

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_charn_ty_runtime_size.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_charn_ty_runtime_size.snap
@@ -1,0 +1,12 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "var k : int type _ : char(k)"
+
+---
+"k"@(FileId(1), 4..5) [Declared]: int
+"_"@(FileId(1), 17..18) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(1))] of char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 21..28: unsupported type
+| error in file FileId(1) for 21..28: dynamically sized `char(N)` isn't supported yet

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_charn_ty_wrong_size_too_big.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_charn_ty_wrong_size_too_big.snap
@@ -1,0 +1,12 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "type _ : char(32768)"
+
+---
+"_"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 14..19: invalid character count size
+| error in file FileId(1) for 14..19: computed count is 32768
+| info: valid sizes are between 1 to 32767

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_charn_ty_wrong_size_too_small.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_charn_ty_wrong_size_too_small.snap
@@ -1,0 +1,12 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "type _ : char(0)"
+
+---
+"_"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 14..15: invalid character count size
+| error in file FileId(1) for 14..15: computed count is 0
+| info: valid sizes are between 1 to 32767

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_charn_ty_wrong_type_size.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_charn_ty_wrong_type_size.snap
@@ -1,0 +1,12 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "type _ : char(1.0)"
+
+---
+"_"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 14..17: mismatched types
+| note in file FileId(1) for 14..17: this is of type `real`
+| info: `real` is not an integer type

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_charn_ty_wrong_value_size.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_charn_ty_wrong_value_size.snap
@@ -1,0 +1,13 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "type k : int type _ : char(k)"
+
+---
+"k"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of int
+"_"@(FileId(1), 18..19) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(1))] of char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 27..28: cannot use `k` as an expression
+| error in file FileId(1) for 27..28: `k` is a reference to a type, not a variable
+| note in file FileId(1) for 5..6: `k` declared here

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_exit_wrong_value_condition.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_exit_wrong_value_condition.snap
@@ -1,0 +1,12 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "loop\n    type b : boolean\n    exit when b\nend loop\n"
+
+---
+"b"@(FileId(1), 14..15) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of boolean
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 40..41: cannot use `b` as an expression
+| error in file FileId(1) for 40..41: `b` is a reference to a type, not a variable
+| note in file FileId(1) for 14..15: `b` declared here

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_for_wrong_value_bounds.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_for_wrong_value_bounds.snap
@@ -1,0 +1,21 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "type k : string\nfor : k .. k end for\nfor : 1 .. k end for\nfor : k .. 1 end for\n"
+
+---
+"k"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of string
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 22..23: cannot use `k` as an expression
+| error in file FileId(1) for 22..23: `k` is a reference to a type, not a variable
+| note in file FileId(1) for 5..6: `k` declared here
+error in file FileId(1) at 27..28: cannot use `k` as an expression
+| error in file FileId(1) for 27..28: `k` is a reference to a type, not a variable
+| note in file FileId(1) for 5..6: `k` declared here
+error in file FileId(1) at 48..49: cannot use `k` as an expression
+| error in file FileId(1) for 48..49: `k` is a reference to a type, not a variable
+| note in file FileId(1) for 5..6: `k` declared here
+error in file FileId(1) at 64..65: cannot use `k` as an expression
+| error in file FileId(1) for 64..65: `k` is a reference to a type, not a variable
+| note in file FileId(1) for 5..6: `k` declared here

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_for_wrong_value_by.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_for_wrong_value_by.snap
@@ -1,0 +1,12 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "type k : int for : 1 .. 2 by k end for"
+
+---
+"k"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of int
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 29..30: cannot use `k` as an expression
+| error in file FileId(1) for 29..30: `k` is a reference to a type, not a variable
+| note in file FileId(1) for 5..6: `k` declared here

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_get_stmt_valid_aliased_types.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_get_stmt_valid_aliased_types.snap
@@ -1,0 +1,12 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "type i : int\ntype s : string\nvar o : i\nvar w : s\nget : o, w : o ..\nget w : * ..\n"
+
+---
+"i"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of int
+"s"@(FileId(1), 18..19) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(1))] of string
+"o"@(FileId(1), 33..34) [Declared]: alias[DefId(LibraryId(0), LocalDefId(0))] of int
+"w"@(FileId(1), 43..44) [Declared]: alias[DefId(LibraryId(0), LocalDefId(1))] of string
+"<root>"@(dummy) [Declared]: <error>
+

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_get_stmt_wrong_value_item.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_get_stmt_wrong_value_item.snap
@@ -1,0 +1,12 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "type k : int\nget k\n"
+
+---
+"k"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of int
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 17..18: cannot assign into `k`
+| error in file FileId(1) for 17..18: `k` is a reference to a type, not a variable
+| note in file FileId(1) for 5..6: `k` declared here

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_get_stmt_wrong_value_opt.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_get_stmt_wrong_value_opt.snap
@@ -1,0 +1,13 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "type k : int\nvar s : string\nget s : k\n"
+
+---
+"k"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of int
+"s"@(FileId(1), 17..18) [Declared]: string
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 36..37: cannot use `k` as an expression
+| error in file FileId(1) for 36..37: `k` is a reference to a type, not a variable
+| note in file FileId(1) for 5..6: `k` declared here

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_get_stmt_wrong_value_stream.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_get_stmt_wrong_value_stream.snap
@@ -1,0 +1,13 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "type s : int\nvar k : int\nget : s, k\n"
+
+---
+"s"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of int
+"k"@(FileId(1), 17..18) [Declared]: int
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 31..32: cannot use `s` as an expression
+| error in file FileId(1) for 31..32: `s` is a reference to a type, not a variable
+| note in file FileId(1) for 5..6: `s` declared here

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_if_wrong_value_condition.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_if_wrong_value_condition.snap
@@ -1,0 +1,15 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "type b : boolean\nif b then\nelsif b then\nend if"
+
+---
+"b"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of boolean
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 20..21: cannot use `b` as an expression
+| error in file FileId(1) for 20..21: `b` is a reference to a type, not a variable
+| note in file FileId(1) for 5..6: `b` declared here
+error in file FileId(1) at 33..34: cannot use `b` as an expression
+| error in file FileId(1) for 33..34: `b` is a reference to a type, not a variable
+| note in file FileId(1) for 5..6: `b` declared here

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_put_stmt_valid_aliased_types.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_put_stmt_valid_aliased_types.snap
@@ -1,0 +1,12 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "type i : int\nvar o, w, u : i\nput : o, w : o : u : o..\n"
+
+---
+"i"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of int
+"o"@(FileId(1), 17..18) [Declared]: alias[DefId(LibraryId(0), LocalDefId(0))] of int
+"w"@(FileId(1), 20..21) [Declared]: alias[DefId(LibraryId(0), LocalDefId(0))] of int
+"u"@(FileId(1), 23..24) [Declared]: alias[DefId(LibraryId(0), LocalDefId(0))] of int
+"<root>"@(dummy) [Declared]: <error>
+

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_put_stmt_wrong_value_item.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_put_stmt_wrong_value_item.snap
@@ -1,0 +1,12 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "type k : int\nput k\n"
+
+---
+"k"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of int
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 17..18: cannot use `k` as an expression
+| error in file FileId(1) for 17..18: `k` is a reference to a type, not a variable
+| note in file FileId(1) for 5..6: `k` declared here

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_put_stmt_wrong_value_opt.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_put_stmt_wrong_value_opt.snap
@@ -1,0 +1,19 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "type o : int\ntype w : int\nput 1 : o : w : o\n"
+
+---
+"o"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of int
+"w"@(FileId(1), 18..19) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(1))] of int
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 34..35: cannot use `o` as an expression
+| error in file FileId(1) for 34..35: `o` is a reference to a type, not a variable
+| note in file FileId(1) for 5..6: `o` declared here
+error in file FileId(1) at 38..39: cannot use `w` as an expression
+| error in file FileId(1) for 38..39: `w` is a reference to a type, not a variable
+| note in file FileId(1) for 18..19: `w` declared here
+error in file FileId(1) at 42..43: cannot use `o` as an expression
+| error in file FileId(1) for 42..43: `o` is a reference to a type, not a variable
+| note in file FileId(1) for 5..6: `o` declared here

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_put_stmt_wrong_value_stream.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_put_stmt_wrong_value_stream.snap
@@ -1,0 +1,12 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "type k : int\nput : k, 1\n"
+
+---
+"k"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of int
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 19..20: cannot use `k` as an expression
+| error in file FileId(1) for 19..20: `k` is a reference to a type, not a variable
+| note in file FileId(1) for 5..6: `k` declared here

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_result_stmt_wrong_value_result.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_result_stmt_wrong_value_result.snap
@@ -1,0 +1,13 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "fcn b : int type k : int result k end b"
+
+---
+"b"@(FileId(1), 4..5) [Declared]: function -> int
+"k"@(FileId(1), 17..18) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(1))] of int
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 32..33: cannot use `k` as an expression
+| error in file FileId(1) for 32..33: `k` is a reference to a type, not a variable
+| note in file FileId(1) for 17..18: `k` declared here

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_stringn_ty_any_size.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_stringn_ty_any_size.snap
@@ -1,0 +1,9 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "type _ : string(*)"
+
+---
+"_"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of string_n Any
+"<root>"@(dummy) [Declared]: <error>
+

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_stringn_ty_runtime_size.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_stringn_ty_runtime_size.snap
@@ -1,0 +1,13 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "var k : int type _ : string(k)"
+
+---
+"k"@(FileId(1), 4..5) [Declared]: int
+"_"@(FileId(1), 17..18) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(1))] of string_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 28..29: cannot compute `k` at compile-time
+| error in file FileId(1) for 28..29: `k` is a reference to a variable, not a constant
+| note in file FileId(1) for 4..5: `k` declared here

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_stringn_ty_wrong_size_too_big.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_stringn_ty_wrong_size_too_big.snap
@@ -1,0 +1,12 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "type _ : string(256)"
+
+---
+"_"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of string_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 16..19: invalid character count size
+| error in file FileId(1) for 16..19: computed count is 256
+| info: valid sizes are between 1 to 255

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_stringn_ty_wrong_size_too_small.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_stringn_ty_wrong_size_too_small.snap
@@ -1,0 +1,12 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "type _ : string(0)"
+
+---
+"_"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of string_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 16..17: invalid character count size
+| error in file FileId(1) for 16..17: computed count is 0
+| info: valid sizes are between 1 to 255

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_stringn_ty_wrong_type_size.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_stringn_ty_wrong_type_size.snap
@@ -1,0 +1,12 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "type _ : string(1.0)"
+
+---
+"_"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of string_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 16..19: mismatched types
+| note in file FileId(1) for 16..19: this is of type `real`
+| info: `real` is not an integer type

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_stringn_ty_wrong_value_size.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_stringn_ty_wrong_value_size.snap
@@ -1,0 +1,13 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "type k : int type _ : string(k)"
+
+---
+"k"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of int
+"_"@(FileId(1), 18..19) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(1))] of string_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 29..30: cannot use `k` as an expression
+| error in file FileId(1) for 29..30: `k` is a reference to a type, not a variable
+| note in file FileId(1) for 5..6: `k` declared here

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_args_err_not_expr.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_args_err_not_expr.snap
@@ -1,6 +1,6 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-assertion_line: 41
+assertion_line: 42
 expression: "type a : int\nprocedure boop(a, b : int, var c : int) end boop\nboop(1, a, a)\n"
 
 ---
@@ -12,9 +12,9 @@ expression: "type a : int\nprocedure boop(a, b : int, var c : int) end boop\nboo
 "c"@(FileId(1), 44..45) [Declared]: int
 "<root>"@(dummy) [Declared]: <error>
 
-error in file FileId(1) at 70..71: cannot use `a` as an expression
+error in file FileId(1) at 70..71: cannot pass `a` to this parameter
 | error in file FileId(1) for 70..71: `a` is a reference to a type, not a variable
 | note in file FileId(1) for 5..6: `a` declared here
-error in file FileId(1) at 73..74: cannot use `a` as an expression
+error in file FileId(1) at 73..74: cannot pass `a` to this parameter
 | error in file FileId(1) for 73..74: `a` is a reference to a type, not a variable
 | note in file FileId(1) for 5..6: `a` declared here

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_on_type_err.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_on_type_err.snap
@@ -1,6 +1,6 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-assertion_line: 41
+assertion_line: 42
 expression: "type kall : procedure() kall"
 
 ---
@@ -8,6 +8,6 @@ expression: "type kall : procedure() kall"
 "kall"@(FileId(1), 5..9) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(1))] of procedure ( ) -> void
 "<root>"@(dummy) [Declared]: <error>
 
-error in file FileId(1) at 24..28: cannot use `kall` as an expression
-| error in file FileId(1) for 24..28: `kall` is a reference to a type, not a variable
+error in file FileId(1) at 24..28: cannot call or subscript `kall`
+| error in file FileId(1) for 24..28: `kall` is a reference to a type, not a subprogram
 | note in file FileId(1) for 5..9: `kall` declared here

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_decl_sized_return.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_decl_sized_return.snap
@@ -1,0 +1,9 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "function sha : int end sha"
+
+---
+"sha"@(FileId(1), 9..12) [Declared]: function -> int
+"<root>"@(dummy) [Declared]: <error>
+

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_decl_unsized_return_err.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_decl_unsized_return_err.snap
@@ -1,0 +1,12 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "function sha : char(*) end sha"
+
+---
+"sha"@(FileId(1), 9..12) [Declared]: function -> char_n Any
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 15..22: invalid storage type
+| error in file FileId(1) for 15..22: cannot use `char(*)` in `function` declarations
+| info: `char(*)`'s refer to character sequences that do not have a fixed size known at compile-time

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_decl_wrong_type_dev_spec.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_decl_wrong_type_dev_spec.snap
@@ -1,0 +1,12 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "proc a : 1.0 end a"
+
+---
+"a"@(FileId(1), 5..6) [Declared]: procedure -> void
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 9..12: mismatched types
+| note in file FileId(1) for 9..12: this is of type `real`
+| info: `real` is not an integer type

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_decl_wrong_type_stack_size.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_decl_wrong_type_stack_size.snap
@@ -1,0 +1,12 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "process a : 1.0 end a"
+
+---
+"a"@(FileId(1), 8..9) [Declared]: process -> void
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 12..15: mismatched types
+| note in file FileId(1) for 12..15: this is of type `real`
+| info: `real` is not an integer type

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_decl_wrong_value_dev_spec.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_decl_wrong_value_dev_spec.snap
@@ -1,0 +1,13 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "type k : real proc a : k end a"
+
+---
+"k"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of real
+"a"@(FileId(1), 19..20) [Declared]: procedure -> void
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 23..24: cannot use `k` as an expression
+| error in file FileId(1) for 23..24: `k` is a reference to a type, not a variable
+| note in file FileId(1) for 5..6: `k` declared here

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_decl_wrong_value_stack_size.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_decl_wrong_value_stack_size.snap
@@ -1,0 +1,13 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "type k : real process a : k end a"
+
+---
+"k"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of real
+"a"@(FileId(1), 22..23) [Declared]: process -> void
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 26..27: cannot use `k` as an expression
+| error in file FileId(1) for 26..27: `k` is a reference to a type, not a variable
+| note in file FileId(1) for 5..6: `k` declared here


### PR DESCRIPTION
In order to properly support things such as module field lookups, set constructors, etc, the responsibility for value kind checking must be distributed from name exprs to downstream.