### PR TITLE
Add driver cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -635,6 +635,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e280fbe77cc62c91527259e9442153f4688736748d24660126286329742b4c6c"
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -831,6 +837,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "similar"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -932,6 +947,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1016,6 +1040,8 @@ dependencies = [
  "toc_syntax",
  "toc_vfs",
  "toc_vfs_db",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1179,6 +1205,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a1bdf54a7c28a2bbf701e1d2233f6c77f473486b94bee4f9678da5a148dca7f"
+dependencies = [
+ "cfg-if",
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e65ce065b4b5c53e73bb28912318cb8c9e9ad3921f1d669eb0e68b4c8143a2b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa31669fa42c09c34d94d8165dd2012e8ff3c66aca50f3bb226b68f216f2706c"
+dependencies = [
+ "lazy_static",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6923477a48e41c1951f1999ef8bb5a3023eb723ceadafe78ffb65dc366761e3"
+dependencies = [
+ "lazy_static",
+ "log",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e0ab7bdc962035a87fba73f3acca9b8a8d0034c2e6f60b84aeaaddddc155dce"
+dependencies = [
+ "ansi_term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
 name = "ungrammar"
 version = "1.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1241,6 +1325,12 @@ name = "utf8-ranges"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ae116fef2b7fea257ed6440d3cfcff7f190865f170cdad00bb6465bf18ecba"
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vec_map"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,7 +9,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c0f4180b6d7095a1c3130f1aadead4ece7fb3094dc724c701adb30a92a95228"
 dependencies = [
  "cc",
- "clap",
+ "clap 2.34.0",
  "libc",
  "rustc_version",
  "xdg",
@@ -104,10 +104,40 @@ dependencies = [
  "ansi_term",
  "atty",
  "bitflags",
- "strsim",
- "textwrap",
+ "strsim 0.8.0",
+ "textwrap 0.11.0",
  "unicode-width",
  "vec_map",
+]
+
+[[package]]
+name = "clap"
+version = "3.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8c93436c21e4698bacadf42917db28b23017027a4deccb35dbe47a7e7840123"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_derive",
+ "indexmap",
+ "lazy_static",
+ "os_str_bytes",
+ "strsim 0.10.0",
+ "termcolor",
+ "textwrap 0.15.0",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da95d038ede1a964ce99f49cbe27a7fb538d1da595e4b4f70b8c8f338d17bf16"
+dependencies = [
+ "heck 0.4.0",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -493,6 +523,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
+name = "memchr"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+
+[[package]]
 name = "memoffset"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -532,6 +568,15 @@ name = "oorandom"
 version = "11.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
+
+[[package]]
+name = "os_str_bytes"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "parking_lot"
@@ -587,6 +632,30 @@ checksum = "4a13a2fa9d0b63e5f22328828741e523766fff0ee9e779316902290dff3f824f"
 dependencies = [
  "fixedbitset",
  "indexmap",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
 ]
 
 [[package]]
@@ -786,6 +855,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "syn"
 version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -794,6 +869,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -820,6 +904,12 @@ checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
 ]
+
+[[package]]
+name = "textwrap"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"
@@ -913,6 +1003,7 @@ name = "toc_driver"
 version = "0.1.0"
 dependencies = [
  "ariadne",
+ "clap 3.1.6",
  "toc_analysis",
  "toc_ast_db",
  "toc_hir",
@@ -1158,6 +1249,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
 name = "wasi"
 version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1178,6 +1275,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/compiler/toc_driver/Cargo.toml
+++ b/compiler/toc_driver/Cargo.toml
@@ -22,3 +22,5 @@ toc_vfs_db = { path = "../toc_vfs_db" }
 
 ariadne = { version = "0.1" }
 clap = { version = "3.1.6", features = ["derive"] }
+tracing = "0.1.32"
+tracing-subscriber = "0.3.9"

--- a/compiler/toc_driver/Cargo.toml
+++ b/compiler/toc_driver/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "toc_driver"
 version = "0.1.0"
-authors = ["DropDemBits <r3usrlnd@gmail.com>"]
+authors = ["DropDemBits"]
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -21,3 +21,4 @@ toc_vfs = { path = "../toc_vfs" }
 toc_vfs_db = { path = "../toc_vfs_db" }
 
 ariadne = { version = "0.1" }
+clap = { version = "3.1.6", features = ["derive"] }

--- a/compiler/toc_driver/src/config.rs
+++ b/compiler/toc_driver/src/config.rs
@@ -1,0 +1,50 @@
+/*
+ - Selecting what to dump (`--dump [kind]`)
+ - Lint mode (`--lint-only`)
+ - Changing reporting output:
+   - normal
+   - json (in the future)
+   - legacy (for adapting to OpenTuring-QT editor)
+*/
+
+/// Compiler interface for the Turing language
+#[derive(clap::Parser, Debug)]
+#[clap(author, version, about, long_about = None)]
+pub struct Args {
+    /// Only report warnings and errors, don't generate a compiled file
+    #[clap(long)]
+    pub lint: bool,
+
+    /// Optionally dump internal data structure info
+    #[clap(long, arg_enum)]
+    pub dump: Option<DumpMode>,
+
+    /// Change the reporting format
+    #[clap(long, arg_enum)]
+    pub report_format: Option<ReportFormat>,
+
+    /// File to start compiling from
+    pub source_file: String, // FIXME: Should probably be a camino::PathBuf
+}
+
+/// Which data structure to dump
+#[derive(clap::ArgEnum, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DumpMode {
+    /// AST/CST structures (only for the current file)
+    Ast,
+    /// HIR Trees, in line-based format
+    Hir,
+}
+
+/// Format for report output
+#[derive(clap::ArgEnum, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReportFormat {
+    /// CLI report format, with color. This is the default format.
+    Cli,
+}
+
+impl Default for ReportFormat {
+    fn default() -> Self {
+        Self::Cli
+    }
+}

--- a/compiler/toc_driver/src/config.rs
+++ b/compiler/toc_driver/src/config.rs
@@ -23,6 +23,10 @@ pub struct Args {
     #[clap(long, arg_enum)]
     pub report_format: Option<ReportFormat>,
 
+    /// Set internal logging level
+    #[clap(long, arg_enum)]
+    pub log_level: Option<LogLevel>,
+
     /// File to start compiling from
     pub source_file: String, // FIXME: Should probably be a camino::PathBuf
 }
@@ -46,5 +50,38 @@ pub enum ReportFormat {
 impl Default for ReportFormat {
     fn default() -> Self {
         Self::Cli
+    }
+}
+
+#[derive(clap::ArgEnum, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LogLevel {
+    Trace,
+    Debug,
+    Info,
+    Warn,
+    Error,
+}
+
+impl From<LogLevel> for tracing::Level {
+    fn from(level: LogLevel) -> Self {
+        match level {
+            LogLevel::Trace => Self::TRACE,
+            LogLevel::Debug => Self::DEBUG,
+            LogLevel::Info => Self::INFO,
+            LogLevel::Warn => Self::WARN,
+            LogLevel::Error => Self::ERROR,
+        }
+    }
+}
+
+impl From<LogLevel> for tracing::level_filters::LevelFilter {
+    fn from(level: LogLevel) -> Self {
+        <LogLevel as Into<tracing::Level>>::into(level).into()
+    }
+}
+
+impl Default for LogLevel {
+    fn default() -> Self {
+        Self::Info
     }
 }

--- a/compiler/toc_driver/src/main.rs
+++ b/compiler/toc_driver/src/main.rs
@@ -1,7 +1,8 @@
 //! Dummy bin for running the new scanner and parser
 
-use std::{collections::HashMap, env, fs, sync::Arc};
+use std::{collections::HashMap, fs, sync::Arc};
 
+use toc_analysis::db::HirAnalysis;
 use toc_ast_db::{
     db::{AstDatabaseExt, SourceParser, SpanMapping},
     SourceGraph,
@@ -12,10 +13,19 @@ use toc_span::{FileId, Span};
 use toc_vfs::FileLoader;
 use toc_vfs_db::db::FileSystem;
 
+mod config;
+
+// Unrelated FIXMEs:
+// FIXME(toc_hir_lowering): Deal with include globs
+// FIXME: resolve imports between units
+
 fn main() {
+    use clap::Parser;
+
+    let args = config::Args::parse();
+
     let loader = MainFileLoader::default();
-    let str_path: String = env::args().nth(1).expect("Missing path to source file");
-    let path = std::path::Path::new(&str_path);
+    let path = std::path::Path::new(&args.source_file);
     let path = loader.normalize_path(path).unwrap_or_else(|| path.into());
     let output_path = path.with_extension("tbc");
     let mut db = MainDatabase::default();
@@ -29,34 +39,41 @@ fn main() {
     db.set_source_graph(Arc::new(source_graph));
     db.invalidate_source_graph(&loader);
 
-    // Parse root CST & dump output
-    // Note: this is only for temporary parse tree dumping
-    {
-        let parsed = db.parse_file(root_file);
-        let tree = parsed.result();
-        let dependencies = db.parse_depends(root_file);
-        // TODO(toc_ast_db): Add tests for parsing dependencies
+    // Dump requested information
+    if let Some(dump_mode) = args.dump {
+        match dump_mode {
+            config::DumpMode::Ast => {
+                // Show CST + dependencies for the current file
+                let parsed = db.parse_file(root_file);
+                let tree = parsed.result();
+                let dependencies = db.parse_depends(root_file);
 
-        println!("Parsed output: {}", tree.dump_tree());
-        println!("Dependencies: {:#?}", dependencies.result());
+                println!("Parsed output: {}", tree.dump_tree());
+                println!("Dependencies: {:#?}", dependencies.result());
+            }
+            config::DumpMode::Hir => {
+                // Dump library graph
+                println!("Libraries:");
+                let library_graph = db.library_graph();
+
+                for (file, lib) in library_graph.library_roots() {
+                    println!(
+                        "{:?}: {}",
+                        file,
+                        toc_hir_pretty::pretty_print_tree(&db.library(lib))
+                    );
+                }
+            }
+        }
     }
 
-    // TODO(toc_hir_lowering): Deal with include globs
-
-    // Dump library graph
-    println!("Libraries:");
-    let library_graph = db.library_graph();
-
-    for (file, lib) in library_graph.library_roots() {
-        println!(
-            "{:?}: {}",
-            file,
-            toc_hir_pretty::pretty_print_tree(&db.library(lib))
-        );
-    }
-
-    // TODO: resolve imports between units
-    let codegen_res = toc_hir_codegen::generate_code(&db);
+    let codegen_res = if args.lint {
+        // Lint-only mode
+        db.analyze_libraries().map(|_| None)
+    } else {
+        // Do codegen
+        toc_hir_codegen::generate_code(&db)
+    };
 
     // We only need to get the messages for the queries at the end of the chain
     let msgs = codegen_res.messages();


### PR DESCRIPTION
Now with a prettier interface!
Dump mode, report formatting changing (only cli-mode supported right now), and lint-only mode are now available as accessible options