### PR TITLE
Support module visibility lookup and Opaque types

### DIFF
--- a/compiler/toc_analysis/src/ty/db.rs
+++ b/compiler/toc_analysis/src/ty/db.rs
@@ -100,6 +100,12 @@ impl From<InLibrary<ItemId>> for TypeSource {
     }
 }
 
+impl From<(LibraryId, ItemId)> for TypeSource {
+    fn from(id: (LibraryId, ItemId)) -> Self {
+        Self::Item(id.0, id.1)
+    }
+}
+
 impl From<InLibrary<BodyExpr>> for TypeSource {
     fn from(id: InLibrary<BodyExpr>) -> Self {
         Self::BodyExpr(id.0, id.1)
@@ -127,12 +133,6 @@ impl From<(LibraryId, BodyId, ExprId)> for TypeSource {
 impl From<(LibraryId, BodyId)> for TypeSource {
     fn from(id: (LibraryId, BodyId)) -> Self {
         Self::Body(id.0, id.1)
-    }
-}
-
-impl From<(LibraryId, ItemId)> for TypeSource {
-    fn from(id: (LibraryId, ItemId)) -> Self {
-        Self::Item(id.0, id.1)
     }
 }
 

--- a/compiler/toc_analysis/src/ty/lower.rs
+++ b/compiler/toc_analysis/src/ty/lower.rs
@@ -233,7 +233,7 @@ fn type_def_ty(
             .map_or(false, |export| export.is_opaque)
     };
 
-    // Opaque hidden types are equivalent to the peeled alias version
+    // Wrap type inside of an `Opaque`, if required
     let maybe_opaque = |hidden_ty| {
         if is_opaque {
             db.mk_opaque(def_id, hidden_ty)
@@ -442,7 +442,7 @@ fn name_ty(
     body_expr: InLibrary<expr::BodyExpr>,
     expr: &expr::Name,
 ) -> TypeId {
-    // Expected behaviour to leak the hidden type (same as name_ty)
+    // Expected behaviour to leak the hidden type
 
     // If def-id, fetch type from def id map
     // If self, then fetch type from provided class def id?

--- a/compiler/toc_analysis/src/ty/query.rs
+++ b/compiler/toc_analysis/src/ty/query.rs
@@ -46,7 +46,7 @@ fn ty_of_def(db: &dyn db::TypeDatabase, def_id: DefId) -> TypeId {
                 // Refer to the corresponding exported item
                 let library = db.library(def_id.0);
 
-                if let item::ItemKind::Module(module) = &library.item(mod_id.0).kind {
+                if let item::ItemKind::Module(module) = &library.item(mod_id.item_id()).kind {
                     let export_item = module.exports.get(export_id.0).expect("bad export index");
                     let def_id = DefId(def_id.0, library.item(export_item.item_id).def_id);
 
@@ -251,10 +251,10 @@ pub(super) fn value_produced(
                     toc_hir::expr::Name::Name(def_id) => {
                         let def_id = DefId(lib_id, *def_id);
 
-                        if let Some(DefOwner::Export(item_id, export_id)) = db.def_owner(def_id) {
+                        if let Some(DefOwner::Export(mod_id, export_id)) = db.def_owner(def_id) {
                             // Keep track of export mutability
                             let mutability = if let item::ItemKind::Module(item) =
-                                &library.item(item_id.0).kind
+                                &library.item(mod_id.item_id()).kind
                             {
                                 let export =
                                     item.exports.get(export_id.0).expect("bad export index");
@@ -435,10 +435,10 @@ pub(crate) fn find_exported_def(
             match expr {
                 expr::Name::Name(local_def) => {
                     // Take from the def owner
-                    if let Some(DefOwner::Export(item_id, export_id)) =
+                    if let Some(DefOwner::Export(mod_id, export_id)) =
                         db.def_owner(DefId(library_id, *local_def))
                     {
-                        if let item::ItemKind::Module(item) = &library.item(item_id.0).kind {
+                        if let item::ItemKind::Module(item) = &library.item(mod_id.item_id()).kind {
                             let export = item.exports.get(export_id.0).expect("bad export index");
 
                             Some(DefId(library_id, export.def_id))

--- a/compiler/toc_analysis/src/ty/rules.rs
+++ b/compiler/toc_analysis/src/ty/rules.rs
@@ -153,6 +153,10 @@ impl TypeKind {
                 // not one
                 false
             }
+            TypeKind::Opaque(_, _) => {
+                // Considered distinct from its alias type
+                false
+            }
             TypeKind::Forward => {
                 // Forward types are never scalars, since they never represent any type
                 false
@@ -210,6 +214,9 @@ where
 
 // TODO: Document type equivalence
 // steal from the old compiler
+/// Tests if the types are equivalent.
+///
+/// This is a symmetric relation.
 pub fn is_equivalent<T: db::ConstEval + ?Sized>(db: &T, left: TypeId, right: TypeId) -> bool {
     let left = left.in_db(db).to_base_type();
     let right = right.in_db(db).to_base_type();
@@ -322,6 +329,11 @@ pub fn is_equivalent<T: db::ConstEval + ?Sized>(db: &T, left: TypeId, right: Typ
 
                 true
             }
+        }
+        // Opaque types are equivalent to their original alias definition
+        (TypeKind::Opaque(opaque_def, _), TypeKind::Alias(alias_def, _))
+        | (TypeKind::Alias(alias_def, _), TypeKind::Opaque(opaque_def, _)) => {
+            opaque_def == alias_def
         }
         // `void` is equivalent to itself
         (TypeKind::Void, TypeKind::Void) => true,

--- a/compiler/toc_analysis/src/ty/rules.rs
+++ b/compiler/toc_analysis/src/ty/rules.rs
@@ -203,6 +203,34 @@ where
         }
     }
 
+    /// Peels the opaque wrapper into an alias, but only if it would be visible
+    /// from `in_module`. Otherwise, returns itself.
+    pub fn peel_opaque(self, in_module: toc_hir::item::ModuleId) -> Self {
+        match self.kind() {
+            TypeKind::Opaque(def_id, hidden_ty) => {
+                use toc_hir::library::InLibrary;
+
+                let db = self.db;
+
+                let item_of @ InLibrary(library_id, _) =
+                    db.item_of(*def_id).expect("opaque not from type def");
+                let def_module = db.inside_module(item_of.into());
+
+                if db.is_module_ancestor(
+                    InLibrary(library_id, def_module),
+                    InLibrary(library_id, in_module),
+                ) {
+                    // Convert into an alias type
+                    db.mk_alias(*def_id, *hidden_ty).in_db(db)
+                } else {
+                    // Not visible, don't peel
+                    self
+                }
+            }
+            _ => self,
+        }
+    }
+
     /// Transforms the type into its base representation.
     ///
     /// Turns ranges into its common type, and peels aliases.

--- a/compiler/toc_analysis/src/typeck.rs
+++ b/compiler/toc_analysis/src/typeck.rs
@@ -234,6 +234,10 @@ impl TypeCheck<'_> {
         let left = self.db.type_of(def_id.into());
         let right = self.db.type_of((self.library_id, init).into());
 
+        // Peel opaque just for assignability
+        let in_module = self.db.inside_module((self.library_id, id).into());
+        let left = left.in_db(self.db).peel_opaque(in_module).id();
+
         if !ty::rules::is_assignable(self.db, left, right) {
             // Incompatible, report it
             let init_span = self.library.body(init).span.lookup_in(&self.library);
@@ -856,8 +860,13 @@ impl TypeCheck<'_> {
         };
 
         if let Some(hir_ty) = result_ty {
+            // Peel any opaques first
+            let in_module = db.inside_module((self.library_id, hir_ty).into());
             let result_ty = db.from_hir_type(hir_ty.in_library(self.library_id));
-            let result_ty_ref = result_ty.in_db(db).to_base_type();
+            let result_ty_ref = result_ty.in_db(db).peel_opaque(in_module);
+
+            let result_ty = result_ty_ref.id();
+            let result_ty_ref = result_ty_ref.to_base_type();
 
             if matches!(result_ty_ref.kind(), ty::TypeKind::Void) {
                 // Not inside of function
@@ -1122,7 +1131,7 @@ impl TypeCheck<'_> {
 
         match call_kind {
             CallKind::SetCons(elem_ty) => {
-                self.typeck_call_set_cons(lhs_span, arg_list, body, elem_ty);
+                self.typeck_call_set_cons(lhs_expr, lhs_span, arg_list, body, elem_ty);
             }
             CallKind::SubprogramCall => self.typeck_call_subprogram(
                 lhs_tyref,
@@ -1137,6 +1146,7 @@ impl TypeCheck<'_> {
 
     fn typeck_call_set_cons(
         &self,
+        lhs_expr: (LibraryId, body::BodyId, expr::ExprId),
         lhs_span: Span,
         arg_list: Option<&expr::ArgList>,
         body_id: body::BodyId,
@@ -1178,6 +1188,10 @@ impl TypeCheck<'_> {
                     .finish();
             }
         }
+
+        // Peel the elem ty's opaque
+        let in_module = self.db.inside_module(lhs_expr.into());
+        let elem_ty = elem_ty.in_db(self.db).peel_opaque(in_module).id();
 
         // All args must be coercible into the element type
         for arg in arg_list {
@@ -1286,6 +1300,9 @@ impl TypeCheck<'_> {
             }
         }
 
+        // For peeling opaques
+        let in_module = self.db.inside_module(lhs_expr.into());
+
         loop {
             let (param, arg) = match (params.next(), args.next()) {
                 (None, None) => {
@@ -1392,7 +1409,9 @@ impl TypeCheck<'_> {
                     ty::PassBy::Reference(_) => ty::rules::is_coercible_into_param,
                 };
 
-                if !predicate(self.db, param.param_ty, arg_ty) {
+                let param_ty = param.param_ty.in_db(self.db).peel_opaque(in_module).id();
+
+                if !predicate(self.db, param_ty, arg_ty) {
                     self.report_mismatched_param_tys(
                         param.param_ty,
                         arg_ty,
@@ -1511,11 +1530,15 @@ impl TypeCheck<'_> {
         }
     }
 
-    fn typeck_set_ty(&self, _id: toc_hir::ty::TypeId, ty: &toc_hir::ty::Set) {
+    fn typeck_set_ty(&self, id: toc_hir::ty::TypeId, ty: &toc_hir::ty::Set) {
         let db = self.db;
+        let in_module = db.inside_module((self.library_id, id).into());
+
+        // elem tyref should be the visible one
         let elem_tyref = db
             .from_hir_type(ty.elem_ty.in_library(self.library_id))
-            .in_db(db);
+            .in_db(db)
+            .peel_opaque(in_module);
         let span = self
             .library
             .lookup_type(ty.elem_ty)

--- a/compiler/toc_analysis/src/typeck.rs
+++ b/compiler/toc_analysis/src/typeck.rs
@@ -1799,7 +1799,7 @@ impl TypeCheck<'_> {
                     // Likely from an export
                     let exporting_def = self
                         .db
-                        .exporting_def(value_src)
+                        .exporting_def(value_src.into())
                         .expect("at mut storage but rejected it");
                     let exported_library = self.db.library(exporting_def.0);
                     let exported_span = exported_library

--- a/compiler/toc_analysis/src/typeck.rs
+++ b/compiler/toc_analysis/src/typeck.rs
@@ -1041,7 +1041,8 @@ impl TypeCheck<'_> {
             // From an actual expression
             (db.type_of(lhs_expr.into()), false)
         };
-        let lhs_tyref = lhs_ty.in_db(db).to_base_type();
+        let in_module = db.inside_module(lhs_expr.into());
+        let lhs_tyref = lhs_ty.in_db(db).peel_opaque(in_module).to_base_type();
 
         // Bail on error types
         if lhs_tyref.kind().is_error() {

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__equivalence_of_opaques.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__equivalence_of_opaques.snap
@@ -1,0 +1,27 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "module z\n    export unqualified opaque ty, unwrap, make\n\n    type ty : int\n\n    fcn unwrap(t : ty) : int\n        result t\n    end unwrap\n\n    fcn make(i : int) : ty\n        result i\n    end make\nend z\n\n% can't use path syntax since it isn't lowered yet\nvar a, b : ty\nvar c := z.make(1)\n\n% is equivalent to self\na := b\na := c\n\n% to the original alias def\nvar i : int := z.unwrap(a)\n\n% but not the alias type\ni := a\n"
+
+---
+"z"@(FileId(1), 7..8) [Declared]: <error>
+"ty"@(FileId(1), 66..68) [Resolved(Type)]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
+"unwrap"@(FileId(1), 84..90) [Declared]: function ( pass(value) opaque[DefId(LibraryId(0), LocalDefId(1))] type to int, ) -> int
+"<unnamed>"@(dummy) [Declared]: <error>
+"t"@(FileId(1), 91..92) [Declared]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
+"make"@(FileId(1), 146..150) [Declared]: function ( pass(value) int, ) -> opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
+"<unnamed>"@(dummy) [Declared]: <error>
+"i"@(FileId(1), 151..152) [Declared]: int
+"ty"@(FileId(1), 20..41) [ItemExport(LocalDefId(1))]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
+"unwrap"@(FileId(1), 43..49) [ItemExport(LocalDefId(2))]: function ( pass(value) opaque[DefId(LibraryId(0), LocalDefId(1))] type to int, ) -> int
+"make"@(FileId(1), 51..55) [ItemExport(LocalDefId(5))]: function ( pass(value) int, ) -> opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
+"a"@(FileId(1), 257..258) [Declared]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
+"b"@(FileId(1), 260..261) [Declared]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
+"c"@(FileId(1), 271..272) [Declared]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
+"i"@(FileId(1), 358..359) [Declared]: int
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 409..411: mismatched types
+| note in file FileId(1) for 412..413: this is of type `ty (an opaque type)`
+| note in file FileId(1) for 407..408: this is of type `int`
+| info: `ty (an opaque type)` is not assignable into `int`

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_opaque_alias_of_set.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_opaque_alias_of_set.snap
@@ -1,0 +1,23 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "var *_ : boolean\n\nmodule m\n    export opaque s, var a\n    type s : set of boolean\n    var a := s(true)\n    _ := true in a\nend m\n\n% should fail\nvar vs := m.s(false)\n_ := false in m.a\n"
+
+---
+"_"@(FileId(1), 5..6) [Declared]: boolean
+"m"@(FileId(1), 25..26) [Declared]: <error>
+"<anonymous>"@(FileId(1), 67..81) [Declared]: <error>
+"s"@(FileId(1), 63..64) [Resolved(Type)]: opaque[DefId(LibraryId(0), LocalDefId(3))] type to set[DefId(LibraryId(0), LocalDefId(3))] of boolean
+"a"@(FileId(1), 90..91) [Declared]: opaque[DefId(LibraryId(0), LocalDefId(3))] type to set[DefId(LibraryId(0), LocalDefId(3))] of boolean
+"s"@(FileId(1), 38..46) [ItemExport(LocalDefId(3))]: opaque[DefId(LibraryId(0), LocalDefId(3))] type to set[DefId(LibraryId(0), LocalDefId(3))] of boolean
+"a"@(FileId(1), 48..53) [ItemExport(LocalDefId(4))]: opaque[DefId(LibraryId(0), LocalDefId(3))] type to set[DefId(LibraryId(0), LocalDefId(3))] of boolean
+"vs"@(FileId(1), 147..149) [Declared]: <error>
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 153..156: cannot call or subscript `s`
+| note in file FileId(1) for 153..156: this is of type `s (an opaque type)`
+| error in file FileId(1) for 153..156: `s (an opaque type)` is not callable
+error in file FileId(1) at 175..177: mismatched types for `in`
+| note in file FileId(1) for 178..181: this is of type `s (an opaque type)`
+| error in file FileId(1) for 178..181: `s (an opaque type)` is not a set type
+| info: operand must be a set

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_opaque_ty_outside_module.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_opaque_ty_outside_module.snap
@@ -1,0 +1,16 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "module k\n    export opaque ~.* t, f\n\n    type t : int\n\n    fcn f() : t loop end loop end f\nend k\n\nvar a : t\nvar b := k.f()\n% FIXME: uncomment once type paths are lowered\n%var c : k.t\n"
+
+---
+"k"@(FileId(1), 7..8) [Declared]: <error>
+"t"@(FileId(1), 46..47) [Resolved(Type)]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
+"f"@(FileId(1), 63..64) [Declared]: function ( ) -> opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
+"<unnamed>"@(dummy) [Declared]: <error>
+"t"@(FileId(1), 20..32) [ItemExport(LocalDefId(1))]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
+"f"@(FileId(1), 34..35) [ItemExport(LocalDefId(2))]: function ( ) -> opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
+"a"@(FileId(1), 102..103) [Declared]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
+"b"@(FileId(1), 112..113) [Declared]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
+"<root>"@(dummy) [Declared]: <error>
+

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_opaque_ty_poke_opaque_call_no_parens.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_opaque_ty_poke_opaque_call_no_parens.snap
@@ -1,0 +1,19 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "module m\n    export opaque t, f\n    type t : int\n    fcn f : t loop end loop end f\n\n    var a : int := f\nend m\n\n% should fail\nvar b : int := m.f\n"
+
+---
+"m"@(FileId(1), 7..8) [Declared]: <error>
+"t"@(FileId(1), 41..42) [Resolved(Type)]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
+"f"@(FileId(1), 57..58) [Declared]: function -> opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
+"a"@(FileId(1), 92..93) [Declared]: int
+"t"@(FileId(1), 20..28) [ItemExport(LocalDefId(1))]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
+"f"@(FileId(1), 30..31) [ItemExport(LocalDefId(2))]: function -> opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
+"b"@(FileId(1), 130..131) [Declared]: int
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 141..144: mismatched types
+| note in file FileId(1) for 141..144: this is of type `function : t (an opaque type)`
+| note in file FileId(1) for 134..137: this is of type `int`
+| info: `function : t (an opaque type)` is not assignable into `int`

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_opaque_ty_poke_opaque_call_param.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_opaque_ty_poke_opaque_call_param.snap
@@ -1,0 +1,22 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "module m\n    export opaque t, a, p\n    type t : int\n    proc p(a : t) end p\n    var a : t\n\n    % should be coercible\n    m.p(a)\n    m.p(69)\nend m\n\n% should be fine\nvar a := m.a\nm.p(a)\n% shouldn't be fine\nm.p(2)\n"
+
+---
+"m"@(FileId(1), 7..8) [Declared]: <error>
+"t"@(FileId(1), 44..45) [Resolved(Type)]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
+"p"@(FileId(1), 61..62) [Declared]: procedure ( pass(value) opaque[DefId(LibraryId(0), LocalDefId(1))] type to int, ) -> void
+"<unnamed>"@(dummy) [Declared]: <error>
+"a"@(FileId(1), 63..64) [Declared]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
+"a"@(FileId(1), 84..85) [Declared]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
+"t"@(FileId(1), 20..28) [ItemExport(LocalDefId(1))]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
+"a"@(FileId(1), 30..31) [ItemExport(LocalDefId(5))]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
+"p"@(FileId(1), 33..34) [ItemExport(LocalDefId(2))]: procedure ( pass(value) opaque[DefId(LibraryId(0), LocalDefId(1))] type to int, ) -> void
+"a"@(FileId(1), 168..169) [Declared]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 208..209: mismatched types
+| note in file FileId(1) for 208..209: this is of type `{integer}`
+| note in file FileId(1) for 208..209: parameter expects type `t (an opaque type)`
+| info: `{integer}` is not assignable into `t (an opaque type)`

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_opaque_ty_poke_opaque_call_parens.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_opaque_ty_poke_opaque_call_parens.snap
@@ -1,0 +1,20 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "module m\n    export opaque t, f\n    type t : int\n    fcn f() : t loop end loop end f\n\n    var a : int := f()\nend m\n\n% should fail\nvar b : int := m.f()\n"
+
+---
+"m"@(FileId(1), 7..8) [Declared]: <error>
+"t"@(FileId(1), 41..42) [Resolved(Type)]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
+"f"@(FileId(1), 57..58) [Declared]: function ( ) -> opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
+"<unnamed>"@(dummy) [Declared]: <error>
+"a"@(FileId(1), 94..95) [Declared]: int
+"t"@(FileId(1), 20..28) [ItemExport(LocalDefId(1))]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
+"f"@(FileId(1), 30..31) [ItemExport(LocalDefId(2))]: function ( ) -> opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
+"b"@(FileId(1), 134..135) [Declared]: int
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 145..150: mismatched types
+| note in file FileId(1) for 145..150: this is of type `t (an opaque type)`
+| note in file FileId(1) for 138..141: this is of type `int`
+| info: `t (an opaque type)` is not assignable into `int`

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_opaque_ty_poke_opaque_constvar.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_opaque_ty_poke_opaque_constvar.snap
@@ -1,0 +1,18 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "module m\n    export opaque t, ~.* a\n    type t : char\n\n    var a : t := 'c'\nend m\n\n% Hidden type shouldn't be leaked\nvar b := a\nb := 'c'\n"
+
+---
+"m"@(FileId(1), 7..8) [Declared]: <error>
+"t"@(FileId(1), 45..46) [Resolved(Type)]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
+"a"@(FileId(1), 63..64) [Declared]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
+"t"@(FileId(1), 20..28) [ItemExport(LocalDefId(1))]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
+"a"@(FileId(1), 30..35) [ItemExport(LocalDefId(2))]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
+"b"@(FileId(1), 121..122) [Declared]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 130..132: mismatched types
+| note in file FileId(1) for 133..136: this is of type `char`
+| note in file FileId(1) for 128..129: this is of type `t (an opaque type)`
+| info: `char` is not assignable into `t (an opaque type)`

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_opaque_ty_poke_opaque_deref.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_opaque_ty_poke_opaque_deref.snap
@@ -1,0 +1,20 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "module m\n    export opaque t, a\n    type t : int\n    var a : ^t\n    var b : int := ^a\nend m\n\nvar b := m.a\n% should fail\nvar c : int := ^b\n"
+
+---
+"m"@(FileId(1), 7..8) [Declared]: <error>
+"t"@(FileId(1), 41..42) [Resolved(Type)]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
+"a"@(FileId(1), 57..58) [Declared]: pointer to opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
+"b"@(FileId(1), 72..73) [Declared]: int
+"t"@(FileId(1), 20..28) [ItemExport(LocalDefId(1))]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
+"a"@(FileId(1), 30..31) [ItemExport(LocalDefId(2))]: pointer to opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
+"b"@(FileId(1), 97..98) [Declared]: pointer to opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
+"c"@(FileId(1), 124..125) [Declared]: int
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 135..137: mismatched types
+| note in file FileId(1) for 135..137: this is of type `t (an opaque type)`
+| note in file FileId(1) for 128..131: this is of type `int`
+| info: `t (an opaque type)` is not assignable into `int`

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_opaque_ty_poke_opaque_field.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_opaque_ty_poke_opaque_field.snap
@@ -1,0 +1,16 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "module m\n    export opaque t, var a, b\n    type t : int\n\n    var a : t\n    m.a := 2\n    var b := m.a\nend m\n\n% It's fine if `b` leaks the hidden type\nvar c : int := m.b\n"
+
+---
+"m"@(FileId(1), 7..8) [Declared]: <error>
+"t"@(FileId(1), 48..49) [Resolved(Type)]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
+"a"@(FileId(1), 65..66) [Declared]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
+"b"@(FileId(1), 92..93) [Declared]: alias[DefId(LibraryId(0), LocalDefId(1))] of int
+"t"@(FileId(1), 20..28) [ItemExport(LocalDefId(1))]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
+"a"@(FileId(1), 30..35) [ItemExport(LocalDefId(2))]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
+"b"@(FileId(1), 37..38) [ItemExport(LocalDefId(3))]: alias[DefId(LibraryId(0), LocalDefId(1))] of int
+"c"@(FileId(1), 153..154) [Declared]: int
+"<root>"@(dummy) [Declared]: <error>
+

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_opaque_ty_poke_opaque_name.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_opaque_ty_poke_opaque_name.snap
@@ -1,0 +1,16 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "module m\n    export opaque t, a, ~.* b\n    type t : int\n\n    var a : t\n    var b := a\n    a := 2\nend m\n\n% It's fine if `b` leaks the hidden type\nvar c : int := b\n"
+
+---
+"m"@(FileId(1), 7..8) [Declared]: <error>
+"t"@(FileId(1), 48..49) [Resolved(Type)]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
+"a"@(FileId(1), 65..66) [Declared]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
+"b"@(FileId(1), 79..80) [Declared]: alias[DefId(LibraryId(0), LocalDefId(1))] of int
+"t"@(FileId(1), 20..28) [ItemExport(LocalDefId(1))]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
+"a"@(FileId(1), 30..31) [ItemExport(LocalDefId(2))]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
+"b"@(FileId(1), 33..38) [ItemExport(LocalDefId(3))]: alias[DefId(LibraryId(0), LocalDefId(1))] of int
+"c"@(FileId(1), 149..150) [Declared]: int
+"<root>"@(dummy) [Declared]: <error>
+

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_opaque_ty_poke_opaque_result.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_opaque_ty_poke_opaque_result.snap
@@ -1,0 +1,19 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "module m\n    export opaque ~.* t\n    type t : int\n\n    % should be equivalent\n    fcn f() : t result 2 end f\nend m\n\n% should fail\nfcn k() : t result 2 end k\n"
+
+---
+"m"@(FileId(1), 7..8) [Declared]: <error>
+"t"@(FileId(1), 42..43) [Resolved(Type)]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
+"f"@(FileId(1), 86..87) [Declared]: function ( ) -> opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
+"<unnamed>"@(dummy) [Declared]: <error>
+"t"@(FileId(1), 20..32) [ItemExport(LocalDefId(1))]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
+"k"@(FileId(1), 134..135) [Declared]: function ( ) -> opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
+"<unnamed>"@(dummy) [Declared]: <error>
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 149..150: mismatched types
+| note in file FileId(1) for 149..150: this is of type `{integer}`
+| note in file FileId(1) for 140..141: function expects type `t (an opaque type)`
+| info: `{integer}` is not assignable into `t (an opaque type)`

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_opaque_ty_poke_opaque_set_cons_param.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_opaque_ty_poke_opaque_set_cons_param.snap
@@ -1,0 +1,24 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "module m\n    export opaque t, ~.* s, make\n    type t : char\n    type s : set of t\n\n    fcn make(c : char) : t\n        result c\n    end mk\n\n    % both should succeed\n    var a : s := s('6', '9')\n    a := s(make('i'))\nend m\n\n% should fail\nvar vs : s := s('i')\n% should succeed\nvs := s(m.make('i'))\n"
+
+---
+"m"@(FileId(1), 7..8) [Declared]: <error>
+"t"@(FileId(1), 51..52) [Resolved(Type)]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
+"<anonymous>"@(FileId(1), 73..81) [Declared]: <error>
+"s"@(FileId(1), 69..70) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(3))] of opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
+"make"@(FileId(1), 91..95) [Declared]: function ( pass(value) char, ) -> opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
+"<unnamed>"@(dummy) [Declared]: <error>
+"c"@(FileId(1), 96..97) [Declared]: char
+"a"@(FileId(1), 173..174) [Declared]: set[DefId(LibraryId(0), LocalDefId(3))] of opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
+"t"@(FileId(1), 20..28) [ItemExport(LocalDefId(1))]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
+"s"@(FileId(1), 30..35) [ItemExport(LocalDefId(3))]: set[DefId(LibraryId(0), LocalDefId(3))] of opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
+"make"@(FileId(1), 37..41) [ItemExport(LocalDefId(4))]: function ( pass(value) char, ) -> opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
+"vs"@(FileId(1), 241..243) [Declared]: set[DefId(LibraryId(0), LocalDefId(3))] of opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 253..256: mismatched types
+| note in file FileId(1) for 253..256: this is of type `char`
+| note in file FileId(1) for 253..256: parameter expects type `t (an opaque type)`
+| info: `char` is not assignable into `t (an opaque type)`

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_opaque_ty_poke_opaque_set_elem_ty.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_opaque_ty_poke_opaque_set_elem_ty.snap
@@ -1,0 +1,29 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "module m\n    export opaque ~.* t, ~.* s, make\n    type t : char\n    type s : set of t\n    fcn make(c : char) : t result c end make\nend m\n\n% both should fail, is strictly opaque\ntype xs : set of t\nvar vs : s := s('i')\n\n% should succeed\nvar _ : boolean := m.make('i') in vs\n"
+
+---
+"m"@(FileId(1), 7..8) [Declared]: <error>
+"t"@(FileId(1), 55..56) [Resolved(Type)]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
+"<anonymous>"@(FileId(1), 77..85) [Declared]: <error>
+"s"@(FileId(1), 73..74) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(3))] of opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
+"make"@(FileId(1), 94..98) [Declared]: function ( pass(value) char, ) -> opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
+"<unnamed>"@(dummy) [Declared]: <error>
+"c"@(FileId(1), 99..100) [Declared]: char
+"t"@(FileId(1), 20..32) [ItemExport(LocalDefId(1))]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
+"s"@(FileId(1), 34..39) [ItemExport(LocalDefId(3))]: set[DefId(LibraryId(0), LocalDefId(3))] of opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
+"make"@(FileId(1), 41..45) [ItemExport(LocalDefId(4))]: function ( pass(value) char, ) -> opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
+"<anonymous>"@(FileId(1), 187..195) [Declared]: <error>
+"xs"@(FileId(1), 182..184) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(11))] of opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
+"vs"@(FileId(1), 200..202) [Declared]: set[DefId(LibraryId(0), LocalDefId(3))] of opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
+"_"@(FileId(1), 239..240) [Declared]: boolean
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 194..195: mismatched types
+| error in file FileId(1) for 194..195: `t (an opaque type)` is not an index type
+| info: an index type is an integer, a `boolean`, a `char`, an enumerated type, or a range
+error in file FileId(1) at 212..215: mismatched types
+| note in file FileId(1) for 212..215: this is of type `char`
+| note in file FileId(1) for 212..215: parameter expects type `t (an opaque type)`
+| info: `char` is not assignable into `t (an opaque type)`

--- a/compiler/toc_analysis/src/typeck/test.rs
+++ b/compiler/toc_analysis/src/typeck/test.rs
@@ -2421,6 +2421,26 @@ test_named_group! { typeck_opaque_ty,
     ]
 }
 
+test_named_group! { typeck_opaque_alias,
+    [
+        // Sets, records, and unions deal with opaque aliases specially
+        of_set => "
+        var *_ : boolean
+
+        module m
+            export opaque s, var a
+            type s : set of boolean
+            var a := s(true)
+            _ := true in a
+        end m
+
+        % should fail
+        var vs := m.s(false)
+        _ := false in m.a
+        "
+    ]
+}
+
 test_named_group! { typeck_set_ty,
     [
         from_type_alias => "type s : set of boolean var _ : s",

--- a/compiler/toc_analysis/src/typeck/test.rs
+++ b/compiler/toc_analysis/src/typeck/test.rs
@@ -2288,6 +2288,19 @@ test_named_group! { typeck_opaque_ty,
         var b := a
         b := 'c'
         ",
+        poke_opaque_result => "
+        module m
+            export opaque ~.* t
+            type t : int
+
+            % should be equivalent
+            fcn f() : t result 2 end f
+        end m
+
+        % should fail
+        fcn k() : t result 2 end k
+        ",
+        // assignment is also handled by name
         poke_opaque_name => "
         module m
             export opaque t, a, ~.* b
@@ -2295,12 +2308,26 @@ test_named_group! { typeck_opaque_ty,
 
             var a : t
             var b := a
+            a := 2
         end m
 
         % It's fine if `b` leaks the hidden type
-        var b : int := b
+        var c : int := b
         ",
-        // FIXME: add field & arrow pokes once records are lowered
+        poke_opaque_field => "
+        module m
+            export opaque t, var a, b
+            type t : int
+
+            var a : t
+            m.a := 2
+            var b := m.a
+        end m
+
+        % It's fine if `b` leaks the hidden type
+        var c : int := m.b
+        ",
+        // FIXME: add inside arrow poke once records are lowered
         poke_opaque_deref => "
         module m
             export opaque t, a
@@ -2313,7 +2340,84 @@ test_named_group! { typeck_opaque_ty,
         % should fail
         var c : int := ^b
         ",
-        // TODO: add tests for call (result & ingest)
+        poke_opaque_call_parens => "
+        module m
+            export opaque t, f
+            type t : int
+            fcn f() : t loop end loop end f
+
+            var a : int := f()
+        end m
+
+        % should fail
+        var b : int := m.f()
+        ",
+        poke_opaque_call_no_parens => "
+        module m
+            export opaque t, f
+            type t : int
+            fcn f : t loop end loop end f
+
+            var a : int := f
+        end m
+
+        % should fail
+        var b : int := m.f
+        ",
+        poke_opaque_call_param => "
+        module m
+            export opaque t, a, p
+            type t : int
+            proc p(a : t) end p
+            var a : t
+
+            % should be coercible
+            m.p(a)
+            m.p(69)
+        end m
+
+        % should be fine
+        var a := m.a
+        m.p(a)
+        % shouldn't be fine
+        m.p(2)
+        ",
+        poke_opaque_set_cons_param => "
+        module m
+            export opaque t, ~.* s, make
+            type t : char
+            type s : set of t
+
+            fcn make(c : char) : t
+                result c
+            end mk
+
+            % both should succeed
+            var a : s := s('6', '9')
+            a := s(make('i'))
+        end m
+
+        % should fail
+        var vs : s := s('i')
+        % should succeed
+        vs := s(m.make('i'))
+        ",
+
+        poke_opaque_set_elem_ty => "
+        module m
+            export opaque ~.* t, ~.* s, make
+            type t : char
+            type s : set of t
+            fcn make(c : char) : t result c end make
+        end m
+
+        % both should fail, is strictly opaque
+        type xs : set of t
+        var vs : s := s('i')
+
+        % should succeed
+        var _ : boolean := m.make('i') in vs
+        "
     ]
 }
 

--- a/compiler/toc_hir/src/ids.rs
+++ b/compiler/toc_hir/src/ids.rs
@@ -43,6 +43,18 @@ crate::arena_id_wrapper!(
     pub struct ItemId(item::Item);
 );
 
+/// A library local reference to a specific module-like (e.g. [`Module`])
+///
+/// [`Module`]: crate::item::Module
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(transparent)]
+pub struct ModuleId(pub ItemId);
+
+/// A module-local specific reference to a specific export
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(transparent)]
+pub struct ExportId(pub usize);
+
 crate::arena_id_wrapper!(
     /// A library local reference to a body.
     pub struct BodyId(body::Body);

--- a/compiler/toc_hir/src/ids.rs
+++ b/compiler/toc_hir/src/ids.rs
@@ -61,15 +61,22 @@ impl ModuleId {
     /// [`Item`]: crate::item::Item
     /// [`ModuleLike`]: crate::item::ModuleLike
     pub fn new(in_library: &crate::library::Library, item_id: ItemId) -> Self {
-        assert!(
-            matches!(
-                in_library.item(item_id).kind,
-                crate::item::ItemKind::Module(_)
-            ),
-            "only module-likes accepted"
-        );
+        Self::try_new(in_library, item_id).expect("only module-likes accepted")
+    }
 
-        Self(item_id)
+    /// Makes a new [`ModuleId`], returning `None` if it doesn't point to a module-like
+    ///
+    /// [`Item`]: crate::item::Item
+    /// [`ModuleLike`]: crate::item::ModuleLike
+    pub fn try_new(in_library: &crate::library::Library, item_id: ItemId) -> Option<Self> {
+        if !matches!(
+            in_library.item(item_id).kind,
+            crate::item::ItemKind::Module(_)
+        ) {
+            return None;
+        }
+
+        Some(Self(item_id))
     }
 
     pub fn item_id(self) -> ItemId {

--- a/compiler/toc_hir/src/ids.rs
+++ b/compiler/toc_hir/src/ids.rs
@@ -66,7 +66,6 @@ impl ModuleId {
 
     /// Makes a new [`ModuleId`], returning `None` if it doesn't point to a module-like
     ///
-    /// [`Item`]: crate::item::Item
     /// [`ModuleLike`]: crate::item::ModuleLike
     pub fn try_new(in_library: &crate::library::Library, item_id: ItemId) -> Option<Self> {
         if !matches!(
@@ -84,7 +83,7 @@ impl ModuleId {
     }
 }
 
-/// A module-local specific reference to a specific export
+/// A module-local reference to a specific export
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[repr(transparent)]
 pub struct ExportId(pub usize);

--- a/compiler/toc_hir/src/item.rs
+++ b/compiler/toc_hir/src/item.rs
@@ -244,3 +244,30 @@ pub struct FieldInfo {
     /// If this field refers to an opaque type
     pub is_opaque: bool,
 }
+
+/// A module-like item (e.g. a `module`, a `class`, a `monitor`)
+#[derive(Debug, PartialEq, Eq)]
+pub enum ModuleLike<'a> {
+    Module(&'a Module),
+}
+
+/// Represents the module hierarchy, from leaf modules to root modules
+#[derive(Debug, Default, PartialEq, Eq, Clone)]
+pub struct ModuleTree {
+    /// Links up to the module root
+    modules: la_arena::ArenaMap<crate::ids::ItemIndex, ModuleId>,
+}
+
+impl ModuleTree {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn link_modules(&mut self, from: ModuleId, to: ModuleId) {
+        self.modules.insert(to.0 .0, from)
+    }
+
+    pub fn parent_of(&self, module: ModuleId) -> Option<ModuleId> {
+        self.modules.get(module.0 .0).copied()
+    }
+}

--- a/compiler/toc_hir/src/item.rs
+++ b/compiler/toc_hir/src/item.rs
@@ -260,6 +260,12 @@ impl ModuleLike<'_> {
             }
         }
     }
+
+    pub fn exports_of(&self) -> &[ExportItem] {
+        match self {
+            ModuleLike::Module(module) => &module.exports,
+        }
+    }
 }
 
 /// Represents the item hierarchy, from leaf items to root items
@@ -278,10 +284,8 @@ impl ModuleTree {
         self.in_module.insert(to.item_id().0, from)
     }
 
-    pub fn link_declared_items(&mut self, module_id: ModuleId, declares: &[ItemId]) {
-        for item_id in declares {
-            self.in_module.insert(item_id.0, module_id)
-        }
+    pub fn link_declared_item(&mut self, module_id: ModuleId, declares: ItemId) {
+        self.in_module.insert(declares.0, module_id)
     }
 
     /// Gets the parent of this module.

--- a/compiler/toc_hir/src/item.rs
+++ b/compiler/toc_hir/src/item.rs
@@ -9,7 +9,7 @@ use crate::{
     ty,
 };
 
-pub use crate::ids::ItemId;
+pub use crate::ids::{ExportId, ItemId, ModuleId};
 
 /// An entity representing a declaration.
 ///

--- a/compiler/toc_hir/src/item.rs
+++ b/compiler/toc_hir/src/item.rs
@@ -251,6 +251,16 @@ pub enum ModuleLike<'a> {
     Module(&'a Module),
 }
 
+impl ModuleLike<'_> {
+    pub fn export(&self, export_id: ExportId) -> &ExportItem {
+        match self {
+            ModuleLike::Module(module) => {
+                module.exports.get(export_id.0).expect("bad export index")
+            }
+        }
+    }
+}
+
 /// Represents the module hierarchy, from leaf modules to root modules
 #[derive(Debug, Default, PartialEq, Eq, Clone)]
 pub struct ModuleTree {

--- a/compiler/toc_hir/src/library.rs
+++ b/compiler/toc_hir/src/library.rs
@@ -79,6 +79,13 @@ impl Library {
         &self.items[item_id.into()]
     }
 
+    pub fn module_item(&self, module_id: item::ModuleId) -> item::ModuleLike<'_> {
+        match &self.item(module_id.item_id()).kind {
+            item::ItemKind::Module(module) => item::ModuleLike::Module(module),
+            _ => unreachable!("not a module-like"),
+        }
+    }
+
     pub fn local_def(&self, def_id: symbol::LocalDefId) -> &symbol::DefInfo {
         &self.defs[def_id.into()]
     }

--- a/compiler/toc_hir/src/symbol.rs
+++ b/compiler/toc_hir/src/symbol.rs
@@ -8,7 +8,7 @@ use toc_span::SpanId;
 
 pub use crate::ids::{DefId, LocalDefId};
 use crate::{
-    ids::{ItemId, LocalDefIndex},
+    ids::{ExportId, ItemId, LocalDefIndex, ModuleId},
     stmt::BodyStmt,
 };
 
@@ -113,8 +113,8 @@ pub enum DefOwner {
     Item(ItemId),
     /// Parameter on a given `Item`
     ItemParam(ItemId, LocalDefId),
-    /// Export on a given `Item`
-    ItemExport(ItemId, usize),
+    /// Export from a given `Module`
+    Export(ModuleId, ExportId),
     /// Owned by a `Stmt`
     Stmt(BodyStmt),
 }

--- a/compiler/toc_hir/src/ty.rs
+++ b/compiler/toc_hir/src/ty.rs
@@ -16,7 +16,7 @@ pub struct TypeTable {
 }
 
 // FIXME: "Unintern" HIR types
-// They're not actually interned because they have spans attached to them
+// They're not actually interned because they have spans attached to them, effectively making them all unique
 impl TypeTable {
     /// Interns the given type.
     /// Note: not actually interned because of spans.

--- a/compiler/toc_hir_codegen/src/lib.rs
+++ b/compiler/toc_hir_codegen/src/lib.rs
@@ -2402,6 +2402,7 @@ impl BodyCodeGenerator<'_> {
                     .emit_opcode(Opcode::PUSHINT(char_len.try_into().expect("not a u32")));
                 (Opcode::ASNSTR(), Opcode::ASNSTRINV())
             }
+            ty::TypeKind::Opaque(_, ty) => return self.generate_assign(*ty, order), // defer to the opaque type
             ty::TypeKind::Set(..) => unimplemented!(),
             ty::TypeKind::Pointer(..) => unimplemented!(),
             ty::TypeKind::Subprogram(..) => (Opcode::ASNADDR(), Opcode::ASNADDRINV()),
@@ -2467,6 +2468,7 @@ impl BodyCodeGenerator<'_> {
             ty::TypeKind::Char => Opcode::FETCHNAT1(), // chars are equivalent to nat1 on regular Turing backend
             ty::TypeKind::String | ty::TypeKind::StringN(_) => Opcode::FETCHSTR(),
             ty::TypeKind::CharN(_) => return None, // don't need to dereference the pointer to storage
+            ty::TypeKind::Opaque(_, ty) => return self.pick_fetch_op(*ty), // defer to the opaque type
             ty::TypeKind::Set(..) => unimplemented!(),
             ty::TypeKind::Pointer(..) => unimplemented!(),
             ty::TypeKind::Subprogram(..) => Opcode::FETCHADDR(),

--- a/compiler/toc_hir_db/src/db.rs
+++ b/compiler/toc_hir_db/src/db.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use toc_hir::item::ModuleTree;
 use toc_hir::{
     body,
     body::BodyTable,
@@ -33,6 +34,11 @@ pub trait HirDatabase: toc_hir_lowering::LoweringDb {
     #[salsa::invoke(query::collect_body_owners)]
     fn body_owners_of(&self, library: LibraryId) -> Arc<BodyTable>;
 
+    /// Gets the module tree from the library,
+    /// providing a link from child modules to parent modules.
+    #[salsa::invoke(query::collect_module_tree)]
+    fn module_tree_of(&self, library: LibraryId) -> Arc<ModuleTree>;
+
     /// Gets the corresponding [`DefOwner`] to the given [`DefId`]
     ///
     /// This does not perform any form of definition resolution.
@@ -42,6 +48,19 @@ pub trait HirDatabase: toc_hir_lowering::LoweringDb {
     /// Gets the corresponding [`BodyOwner`](body::BodyOwner) to the given [`BodyId`](body::BodyId)
     #[salsa::invoke(query::lookup_body_owner)]
     fn body_owner(&self, body: InLibrary<body::BodyId>) -> Option<body::BodyOwner>;
+
+    /// Gets the parent module of the given module.
+    #[salsa::invoke(query::lookup_module_parent)]
+    fn module_parent(&self, module: InLibrary<item::ModuleId>) -> Option<item::ModuleId>;
+
+    /// Tests if `parent` is an ancestor module of `child`.
+    /// All modules are their own ancestors.
+    #[salsa::invoke(query::is_module_ancestor)]
+    fn is_module_ancestor(
+        &self,
+        parent: InLibrary<item::ModuleId>,
+        child: InLibrary<item::ModuleId>,
+    ) -> bool;
 
     /// Looks up the corresponding item for the given [`DefId`],
     /// or `None` if it doesn't exist.

--- a/compiler/toc_hir_db/src/db.rs
+++ b/compiler/toc_hir_db/src/db.rs
@@ -1,9 +1,9 @@
 use std::sync::Arc;
 
-use toc_hir::item::ModuleTree;
 use toc_hir::{
     body::{self, BodyTable},
-    expr, item,
+    expr,
+    item::{self, ModuleTree},
     library::{InLibrary, LibraryId, LoweredLibrary},
     library_graph::LibraryGraph,
     stmt,

--- a/compiler/toc_hir_db/src/db.rs
+++ b/compiler/toc_hir_db/src/db.rs
@@ -151,6 +151,12 @@ impl From<(LibraryId, expr::BodyExpr)> for InsideModule {
     }
 }
 
+impl From<InLibrary<expr::BodyExpr>> for InsideModule {
+    fn from(InLibrary(library_id, body_expr): InLibrary<expr::BodyExpr>) -> Self {
+        Self::Expr(library_id, body_expr)
+    }
+}
+
 impl From<(LibraryId, body::BodyId, expr::ExprId)> for InsideModule {
     fn from((library_id, body_id, expr_id): (LibraryId, body::BodyId, expr::ExprId)) -> Self {
         Self::Expr(library_id, expr::BodyExpr(body_id, expr_id))

--- a/compiler/toc_hir_db/src/db.rs
+++ b/compiler/toc_hir_db/src/db.rs
@@ -2,12 +2,13 @@ use std::sync::Arc;
 
 use toc_hir::item::ModuleTree;
 use toc_hir::{
-    body,
-    body::BodyTable,
-    item,
+    body::{self, BodyTable},
+    expr, item,
     library::{InLibrary, LibraryId, LoweredLibrary},
     library_graph::LibraryGraph,
+    stmt,
     symbol::{DefId, DefOwner, DefTable},
+    ty::{self, TypeOwners},
 };
 use toc_salsa::salsa;
 
@@ -34,6 +35,11 @@ pub trait HirDatabase: toc_hir_lowering::LoweringDb {
     #[salsa::invoke(query::collect_body_owners)]
     fn body_owners_of(&self, library: LibraryId) -> Arc<BodyTable>;
 
+    /// Gets all of the type owners in the library,
+    /// providing a link between types and type owners.
+    #[salsa::invoke(query::collect_type_owners)]
+    fn type_owners_of(&self, library: LibraryId) -> Arc<TypeOwners>;
+
     /// Gets the module tree from the library,
     /// providing a link from child modules to parent modules.
     #[salsa::invoke(query::collect_module_tree)]
@@ -45,9 +51,14 @@ pub trait HirDatabase: toc_hir_lowering::LoweringDb {
     #[salsa::invoke(query::lookup_def_owner)]
     fn def_owner(&self, def_id: DefId) -> Option<DefOwner>;
 
+    // FIXME: Make body_owner lookup infallible
     /// Gets the corresponding [`BodyOwner`](body::BodyOwner) to the given [`BodyId`](body::BodyId)
     #[salsa::invoke(query::lookup_body_owner)]
     fn body_owner(&self, body: InLibrary<body::BodyId>) -> Option<body::BodyOwner>;
+
+    /// Gets the corresponding [`TypeOwner`](ty::TypeOwner) for the given [`TypeId`](ty::TypeId)
+    #[salsa::invoke(query::lookup_type_owner)]
+    fn type_owner(&self, ty: InLibrary<ty::TypeId>) -> ty::TypeOwner;
 
     /// Gets the parent module of the given module.
     #[salsa::invoke(query::lookup_module_parent)]
@@ -61,6 +72,10 @@ pub trait HirDatabase: toc_hir_lowering::LoweringDb {
         parent: InLibrary<item::ModuleId>,
         child: InLibrary<item::ModuleId>,
     ) -> bool;
+
+    /// Looks up which module the given HIR node is in
+    #[salsa::invoke(query::lookup_inside_module)]
+    fn inside_module(&self, inside_mod: InsideModule) -> item::ModuleId;
 
     /// Looks up the corresponding item for the given [`DefId`],
     /// or `None` if it doesn't exist.
@@ -77,4 +92,79 @@ pub trait HirDatabase: toc_hir_lowering::LoweringDb {
     /// or itself if it is one.
     #[salsa::invoke(query::resolve_def)]
     fn resolve_def(&self, def_id: DefId) -> DefId;
+}
+
+/// Any HIR node that can uniquely be inside of a module
+///
+/// ## Note
+///
+/// [`DefId`]s can't be uniquely inside of a module as undeclared don't have a
+/// declaration that pins them to a specific module.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum InsideModule {
+    Item(LibraryId, item::ItemId),
+    Type(LibraryId, ty::TypeId),
+    Body(LibraryId, body::BodyId),
+    Stmt(LibraryId, stmt::BodyStmt),
+    Expr(LibraryId, expr::BodyExpr),
+}
+
+impl From<(LibraryId, item::ItemId)> for InsideModule {
+    fn from((library_id, item_id): (LibraryId, item::ItemId)) -> Self {
+        Self::Item(library_id, item_id)
+    }
+}
+
+impl From<InLibrary<item::ItemId>> for InsideModule {
+    fn from(InLibrary(library_id, item_id): InLibrary<item::ItemId>) -> Self {
+        Self::Item(library_id, item_id)
+    }
+}
+
+impl From<(LibraryId, ty::TypeId)> for InsideModule {
+    fn from((library_id, type_id): (LibraryId, ty::TypeId)) -> Self {
+        Self::Type(library_id, type_id)
+    }
+}
+
+impl From<InLibrary<ty::TypeId>> for InsideModule {
+    fn from(InLibrary(library_id, type_id): InLibrary<ty::TypeId>) -> Self {
+        Self::Type(library_id, type_id)
+    }
+}
+
+impl From<(LibraryId, body::BodyId)> for InsideModule {
+    fn from((library_id, body_id): (LibraryId, body::BodyId)) -> Self {
+        Self::Body(library_id, body_id)
+    }
+}
+
+impl From<InLibrary<body::BodyId>> for InsideModule {
+    fn from(InLibrary(library_id, body_id): InLibrary<body::BodyId>) -> Self {
+        Self::Body(library_id, body_id)
+    }
+}
+
+impl From<(LibraryId, expr::BodyExpr)> for InsideModule {
+    fn from((library_id, body_expr): (LibraryId, expr::BodyExpr)) -> Self {
+        Self::Expr(library_id, body_expr)
+    }
+}
+
+impl From<(LibraryId, body::BodyId, expr::ExprId)> for InsideModule {
+    fn from((library_id, body_id, expr_id): (LibraryId, body::BodyId, expr::ExprId)) -> Self {
+        Self::Expr(library_id, expr::BodyExpr(body_id, expr_id))
+    }
+}
+
+impl From<(LibraryId, stmt::BodyStmt)> for InsideModule {
+    fn from((library_id, body_stmt): (LibraryId, stmt::BodyStmt)) -> Self {
+        Self::Stmt(library_id, body_stmt)
+    }
+}
+
+impl From<(LibraryId, body::BodyId, stmt::StmtId)> for InsideModule {
+    fn from((library_id, body_id, stmt_id): (LibraryId, body::BodyId, stmt::StmtId)) -> Self {
+        Self::Stmt(library_id, stmt::BodyStmt(body_id, stmt_id))
+    }
 }

--- a/compiler/toc_hir_db/src/query.rs
+++ b/compiler/toc_hir_db/src/query.rs
@@ -90,11 +90,11 @@ pub(crate) fn resolve_def(db: &dyn HirDatabase, def_id: DefId) -> DefId {
 
     // Poke through item exports
     match def_owner {
-        DefOwner::ItemExport(item_id, export_idx) => {
+        DefOwner::Export(mod_id, export_id) => {
             let library = db.library(def_id.0);
 
-            if let item::ItemKind::Module(module) = &library.item(item_id).kind {
-                let export = module.exports.get(export_idx).expect("bad export index");
+            if let item::ItemKind::Module(module) = &library.item(mod_id.0).kind {
+                let export = module.exports.get(export_id.0).expect("bad export index");
                 let exported_item = library.item(export.item_id);
                 DefId(def_id.0, exported_item.def_id)
             } else {
@@ -126,7 +126,10 @@ impl HirVisitor for DefCollector<'_> {
     fn visit_module(&self, id: item::ItemId, item: &item::Module) {
         // Add all exports as being owned by this one
         for (idx, export) in item.exports.iter().enumerate() {
-            self.add_owner(export.def_id, DefOwner::ItemExport(id, idx));
+            self.add_owner(
+                export.def_id,
+                DefOwner::Export(item::ModuleId(id), item::ExportId(idx)),
+            );
         }
     }
 

--- a/compiler/toc_hir_db/src/query.rs
+++ b/compiler/toc_hir_db/src/query.rs
@@ -2,20 +2,19 @@
 
 use std::{cell::RefCell, sync::Arc};
 
-use toc_hir::item::{ModuleId, ModuleTree};
 use toc_hir::{
-    body,
-    body::{BodyOwner, BodyTable},
-    item,
+    body::{self, BodyOwner, BodyTable},
+    expr,
+    item::{self, ModuleId, ModuleTree},
     library::{InLibrary, Library, LibraryId, LoweredLibrary},
     library_graph::LibraryGraph,
     stmt,
     symbol::{DefId, DefOwner, DefTable, LocalDefId, SymbolKind},
-    ty,
+    ty::{self, TypeOwner, TypeOwners},
     visitor::HirVisitor,
 };
 
-use crate::db::HirDatabase;
+use crate::db::{HirDatabase, InsideModule};
 
 pub fn library_query(db: &dyn HirDatabase, library: LibraryId) -> LoweredLibrary {
     let file = db.library_graph().file_of(library);
@@ -50,7 +49,7 @@ pub fn collect_body_owners(db: &dyn HirDatabase, library_id: LibraryId) -> Arc<B
 
     let library = db.library(library_id);
 
-    // Collect definitions
+    // Collect bodies
     let body_collector = BodyCollector {
         body_table: Default::default(),
         _library: &library,
@@ -67,6 +66,24 @@ pub fn lookup_body_owner(
     db.body_owners_of(body_id.0).get_owner(body_id.1)
 }
 
+pub(crate) fn collect_type_owners(db: &dyn HirDatabase, library_id: LibraryId) -> Arc<TypeOwners> {
+    use toc_hir::visitor::Walker;
+
+    let library = db.library(library_id);
+
+    // Collect types
+    let type_collector = TypeCollector {
+        type_table: Default::default(),
+    };
+    Walker::from_library(&library).visit_preorder(&type_collector);
+
+    Arc::new(type_collector.type_table.into_inner())
+}
+
+pub(crate) fn lookup_type_owner(db: &dyn HirDatabase, ty: InLibrary<ty::TypeId>) -> TypeOwner {
+    db.type_owners_of(ty.0).lookup_owner(ty.1)
+}
+
 pub(crate) fn collect_module_tree(db: &dyn HirDatabase, library: LibraryId) -> Arc<ModuleTree> {
     use toc_hir::visitor::{WalkEvent, WalkNode, Walker};
 
@@ -79,13 +96,15 @@ pub(crate) fn collect_module_tree(db: &dyn HirDatabase, library: LibraryId) -> A
     while let Some(event) = walker.next_event() {
         match event {
             WalkEvent::Enter(WalkNode::Item(item_id, item)) => {
-                if let item::ItemKind::Module(_) = &item.kind {
+                if let item::ItemKind::Module(module) = &item.kind {
                     let child_mod = ModuleId::new(&library, item_id);
 
                     // Link to parent
                     if let Some(&parent_mod) = module_path.last() {
                         module_tree.link_modules(parent_mod, child_mod);
                     }
+
+                    module_tree.link_declared_items(child_mod, &module.declares);
 
                     // Add to path
                     module_path.push(child_mod);
@@ -137,6 +156,44 @@ pub(crate) fn is_module_ancestor(
         module_tree.parent_of(*id)
     })
     .any(|mod_id| mod_id == parent.1)
+}
+
+pub(crate) fn lookup_inside_module(
+    db: &dyn HirDatabase,
+    inside_module: InsideModule,
+) -> item::ModuleId {
+    let inside_module = match inside_module {
+        InsideModule::Item(library_id, item_id) => {
+            return db
+                .module_tree_of(library_id)
+                .module_of(item_id)
+                .expect("root items aren't in any modules")
+        }
+        InsideModule::Type(library_id, type_id) => {
+            let owner = db.type_owner(InLibrary(library_id, type_id));
+
+            match owner {
+                TypeOwner::Item(item_id) => (library_id, item_id).into(),
+                TypeOwner::Type(type_id) => (library_id, type_id).into(),
+            }
+        }
+        InsideModule::Body(library_id, body_id) => {
+            let owner = db
+                .body_owner(InLibrary(library_id, body_id))
+                .expect("missing owner");
+
+            match owner {
+                BodyOwner::Item(item_id) => (library_id, item_id).into(),
+                BodyOwner::Type(type_id) => (library_id, type_id).into(),
+            }
+        }
+        InsideModule::Stmt(library_id, stmt::BodyStmt(body_id, _))
+        | InsideModule::Expr(library_id, expr::BodyExpr(body_id, _)) => {
+            (library_id, body_id).into()
+        }
+    };
+
+    db.inside_module(inside_module)
 }
 
 pub fn lookup_item(db: &dyn HirDatabase, def_id: DefId) -> Option<InLibrary<item::ItemId>> {
@@ -272,5 +329,58 @@ impl HirVisitor for BodyCollector<'_> {
             }
             _ => (),
         }
+    }
+}
+
+/// Library-local type owner collector
+struct TypeCollector {
+    type_table: RefCell<TypeOwners>,
+}
+
+impl TypeCollector {
+    fn add_owner(&self, type_id: ty::TypeId, owner: TypeOwner) {
+        self.type_table.borrow_mut().add_owner(type_id, owner);
+    }
+}
+
+impl HirVisitor for TypeCollector {
+    fn visit_constvar(&self, id: item::ItemId, item: &item::ConstVar) {
+        if let Some(ty_spec) = item.type_spec {
+            self.add_owner(ty_spec, TypeOwner::Item(id));
+        }
+    }
+
+    fn visit_type_decl(&self, id: item::ItemId, item: &item::Type) {
+        if let item::DefinedType::Alias(ty_id) = item.type_def {
+            self.add_owner(ty_id, TypeOwner::Item(id));
+        }
+    }
+
+    fn visit_subprogram_decl(&self, id: item::ItemId, item: &item::Subprogram) {
+        if let Some(param_list) = &item.param_list {
+            for param in &param_list.tys {
+                self.add_owner(param.param_ty, TypeOwner::Item(id));
+            }
+        }
+
+        self.add_owner(item.result.ty, TypeOwner::Item(id));
+    }
+
+    fn visit_set(&self, id: ty::TypeId, ty: &ty::Set) {
+        self.add_owner(ty.elem_ty, TypeOwner::Type(id));
+    }
+
+    fn visit_pointer(&self, id: ty::TypeId, ty: &ty::Pointer) {
+        self.add_owner(ty.ty, TypeOwner::Type(id));
+    }
+
+    fn visit_subprogram_ty(&self, id: ty::TypeId, ty: &ty::Subprogram) {
+        if let Some(param_list) = &ty.param_list {
+            for param in param_list {
+                self.add_owner(param.param_ty, TypeOwner::Type(id));
+            }
+        }
+
+        self.add_owner(ty.result_ty, TypeOwner::Type(id));
     }
 }

--- a/compiler/toc_hir_db/src/query.rs
+++ b/compiler/toc_hir_db/src/query.rs
@@ -166,13 +166,12 @@ pub(crate) fn resolve_def(db: &dyn HirDatabase, def_id: DefId) -> DefId {
         DefOwner::Export(mod_id, export_id) => {
             let library = db.library(def_id.0);
 
-            if let item::ItemKind::Module(module) = &library.item(mod_id.item_id()).kind {
-                let export = module.exports.get(export_id.0).expect("bad export index");
-                let exported_item = library.item(export.item_id);
-                DefId(def_id.0, exported_item.def_id)
-            } else {
-                unreachable!("item not module-like");
-            }
+            // Get associated item
+            let module = library.module_item(mod_id);
+            let export = module.export(export_id);
+            let exported_item = library.item(export.item_id);
+
+            DefId(def_id.0, exported_item.def_id)
         }
         // Already the canonical definition
         _ => def_id,


### PR DESCRIPTION
Supporting the type-hiding of opaque types required also knowing the module/item tree, as it's supposed to be a distinct outside of the defining module