### PR TITLE
Support enums types

### DIFF
--- a/compiler/toc_analysis/src/ty.rs
+++ b/compiler/toc_analysis/src/ty.rs
@@ -178,6 +178,14 @@ pub enum WithDef {
     Anonymous(DefId),
 }
 
+impl WithDef {
+    pub fn def_id(self) -> DefId {
+        match self {
+            WithDef::Named(def_id) | WithDef::Anonymous(def_id) => def_id,
+        }
+    }
+}
+
 /// Pointer checkedness
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Checked {

--- a/compiler/toc_analysis/src/ty.rs
+++ b/compiler/toc_analysis/src/ty.rs
@@ -74,6 +74,8 @@ pub enum TypeKind {
     /// An alias exported as an opaque type. Points to the base (un-aliased) alias,
     /// with the [`DefId`] pointing to the original alias.
     Opaque(DefId, TypeId),
+    /// An enumeration type, with associated definition point and variants.
+    Enum(WithDef, Vec<DefId>),
     /// Set type, with associated definition point
     Set(WithDef, TypeId),
     /// Set type, with a given checkedness
@@ -267,6 +269,7 @@ where
             TypeKind::StringN(_) => 1,
             TypeKind::Subprogram(..) => POINTER_ALIGNMENT,
             TypeKind::Void => return None,
+            TypeKind::Enum(..) => 4, // ???: Alignment based on user-specified size?
             TypeKind::Set(..) => 2,
             TypeKind::Pointer(_, _) => POINTER_ALIGNMENT,
             // Defer to the aliased type
@@ -314,6 +317,7 @@ where
             }
             TypeKind::Subprogram(..) => POINTER_SIZE,
             TypeKind::Void => return None,
+            TypeKind::Enum(..) => 4, // FIXME: Have size be based on a user-specified size
             TypeKind::Set(_, _elem_ty) => return None, // FIXME: Compute size of sets
             TypeKind::Pointer(Checked::Checked, _) => POINTER_SIZE * 2, // address + metadata
             TypeKind::Pointer(Checked::Unchecked, _) => POINTER_SIZE, // address only

--- a/compiler/toc_analysis/src/ty/db.rs
+++ b/compiler/toc_analysis/src/ty/db.rs
@@ -69,6 +69,7 @@ pub trait TypeInternExt {
     fn mk_alias(&self, def_id: DefId, base_ty: ty::TypeId) -> ty::TypeId;
     fn mk_opaque(&self, def_id: DefId, base_ty: ty::TypeId) -> ty::TypeId;
     fn mk_forward(&self) -> ty::TypeId;
+    fn mk_enum(&self, with_def: ty::WithDef, variants: Vec<DefId>) -> ty::TypeId;
     fn mk_set(&self, with_def: ty::WithDef, elem_ty: ty::TypeId) -> ty::TypeId;
     fn mk_pointer(&self, checked: ty::Checked, target_ty: ty::TypeId) -> ty::TypeId;
     fn mk_subprogram(

--- a/compiler/toc_analysis/src/ty/lower.rs
+++ b/compiler/toc_analysis/src/ty/lower.rs
@@ -355,6 +355,20 @@ pub(crate) fn ty_from_item_param(
     require_resolved_hir_type(db, hir_ty.in_library(library_id))
 }
 
+pub(crate) fn ty_from_ty_field(
+    db: &dyn TypeDatabase,
+    type_id: InLibrary<hir_ty::TypeId>,
+    _field_id: hir_ty::FieldId,
+) -> TypeId {
+    let ty_ref = db.from_hir_type(type_id).in_db(db);
+
+    match ty_ref.kind() {
+        // Enum fields are the same type as the original enum
+        TypeKind::Enum(..) => ty_ref.id(),
+        _ => unreachable!("missing field"),
+    }
+}
+
 pub(crate) fn ty_from_stmt(db: &dyn TypeDatabase, stmt_id: InLibrary<stmt::BodyStmt>) -> TypeId {
     let library_id = stmt_id.0;
     let stmt_id = stmt_id.1;

--- a/compiler/toc_analysis/src/ty/lower.rs
+++ b/compiler/toc_analysis/src/ty/lower.rs
@@ -286,12 +286,14 @@ fn type_def_ty(
             match base_ty.kind() {
                 // Forward base types get propagated as errors, since we require a resolved definition
                 ty::TypeKind::Forward => db.mk_error(),
-                // Associate anonymous types with the def of the alias (equivalent behaviour)
-                ty::TypeKind::Set(ty::WithDef::Anonymous(_), elem_ty) => {
-                    maybe_opaque(db.mk_set(ty::WithDef::Named(def_id), *elem_ty))
+                // Make anonymous types not anonymous anymore
+                // They don't need to be wrapped in an alias, since that would result in
+                // "`<name>` (alias of `<name>`)" during display
+                ty::TypeKind::Set(ty::WithDef::Anonymous(def_id), elem_ty) => {
+                    maybe_opaque(db.mk_set(ty::WithDef::Named(*def_id), *elem_ty))
                 }
-                ty::TypeKind::Enum(ty::WithDef::Anonymous(_), variants) => {
-                    maybe_opaque(db.mk_enum(ty::WithDef::Named(def_id), variants.clone()))
+                ty::TypeKind::Enum(ty::WithDef::Anonymous(def_id), variants) => {
+                    maybe_opaque(db.mk_enum(ty::WithDef::Named(*def_id), variants.clone()))
                 }
                 _ if is_opaque => db.mk_opaque(def_id, base_ty.id()),
                 _ => db.mk_alias(def_id, base_ty.id()),

--- a/compiler/toc_analysis/src/ty/lower.rs
+++ b/compiler/toc_analysis/src/ty/lower.rs
@@ -27,6 +27,7 @@ pub(crate) fn ty_from_hir_ty(db: &dyn TypeDatabase, hir_id: InLibrary<hir_ty::Ty
         hir_ty::TypeKind::Missing => db.mk_error(),
         hir_ty::TypeKind::Primitive(ty) => primitive_ty(db, hir_id, ty),
         hir_ty::TypeKind::Alias(ty) => alias_ty(db, hir_id, ty),
+        hir_ty::TypeKind::Enum(_) => db.mk_error(),
         hir_ty::TypeKind::Set(ty) => set_ty(db, hir_id, ty),
         hir_ty::TypeKind::Pointer(ty) => pointer_ty(db, hir_id, ty),
         hir_ty::TypeKind::Subprogram(ty) => subprogram_ty(db, hir_id, ty),

--- a/compiler/toc_analysis/src/ty/query.rs
+++ b/compiler/toc_analysis/src/ty/query.rs
@@ -593,6 +593,15 @@ where
         )
     }
 
+    fn mk_enum(&self, with_def: WithDef, variants: Vec<DefId>) -> TypeId {
+        self.intern_type(
+            Type {
+                kind: TypeKind::Enum(with_def, variants),
+            }
+            .into(),
+        )
+    }
+
     fn mk_set(&self, with_def: WithDef, elem_ty: TypeId) -> TypeId {
         self.intern_type(
             Type {

--- a/compiler/toc_analysis/src/ty/query.rs
+++ b/compiler/toc_analysis/src/ty/query.rs
@@ -451,7 +451,6 @@ pub(crate) fn fields_of(
                 BindingTo::Storage(_) | BindingTo::Register(_) => {
                     // To some storage
                     // Get fields based off of the type
-                    eprintln!("fields of {binding_to:?} ({lib_id:?}, {body_expr:?})");
 
                     // Defer to the corresponding type
                     let ty_id = db.type_of((lib_id, body_expr).into());

--- a/compiler/toc_analysis/src/ty/rules.rs
+++ b/compiler/toc_analysis/src/ty/rules.rs
@@ -224,9 +224,9 @@ where
                     let hidden_tyref = hidden_ty.in_db(db);
 
                     match hidden_tyref.kind() {
-                        // Sets, records, and unions don't need an alias
+                        // Enums, sets, records, and unions don't need an alias
                         // FIXME: add special cases for records and unions once lowered
-                        TypeKind::Set(..) => hidden_tyref,
+                        TypeKind::Enum(..) | TypeKind::Set(..) => hidden_tyref,
                         TypeKind::Alias(..) => unreachable!("found alias wrapped in opaque"),
                         _ => db.mk_alias(*def_id, *hidden_ty).in_db(db),
                     }

--- a/compiler/toc_analysis/src/ty/rules.rs
+++ b/compiler/toc_analysis/src/ty/rules.rs
@@ -139,11 +139,11 @@ impl TypeKind {
             | TypeKind::Real(_)
             | TypeKind::Integer
             | TypeKind::Char
-            | TypeKind::Pointer(_, _)
+            | TypeKind::Enum(..)
+            | TypeKind::Pointer(..)
             | TypeKind::Subprogram(..) => true,
             // Missing scalars:
             // - subrange
-            // - enum
             TypeKind::String | TypeKind::CharN(_) | TypeKind::StringN(_) => {
                 // Aggregate types of characters
                 false

--- a/compiler/toc_analysis/src/ty/rules.rs
+++ b/compiler/toc_analysis/src/ty/rules.rs
@@ -301,8 +301,17 @@ pub fn is_equivalent<T: db::ConstEval + ?Sized>(db: &T, left: TypeId, right: Typ
             // sized charseqs are treated as equivalent types if the sizes are equal
             left_sz.cmp(right_sz).is_eq()
         }
-        // Set types are equivalent if they come from the same definition
-        (TypeKind::Set(left_def, _), TypeKind::Set(right_def, _)) => left_def == right_def,
+
+        // The following types are equivalent to the other type if they both come from the same definition:
+        // - Enum
+        // - Set
+        // x Record
+        // x Union
+        (TypeKind::Enum(left_def, _), TypeKind::Enum(right_def, _))
+        | (TypeKind::Set(left_def, _), TypeKind::Set(right_def, _)) => {
+            left_def.def_id() == right_def.def_id()
+        }
+
         // Pointer types are equivalent if they have the same checkedness and equivalent target types
         (TypeKind::Pointer(left_chk, left_to), TypeKind::Pointer(right_chk, right_to)) => {
             left_chk == right_chk && is_equivalent(db, *left_to, *right_to)

--- a/compiler/toc_analysis/src/ty/rules.rs
+++ b/compiler/toc_analysis/src/ty/rules.rs
@@ -46,7 +46,11 @@ impl TypeKind {
     }
 
     pub fn is_alias(&self) -> bool {
-        matches!(self, TypeKind::Alias(_, _))
+        matches!(self, TypeKind::Alias(..))
+    }
+
+    pub fn is_enum(&self) -> bool {
+        matches!(self, TypeKind::Enum(..))
     }
 
     pub fn is_set(&self) -> bool {
@@ -98,7 +102,11 @@ impl TypeKind {
 
     /// index types includes all integer types, `Char`, `Boolean`, `Enum`, and `Range` types
     pub fn is_index(&self) -> bool {
-        self.is_integer() || matches!(self, TypeKind::Char | TypeKind::Boolean)
+        self.is_integer()
+            || matches!(
+                self,
+                TypeKind::Char | TypeKind::Boolean | TypeKind::Enum(..)
+            )
     }
 
     /// If the type can be printed in a `put` stmt
@@ -114,7 +122,6 @@ impl TypeKind {
     /// - Boolean
     /// - Enum
     pub fn is_printable(&self) -> bool {
-        // missing: Enum
         matches!(
             self,
             TypeKind::Boolean
@@ -126,6 +133,7 @@ impl TypeKind {
                 | TypeKind::CharN(_)
                 | TypeKind::String
                 | TypeKind::StringN(_)
+                | TypeKind::Enum(..)
         )
     }
 
@@ -1078,7 +1086,7 @@ pub fn check_binary_op<T: ?Sized + db::ConstEval>(
             // Operations:
             // - Numeric compare (number, number => boolean)
             // - Charseq compare (charseq, charseq => boolean)
-            // x Enum compare (enum, enum => boolean)
+            // - Enum compare (enum, enum => boolean)
             // - Set sub/supersets (set, set => boolean)
             // x Class hierarchy (class, class => boolean)
 
@@ -1087,8 +1095,17 @@ pub fn check_binary_op<T: ?Sized + db::ConstEval>(
                 (lhs, rhs) if lhs.is_number() && rhs.is_number() => Ok(()),
                 // Charseqs that can be coerced to a sized type are comparable
                 (lhs, rhs) if lhs.is_cmp_charseq() && rhs.is_cmp_charseq() => Ok(()),
-                // Sets that are equivalent are comparable
-                (lhs, _) if is_equivalent(db, left.id(), right.id()) && lhs.is_set() => Ok(()),
+                // Types that are equivalent may be compared
+                (lhs, _) if is_equivalent(db, left.id(), right.id()) => {
+                    // This only applies to the following types:
+                    // - Sets
+                    // - Enums
+                    if lhs.is_set() || lhs.is_enum() {
+                        Ok(())
+                    } else {
+                        mk_type_error()
+                    }
+                }
                 // All other types aren't comparable
                 _ => mk_type_error(),
             }
@@ -1117,11 +1134,12 @@ pub fn check_binary_op<T: ?Sized + db::ConstEval>(
                         mk_type_error()
                     }
                 }
+                // Types that are equivalent may be tested for equality
                 (lhs, _) if is_equivalent(db, left.id(), right.id()) => {
-                    // If they are equivalent and are the following types:
+                    // This only applies to the following types:
                     // - Sets
+                    // - Enums
                     // - Pointers
-                    // They can be tested for equality
                     if lhs.is_set() || lhs.is_pointer() {
                         Ok(())
                     } else {

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_enums_equal.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_enums_equal.snap
@@ -1,0 +1,14 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "\n    type s : enum(a)\n    var a, b : s\n\n    % should all produce booleans\n    var _v_res : boolean\n\n    _v_res := a = b\n    _v_res := b = a\n    % enum variants are covered by equivalence rules\n    "
+
+---
+"a"@(FileId(1), 19..20) [Declared]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "a"@(FileId(1), 19..20), )
+"s"@(FileId(1), 14..21) [Declared]: <error>
+"s"@(FileId(1), 10..11) [Resolved(Type)]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "a"@(FileId(1), 19..20), )
+"a"@(FileId(1), 30..31) [Declared]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "a"@(FileId(1), 19..20), )
+"b"@(FileId(1), 33..34) [Declared]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "a"@(FileId(1), 19..20), )
+"_v_res"@(FileId(1), 82..88) [Declared]: boolean
+"<root>"@(dummy) [Declared]: <error>
+

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_enums_greater.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_enums_greater.snap
@@ -1,0 +1,14 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "\n    type s : enum(a)\n    var a, b : s\n\n    % should all produce booleans\n    var _v_res : boolean\n\n    _v_res := a > b\n    _v_res := b > a\n    % enum variants are covered by equivalence rules\n    "
+
+---
+"a"@(FileId(1), 19..20) [Declared]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "a"@(FileId(1), 19..20), )
+"s"@(FileId(1), 14..21) [Declared]: <error>
+"s"@(FileId(1), 10..11) [Resolved(Type)]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "a"@(FileId(1), 19..20), )
+"a"@(FileId(1), 30..31) [Declared]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "a"@(FileId(1), 19..20), )
+"b"@(FileId(1), 33..34) [Declared]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "a"@(FileId(1), 19..20), )
+"_v_res"@(FileId(1), 82..88) [Declared]: boolean
+"<root>"@(dummy) [Declared]: <error>
+

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_enums_greater_eq.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_enums_greater_eq.snap
@@ -1,0 +1,14 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "\n    type s : enum(a)\n    var a, b : s\n\n    % should all produce booleans\n    var _v_res : boolean\n\n    _v_res := a >= b\n    _v_res := b >= a\n    % enum variants are covered by equivalence rules\n    "
+
+---
+"a"@(FileId(1), 19..20) [Declared]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "a"@(FileId(1), 19..20), )
+"s"@(FileId(1), 14..21) [Declared]: <error>
+"s"@(FileId(1), 10..11) [Resolved(Type)]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "a"@(FileId(1), 19..20), )
+"a"@(FileId(1), 30..31) [Declared]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "a"@(FileId(1), 19..20), )
+"b"@(FileId(1), 33..34) [Declared]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "a"@(FileId(1), 19..20), )
+"_v_res"@(FileId(1), 82..88) [Declared]: boolean
+"<root>"@(dummy) [Declared]: <error>
+

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_enums_less.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_enums_less.snap
@@ -1,0 +1,14 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "\n    type s : enum(a)\n    var a, b : s\n\n    % should all produce booleans\n    var _v_res : boolean\n\n    _v_res := a < b\n    _v_res := b < a\n    % enum variants are covered by equivalence rules\n    "
+
+---
+"a"@(FileId(1), 19..20) [Declared]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "a"@(FileId(1), 19..20), )
+"s"@(FileId(1), 14..21) [Declared]: <error>
+"s"@(FileId(1), 10..11) [Resolved(Type)]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "a"@(FileId(1), 19..20), )
+"a"@(FileId(1), 30..31) [Declared]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "a"@(FileId(1), 19..20), )
+"b"@(FileId(1), 33..34) [Declared]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "a"@(FileId(1), 19..20), )
+"_v_res"@(FileId(1), 82..88) [Declared]: boolean
+"<root>"@(dummy) [Declared]: <error>
+

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_enums_less_eq.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_enums_less_eq.snap
@@ -1,0 +1,14 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "\n    type s : enum(a)\n    var a, b : s\n\n    % should all produce booleans\n    var _v_res : boolean\n\n    _v_res := a <= b\n    _v_res := b <= a\n    % enum variants are covered by equivalence rules\n    "
+
+---
+"a"@(FileId(1), 19..20) [Declared]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "a"@(FileId(1), 19..20), )
+"s"@(FileId(1), 14..21) [Declared]: <error>
+"s"@(FileId(1), 10..11) [Resolved(Type)]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "a"@(FileId(1), 19..20), )
+"a"@(FileId(1), 30..31) [Declared]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "a"@(FileId(1), 19..20), )
+"b"@(FileId(1), 33..34) [Declared]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "a"@(FileId(1), 19..20), )
+"_v_res"@(FileId(1), 82..88) [Declared]: boolean
+"<root>"@(dummy) [Declared]: <error>
+

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_enums_not_equal.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_enums_not_equal.snap
@@ -1,0 +1,14 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "\n    type s : enum(a)\n    var a, b : s\n\n    % should all produce booleans\n    var _v_res : boolean\n\n    _v_res := a not= b\n    _v_res := b not= a\n    % enum variants are covered by equivalence rules\n    "
+
+---
+"a"@(FileId(1), 19..20) [Declared]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "a"@(FileId(1), 19..20), )
+"s"@(FileId(1), 14..21) [Declared]: <error>
+"s"@(FileId(1), 10..11) [Resolved(Type)]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "a"@(FileId(1), 19..20), )
+"a"@(FileId(1), 30..31) [Declared]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "a"@(FileId(1), 19..20), )
+"b"@(FileId(1), 33..34) [Declared]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "a"@(FileId(1), 19..20), )
+"_v_res"@(FileId(1), 82..88) [Declared]: boolean
+"<root>"@(dummy) [Declared]: <error>
+

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_sets_equal.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_sets_equal.snap
@@ -4,10 +4,10 @@ assertion_line: 42
 expression: "\n    type s : set of boolean\n    var a, b : s\n\n    % should all produce booleans\n    var _v_res : boolean\n\n    _v_res := a = b\n    _v_res := b = a\n    "
 
 ---
-"<anonymous>"@(FileId(1), 14..28) [Declared]: <error>
-"s"@(FileId(1), 10..11) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
-"a"@(FileId(1), 37..38) [Declared]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
-"b"@(FileId(1), 40..41) [Declared]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
+"s"@(FileId(1), 14..28) [Declared]: <error>
+"s"@(FileId(1), 10..11) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
+"a"@(FileId(1), 37..38) [Declared]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
+"b"@(FileId(1), 40..41) [Declared]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
 "_v_res"@(FileId(1), 89..95) [Declared]: boolean
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_sets_greater.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_sets_greater.snap
@@ -4,10 +4,10 @@ assertion_line: 42
 expression: "\n    type s : set of boolean\n    var a, b : s\n\n    % should all produce booleans\n    var _v_res : boolean\n\n    _v_res := a > b\n    _v_res := b > a\n    "
 
 ---
-"<anonymous>"@(FileId(1), 14..28) [Declared]: <error>
-"s"@(FileId(1), 10..11) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
-"a"@(FileId(1), 37..38) [Declared]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
-"b"@(FileId(1), 40..41) [Declared]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
+"s"@(FileId(1), 14..28) [Declared]: <error>
+"s"@(FileId(1), 10..11) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
+"a"@(FileId(1), 37..38) [Declared]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
+"b"@(FileId(1), 40..41) [Declared]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
 "_v_res"@(FileId(1), 89..95) [Declared]: boolean
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_sets_greater_eq.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_sets_greater_eq.snap
@@ -4,10 +4,10 @@ assertion_line: 42
 expression: "\n    type s : set of boolean\n    var a, b : s\n\n    % should all produce booleans\n    var _v_res : boolean\n\n    _v_res := a >= b\n    _v_res := b >= a\n    "
 
 ---
-"<anonymous>"@(FileId(1), 14..28) [Declared]: <error>
-"s"@(FileId(1), 10..11) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
-"a"@(FileId(1), 37..38) [Declared]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
-"b"@(FileId(1), 40..41) [Declared]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
+"s"@(FileId(1), 14..28) [Declared]: <error>
+"s"@(FileId(1), 10..11) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
+"a"@(FileId(1), 37..38) [Declared]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
+"b"@(FileId(1), 40..41) [Declared]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
 "_v_res"@(FileId(1), 89..95) [Declared]: boolean
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_sets_less.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_sets_less.snap
@@ -4,10 +4,10 @@ assertion_line: 42
 expression: "\n    type s : set of boolean\n    var a, b : s\n\n    % should all produce booleans\n    var _v_res : boolean\n\n    _v_res := a < b\n    _v_res := b < a\n    "
 
 ---
-"<anonymous>"@(FileId(1), 14..28) [Declared]: <error>
-"s"@(FileId(1), 10..11) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
-"a"@(FileId(1), 37..38) [Declared]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
-"b"@(FileId(1), 40..41) [Declared]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
+"s"@(FileId(1), 14..28) [Declared]: <error>
+"s"@(FileId(1), 10..11) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
+"a"@(FileId(1), 37..38) [Declared]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
+"b"@(FileId(1), 40..41) [Declared]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
 "_v_res"@(FileId(1), 89..95) [Declared]: boolean
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_sets_less_eq.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_sets_less_eq.snap
@@ -4,10 +4,10 @@ assertion_line: 42
 expression: "\n    type s : set of boolean\n    var a, b : s\n\n    % should all produce booleans\n    var _v_res : boolean\n\n    _v_res := a <= b\n    _v_res := b <= a\n    "
 
 ---
-"<anonymous>"@(FileId(1), 14..28) [Declared]: <error>
-"s"@(FileId(1), 10..11) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
-"a"@(FileId(1), 37..38) [Declared]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
-"b"@(FileId(1), 40..41) [Declared]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
+"s"@(FileId(1), 14..28) [Declared]: <error>
+"s"@(FileId(1), 10..11) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
+"a"@(FileId(1), 37..38) [Declared]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
+"b"@(FileId(1), 40..41) [Declared]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
 "_v_res"@(FileId(1), 89..95) [Declared]: boolean
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_sets_not_equal.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_sets_not_equal.snap
@@ -4,10 +4,10 @@ assertion_line: 42
 expression: "\n    type s : set of boolean\n    var a, b : s\n\n    % should all produce booleans\n    var _v_res : boolean\n\n    _v_res := a not= b\n    _v_res := b not= a\n    "
 
 ---
-"<anonymous>"@(FileId(1), 14..28) [Declared]: <error>
-"s"@(FileId(1), 10..11) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
-"a"@(FileId(1), 37..38) [Declared]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
-"b"@(FileId(1), 40..41) [Declared]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
+"s"@(FileId(1), 14..28) [Declared]: <error>
+"s"@(FileId(1), 10..11) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
+"a"@(FileId(1), 37..38) [Declared]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
+"b"@(FileId(1), 40..41) [Declared]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
 "_v_res"@(FileId(1), 89..95) [Declared]: boolean
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_enums_equal.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_enums_equal.snap
@@ -1,0 +1,28 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "\n    % Different enums\n    type e1 : enum(v)\n    type e2 : enum(v)\n    var ae1 : e1\n    var be2 : e2\n    var aas : enum(v)\n\n    % should all produce boolean anyway\n    var _v_res : boolean\n\n    _v_res := ae1 = be2\n    _v_res := be1 = ae2\n    _v_res := aes = ae1\n    _v_res := ae1 = aes\n    "
+
+---
+"v"@(FileId(1), 42..43) [Declared]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "v"@(FileId(1), 42..43), )
+"e1"@(FileId(1), 37..44) [Declared]: <error>
+"e1"@(FileId(1), 32..34) [Resolved(Type)]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "v"@(FileId(1), 42..43), )
+"v"@(FileId(1), 64..65) [Declared]: enum[DefId(LibraryId(0), LocalDefId(4))] ( "v"@(FileId(1), 64..65), )
+"e2"@(FileId(1), 59..66) [Declared]: <error>
+"e2"@(FileId(1), 54..56) [Resolved(Type)]: enum[DefId(LibraryId(0), LocalDefId(4))] ( "v"@(FileId(1), 64..65), )
+"ae1"@(FileId(1), 75..78) [Declared]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "v"@(FileId(1), 42..43), )
+"be2"@(FileId(1), 92..95) [Declared]: enum[DefId(LibraryId(0), LocalDefId(4))] ( "v"@(FileId(1), 64..65), )
+"v"@(FileId(1), 120..121) [Declared]: enum[DefId(LibraryId(0), LocalDefId(9))] ( "v"@(FileId(1), 120..121), )
+"<anonymous>"@(FileId(1), 115..122) [Declared]: <error>
+"aas"@(FileId(1), 109..112) [Declared]: enum[DefId(LibraryId(0), LocalDefId(9))] ( "v"@(FileId(1), 120..121), )
+"_v_res"@(FileId(1), 172..178) [Declared]: boolean
+"be1"@(FileId(1), 228..231) [Undeclared]: <error>
+"ae2"@(FileId(1), 234..237) [Undeclared]: <error>
+"aes"@(FileId(1), 252..255) [Undeclared]: <error>
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 208..209: mismatched types for `=`
+| note in file FileId(1) for 210..213: this is of type `enum e2`
+| note in file FileId(1) for 204..207: this is of type `enum e1`
+| error in file FileId(1) for 208..209: `enum e1` cannot be compared to `enum e2`
+| info: operands must both be the same type

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_enums_greater.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_enums_greater.snap
@@ -1,0 +1,28 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "\n    % Different enums\n    type e1 : enum(v)\n    type e2 : enum(v)\n    var ae1 : e1\n    var be2 : e2\n    var aas : enum(v)\n\n    % should all produce boolean anyway\n    var _v_res : boolean\n\n    _v_res := ae1 > be2\n    _v_res := be1 > ae2\n    _v_res := aes > ae1\n    _v_res := ae1 > aes\n    "
+
+---
+"v"@(FileId(1), 42..43) [Declared]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "v"@(FileId(1), 42..43), )
+"e1"@(FileId(1), 37..44) [Declared]: <error>
+"e1"@(FileId(1), 32..34) [Resolved(Type)]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "v"@(FileId(1), 42..43), )
+"v"@(FileId(1), 64..65) [Declared]: enum[DefId(LibraryId(0), LocalDefId(4))] ( "v"@(FileId(1), 64..65), )
+"e2"@(FileId(1), 59..66) [Declared]: <error>
+"e2"@(FileId(1), 54..56) [Resolved(Type)]: enum[DefId(LibraryId(0), LocalDefId(4))] ( "v"@(FileId(1), 64..65), )
+"ae1"@(FileId(1), 75..78) [Declared]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "v"@(FileId(1), 42..43), )
+"be2"@(FileId(1), 92..95) [Declared]: enum[DefId(LibraryId(0), LocalDefId(4))] ( "v"@(FileId(1), 64..65), )
+"v"@(FileId(1), 120..121) [Declared]: enum[DefId(LibraryId(0), LocalDefId(9))] ( "v"@(FileId(1), 120..121), )
+"<anonymous>"@(FileId(1), 115..122) [Declared]: <error>
+"aas"@(FileId(1), 109..112) [Declared]: enum[DefId(LibraryId(0), LocalDefId(9))] ( "v"@(FileId(1), 120..121), )
+"_v_res"@(FileId(1), 172..178) [Declared]: boolean
+"be1"@(FileId(1), 228..231) [Undeclared]: <error>
+"ae2"@(FileId(1), 234..237) [Undeclared]: <error>
+"aes"@(FileId(1), 252..255) [Undeclared]: <error>
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 208..209: mismatched types for `>`
+| note in file FileId(1) for 210..213: this is of type `enum e2`
+| note in file FileId(1) for 204..207: this is of type `enum e1`
+| error in file FileId(1) for 208..209: `enum e1` cannot be compared to `enum e2`
+| info: operands must both be the same type

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_enums_greater_eq.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_enums_greater_eq.snap
@@ -1,0 +1,28 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "\n    % Different enums\n    type e1 : enum(v)\n    type e2 : enum(v)\n    var ae1 : e1\n    var be2 : e2\n    var aas : enum(v)\n\n    % should all produce boolean anyway\n    var _v_res : boolean\n\n    _v_res := ae1 >= be2\n    _v_res := be1 >= ae2\n    _v_res := aes >= ae1\n    _v_res := ae1 >= aes\n    "
+
+---
+"v"@(FileId(1), 42..43) [Declared]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "v"@(FileId(1), 42..43), )
+"e1"@(FileId(1), 37..44) [Declared]: <error>
+"e1"@(FileId(1), 32..34) [Resolved(Type)]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "v"@(FileId(1), 42..43), )
+"v"@(FileId(1), 64..65) [Declared]: enum[DefId(LibraryId(0), LocalDefId(4))] ( "v"@(FileId(1), 64..65), )
+"e2"@(FileId(1), 59..66) [Declared]: <error>
+"e2"@(FileId(1), 54..56) [Resolved(Type)]: enum[DefId(LibraryId(0), LocalDefId(4))] ( "v"@(FileId(1), 64..65), )
+"ae1"@(FileId(1), 75..78) [Declared]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "v"@(FileId(1), 42..43), )
+"be2"@(FileId(1), 92..95) [Declared]: enum[DefId(LibraryId(0), LocalDefId(4))] ( "v"@(FileId(1), 64..65), )
+"v"@(FileId(1), 120..121) [Declared]: enum[DefId(LibraryId(0), LocalDefId(9))] ( "v"@(FileId(1), 120..121), )
+"<anonymous>"@(FileId(1), 115..122) [Declared]: <error>
+"aas"@(FileId(1), 109..112) [Declared]: enum[DefId(LibraryId(0), LocalDefId(9))] ( "v"@(FileId(1), 120..121), )
+"_v_res"@(FileId(1), 172..178) [Declared]: boolean
+"be1"@(FileId(1), 229..232) [Undeclared]: <error>
+"ae2"@(FileId(1), 236..239) [Undeclared]: <error>
+"aes"@(FileId(1), 254..257) [Undeclared]: <error>
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 208..210: mismatched types for `>=`
+| note in file FileId(1) for 211..214: this is of type `enum e2`
+| note in file FileId(1) for 204..207: this is of type `enum e1`
+| error in file FileId(1) for 208..210: `enum e1` cannot be compared to `enum e2`
+| info: operands must both be the same type

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_enums_less.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_enums_less.snap
@@ -1,0 +1,28 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "\n    % Different enums\n    type e1 : enum(v)\n    type e2 : enum(v)\n    var ae1 : e1\n    var be2 : e2\n    var aas : enum(v)\n\n    % should all produce boolean anyway\n    var _v_res : boolean\n\n    _v_res := ae1 < be2\n    _v_res := be1 < ae2\n    _v_res := aes < ae1\n    _v_res := ae1 < aes\n    "
+
+---
+"v"@(FileId(1), 42..43) [Declared]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "v"@(FileId(1), 42..43), )
+"e1"@(FileId(1), 37..44) [Declared]: <error>
+"e1"@(FileId(1), 32..34) [Resolved(Type)]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "v"@(FileId(1), 42..43), )
+"v"@(FileId(1), 64..65) [Declared]: enum[DefId(LibraryId(0), LocalDefId(4))] ( "v"@(FileId(1), 64..65), )
+"e2"@(FileId(1), 59..66) [Declared]: <error>
+"e2"@(FileId(1), 54..56) [Resolved(Type)]: enum[DefId(LibraryId(0), LocalDefId(4))] ( "v"@(FileId(1), 64..65), )
+"ae1"@(FileId(1), 75..78) [Declared]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "v"@(FileId(1), 42..43), )
+"be2"@(FileId(1), 92..95) [Declared]: enum[DefId(LibraryId(0), LocalDefId(4))] ( "v"@(FileId(1), 64..65), )
+"v"@(FileId(1), 120..121) [Declared]: enum[DefId(LibraryId(0), LocalDefId(9))] ( "v"@(FileId(1), 120..121), )
+"<anonymous>"@(FileId(1), 115..122) [Declared]: <error>
+"aas"@(FileId(1), 109..112) [Declared]: enum[DefId(LibraryId(0), LocalDefId(9))] ( "v"@(FileId(1), 120..121), )
+"_v_res"@(FileId(1), 172..178) [Declared]: boolean
+"be1"@(FileId(1), 228..231) [Undeclared]: <error>
+"ae2"@(FileId(1), 234..237) [Undeclared]: <error>
+"aes"@(FileId(1), 252..255) [Undeclared]: <error>
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 208..209: mismatched types for `<`
+| note in file FileId(1) for 210..213: this is of type `enum e2`
+| note in file FileId(1) for 204..207: this is of type `enum e1`
+| error in file FileId(1) for 208..209: `enum e1` cannot be compared to `enum e2`
+| info: operands must both be the same type

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_enums_less_eq.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_enums_less_eq.snap
@@ -1,0 +1,28 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "\n    % Different enums\n    type e1 : enum(v)\n    type e2 : enum(v)\n    var ae1 : e1\n    var be2 : e2\n    var aas : enum(v)\n\n    % should all produce boolean anyway\n    var _v_res : boolean\n\n    _v_res := ae1 <= be2\n    _v_res := be1 <= ae2\n    _v_res := aes <= ae1\n    _v_res := ae1 <= aes\n    "
+
+---
+"v"@(FileId(1), 42..43) [Declared]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "v"@(FileId(1), 42..43), )
+"e1"@(FileId(1), 37..44) [Declared]: <error>
+"e1"@(FileId(1), 32..34) [Resolved(Type)]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "v"@(FileId(1), 42..43), )
+"v"@(FileId(1), 64..65) [Declared]: enum[DefId(LibraryId(0), LocalDefId(4))] ( "v"@(FileId(1), 64..65), )
+"e2"@(FileId(1), 59..66) [Declared]: <error>
+"e2"@(FileId(1), 54..56) [Resolved(Type)]: enum[DefId(LibraryId(0), LocalDefId(4))] ( "v"@(FileId(1), 64..65), )
+"ae1"@(FileId(1), 75..78) [Declared]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "v"@(FileId(1), 42..43), )
+"be2"@(FileId(1), 92..95) [Declared]: enum[DefId(LibraryId(0), LocalDefId(4))] ( "v"@(FileId(1), 64..65), )
+"v"@(FileId(1), 120..121) [Declared]: enum[DefId(LibraryId(0), LocalDefId(9))] ( "v"@(FileId(1), 120..121), )
+"<anonymous>"@(FileId(1), 115..122) [Declared]: <error>
+"aas"@(FileId(1), 109..112) [Declared]: enum[DefId(LibraryId(0), LocalDefId(9))] ( "v"@(FileId(1), 120..121), )
+"_v_res"@(FileId(1), 172..178) [Declared]: boolean
+"be1"@(FileId(1), 229..232) [Undeclared]: <error>
+"ae2"@(FileId(1), 236..239) [Undeclared]: <error>
+"aes"@(FileId(1), 254..257) [Undeclared]: <error>
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 208..210: mismatched types for `<=`
+| note in file FileId(1) for 211..214: this is of type `enum e2`
+| note in file FileId(1) for 204..207: this is of type `enum e1`
+| error in file FileId(1) for 208..210: `enum e1` cannot be compared to `enum e2`
+| info: operands must both be the same type

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_enums_not_equal.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_enums_not_equal.snap
@@ -1,0 +1,28 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "\n    % Different enums\n    type e1 : enum(v)\n    type e2 : enum(v)\n    var ae1 : e1\n    var be2 : e2\n    var aas : enum(v)\n\n    % should all produce boolean anyway\n    var _v_res : boolean\n\n    _v_res := ae1 not= be2\n    _v_res := be1 not= ae2\n    _v_res := aes not= ae1\n    _v_res := ae1 not= aes\n    "
+
+---
+"v"@(FileId(1), 42..43) [Declared]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "v"@(FileId(1), 42..43), )
+"e1"@(FileId(1), 37..44) [Declared]: <error>
+"e1"@(FileId(1), 32..34) [Resolved(Type)]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "v"@(FileId(1), 42..43), )
+"v"@(FileId(1), 64..65) [Declared]: enum[DefId(LibraryId(0), LocalDefId(4))] ( "v"@(FileId(1), 64..65), )
+"e2"@(FileId(1), 59..66) [Declared]: <error>
+"e2"@(FileId(1), 54..56) [Resolved(Type)]: enum[DefId(LibraryId(0), LocalDefId(4))] ( "v"@(FileId(1), 64..65), )
+"ae1"@(FileId(1), 75..78) [Declared]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "v"@(FileId(1), 42..43), )
+"be2"@(FileId(1), 92..95) [Declared]: enum[DefId(LibraryId(0), LocalDefId(4))] ( "v"@(FileId(1), 64..65), )
+"v"@(FileId(1), 120..121) [Declared]: enum[DefId(LibraryId(0), LocalDefId(9))] ( "v"@(FileId(1), 120..121), )
+"<anonymous>"@(FileId(1), 115..122) [Declared]: <error>
+"aas"@(FileId(1), 109..112) [Declared]: enum[DefId(LibraryId(0), LocalDefId(9))] ( "v"@(FileId(1), 120..121), )
+"_v_res"@(FileId(1), 172..178) [Declared]: boolean
+"be1"@(FileId(1), 231..234) [Undeclared]: <error>
+"ae2"@(FileId(1), 240..243) [Undeclared]: <error>
+"aes"@(FileId(1), 258..261) [Undeclared]: <error>
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 208..212: mismatched types for `not =`
+| note in file FileId(1) for 213..216: this is of type `enum e2`
+| note in file FileId(1) for 204..207: this is of type `enum e1`
+| error in file FileId(1) for 208..212: `enum e1` cannot be compared to `enum e2`
+| info: operands must both be the same type

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_equal.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_equal.snap
@@ -12,12 +12,12 @@ expression: "\n    % Numerics\n    var r : real\n    var i : int\n    var n : na
 "c_sz"@(FileId(1), 153..157) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
 "s"@(FileId(1), 176..177) [Declared]: string
 "s_sz"@(FileId(1), 195..199) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
-"<anonymous>"@(FileId(1), 248..262) [Declared]: <error>
-"s1"@(FileId(1), 243..245) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(9))] of boolean
-"<anonymous>"@(FileId(1), 277..291) [Declared]: <error>
-"s2"@(FileId(1), 272..274) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(11))] of boolean
-"as1"@(FileId(1), 300..303) [Declared]: set[DefId(LibraryId(0), LocalDefId(9))] of boolean
-"bs2"@(FileId(1), 317..320) [Declared]: set[DefId(LibraryId(0), LocalDefId(11))] of boolean
+"s1"@(FileId(1), 248..262) [Declared]: <error>
+"s1"@(FileId(1), 243..245) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(8))] of boolean
+"s2"@(FileId(1), 277..291) [Declared]: <error>
+"s2"@(FileId(1), 272..274) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(10))] of boolean
+"as1"@(FileId(1), 300..303) [Declared]: set[DefId(LibraryId(0), LocalDefId(8))] of boolean
+"bs2"@(FileId(1), 317..320) [Declared]: set[DefId(LibraryId(0), LocalDefId(10))] of boolean
 "<anonymous>"@(FileId(1), 340..354) [Declared]: <error>
 "aas"@(FileId(1), 334..337) [Declared]: set[DefId(LibraryId(0), LocalDefId(14))] of boolean
 "_v_res"@(FileId(1), 404..410) [Declared]: boolean

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_greater.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_greater.snap
@@ -12,12 +12,12 @@ expression: "\n    % Numerics\n    var r : real\n    var i : int\n    var n : na
 "c_sz"@(FileId(1), 153..157) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
 "s"@(FileId(1), 176..177) [Declared]: string
 "s_sz"@(FileId(1), 195..199) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
-"<anonymous>"@(FileId(1), 248..262) [Declared]: <error>
-"s1"@(FileId(1), 243..245) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(9))] of boolean
-"<anonymous>"@(FileId(1), 277..291) [Declared]: <error>
-"s2"@(FileId(1), 272..274) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(11))] of boolean
-"as1"@(FileId(1), 300..303) [Declared]: set[DefId(LibraryId(0), LocalDefId(9))] of boolean
-"bs2"@(FileId(1), 317..320) [Declared]: set[DefId(LibraryId(0), LocalDefId(11))] of boolean
+"s1"@(FileId(1), 248..262) [Declared]: <error>
+"s1"@(FileId(1), 243..245) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(8))] of boolean
+"s2"@(FileId(1), 277..291) [Declared]: <error>
+"s2"@(FileId(1), 272..274) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(10))] of boolean
+"as1"@(FileId(1), 300..303) [Declared]: set[DefId(LibraryId(0), LocalDefId(8))] of boolean
+"bs2"@(FileId(1), 317..320) [Declared]: set[DefId(LibraryId(0), LocalDefId(10))] of boolean
 "<anonymous>"@(FileId(1), 340..354) [Declared]: <error>
 "aas"@(FileId(1), 334..337) [Declared]: set[DefId(LibraryId(0), LocalDefId(14))] of boolean
 "_v_res"@(FileId(1), 404..410) [Declared]: boolean

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_greater_eq.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_greater_eq.snap
@@ -12,12 +12,12 @@ expression: "\n    % Numerics\n    var r : real\n    var i : int\n    var n : na
 "c_sz"@(FileId(1), 153..157) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
 "s"@(FileId(1), 176..177) [Declared]: string
 "s_sz"@(FileId(1), 195..199) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
-"<anonymous>"@(FileId(1), 248..262) [Declared]: <error>
-"s1"@(FileId(1), 243..245) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(9))] of boolean
-"<anonymous>"@(FileId(1), 277..291) [Declared]: <error>
-"s2"@(FileId(1), 272..274) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(11))] of boolean
-"as1"@(FileId(1), 300..303) [Declared]: set[DefId(LibraryId(0), LocalDefId(9))] of boolean
-"bs2"@(FileId(1), 317..320) [Declared]: set[DefId(LibraryId(0), LocalDefId(11))] of boolean
+"s1"@(FileId(1), 248..262) [Declared]: <error>
+"s1"@(FileId(1), 243..245) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(8))] of boolean
+"s2"@(FileId(1), 277..291) [Declared]: <error>
+"s2"@(FileId(1), 272..274) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(10))] of boolean
+"as1"@(FileId(1), 300..303) [Declared]: set[DefId(LibraryId(0), LocalDefId(8))] of boolean
+"bs2"@(FileId(1), 317..320) [Declared]: set[DefId(LibraryId(0), LocalDefId(10))] of boolean
 "<anonymous>"@(FileId(1), 340..354) [Declared]: <error>
 "aas"@(FileId(1), 334..337) [Declared]: set[DefId(LibraryId(0), LocalDefId(14))] of boolean
 "_v_res"@(FileId(1), 404..410) [Declared]: boolean

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_less.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_less.snap
@@ -12,12 +12,12 @@ expression: "\n    % Numerics\n    var r : real\n    var i : int\n    var n : na
 "c_sz"@(FileId(1), 153..157) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
 "s"@(FileId(1), 176..177) [Declared]: string
 "s_sz"@(FileId(1), 195..199) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
-"<anonymous>"@(FileId(1), 248..262) [Declared]: <error>
-"s1"@(FileId(1), 243..245) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(9))] of boolean
-"<anonymous>"@(FileId(1), 277..291) [Declared]: <error>
-"s2"@(FileId(1), 272..274) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(11))] of boolean
-"as1"@(FileId(1), 300..303) [Declared]: set[DefId(LibraryId(0), LocalDefId(9))] of boolean
-"bs2"@(FileId(1), 317..320) [Declared]: set[DefId(LibraryId(0), LocalDefId(11))] of boolean
+"s1"@(FileId(1), 248..262) [Declared]: <error>
+"s1"@(FileId(1), 243..245) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(8))] of boolean
+"s2"@(FileId(1), 277..291) [Declared]: <error>
+"s2"@(FileId(1), 272..274) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(10))] of boolean
+"as1"@(FileId(1), 300..303) [Declared]: set[DefId(LibraryId(0), LocalDefId(8))] of boolean
+"bs2"@(FileId(1), 317..320) [Declared]: set[DefId(LibraryId(0), LocalDefId(10))] of boolean
 "<anonymous>"@(FileId(1), 340..354) [Declared]: <error>
 "aas"@(FileId(1), 334..337) [Declared]: set[DefId(LibraryId(0), LocalDefId(14))] of boolean
 "_v_res"@(FileId(1), 404..410) [Declared]: boolean

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_less_eq.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_less_eq.snap
@@ -12,12 +12,12 @@ expression: "\n    % Numerics\n    var r : real\n    var i : int\n    var n : na
 "c_sz"@(FileId(1), 153..157) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
 "s"@(FileId(1), 176..177) [Declared]: string
 "s_sz"@(FileId(1), 195..199) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
-"<anonymous>"@(FileId(1), 248..262) [Declared]: <error>
-"s1"@(FileId(1), 243..245) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(9))] of boolean
-"<anonymous>"@(FileId(1), 277..291) [Declared]: <error>
-"s2"@(FileId(1), 272..274) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(11))] of boolean
-"as1"@(FileId(1), 300..303) [Declared]: set[DefId(LibraryId(0), LocalDefId(9))] of boolean
-"bs2"@(FileId(1), 317..320) [Declared]: set[DefId(LibraryId(0), LocalDefId(11))] of boolean
+"s1"@(FileId(1), 248..262) [Declared]: <error>
+"s1"@(FileId(1), 243..245) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(8))] of boolean
+"s2"@(FileId(1), 277..291) [Declared]: <error>
+"s2"@(FileId(1), 272..274) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(10))] of boolean
+"as1"@(FileId(1), 300..303) [Declared]: set[DefId(LibraryId(0), LocalDefId(8))] of boolean
+"bs2"@(FileId(1), 317..320) [Declared]: set[DefId(LibraryId(0), LocalDefId(10))] of boolean
 "<anonymous>"@(FileId(1), 340..354) [Declared]: <error>
 "aas"@(FileId(1), 334..337) [Declared]: set[DefId(LibraryId(0), LocalDefId(14))] of boolean
 "_v_res"@(FileId(1), 404..410) [Declared]: boolean

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_not_equal.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_not_equal.snap
@@ -12,12 +12,12 @@ expression: "\n    % Numerics\n    var r : real\n    var i : int\n    var n : na
 "c_sz"@(FileId(1), 153..157) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
 "s"@(FileId(1), 176..177) [Declared]: string
 "s_sz"@(FileId(1), 195..199) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
-"<anonymous>"@(FileId(1), 248..262) [Declared]: <error>
-"s1"@(FileId(1), 243..245) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(9))] of boolean
-"<anonymous>"@(FileId(1), 277..291) [Declared]: <error>
-"s2"@(FileId(1), 272..274) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(11))] of boolean
-"as1"@(FileId(1), 300..303) [Declared]: set[DefId(LibraryId(0), LocalDefId(9))] of boolean
-"bs2"@(FileId(1), 317..320) [Declared]: set[DefId(LibraryId(0), LocalDefId(11))] of boolean
+"s1"@(FileId(1), 248..262) [Declared]: <error>
+"s1"@(FileId(1), 243..245) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(8))] of boolean
+"s2"@(FileId(1), 277..291) [Declared]: <error>
+"s2"@(FileId(1), 272..274) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(10))] of boolean
+"as1"@(FileId(1), 300..303) [Declared]: set[DefId(LibraryId(0), LocalDefId(8))] of boolean
+"bs2"@(FileId(1), 317..320) [Declared]: set[DefId(LibraryId(0), LocalDefId(10))] of boolean
 "<anonymous>"@(FileId(1), 340..354) [Declared]: <error>
 "aas"@(FileId(1), 334..337) [Declared]: set[DefId(LibraryId(0), LocalDefId(14))] of boolean
 "_v_res"@(FileId(1), 404..410) [Declared]: boolean

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__enum_field_not_variant.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__enum_field_not_variant.snap
@@ -1,0 +1,16 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "type e : enum(a, b, c)\nvar _ := e.e\n"
+
+---
+"a"@(FileId(1), 14..15) [Declared]: enum[DefId(LibraryId(0), LocalDefId(3))] ( "a"@(FileId(1), 14..15), "b"@(FileId(1), 17..18), "c"@(FileId(1), 20..21), )
+"b"@(FileId(1), 17..18) [Declared]: enum[DefId(LibraryId(0), LocalDefId(3))] ( "a"@(FileId(1), 14..15), "b"@(FileId(1), 17..18), "c"@(FileId(1), 20..21), )
+"c"@(FileId(1), 20..21) [Declared]: enum[DefId(LibraryId(0), LocalDefId(3))] ( "a"@(FileId(1), 14..15), "b"@(FileId(1), 17..18), "c"@(FileId(1), 20..21), )
+"e"@(FileId(1), 9..22) [Declared]: <error>
+"e"@(FileId(1), 5..6) [Resolved(Type)]: enum[DefId(LibraryId(0), LocalDefId(3))] ( "a"@(FileId(1), 14..15), "b"@(FileId(1), 17..18), "c"@(FileId(1), 20..21), )
+"_"@(FileId(1), 27..28) [Declared]: <error>
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 34..35: no field named `e` in expression
+| error in file FileId(1) for 34..35: no field named `e` in here

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__enum_field_on_type.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__enum_field_on_type.snap
@@ -1,0 +1,14 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "type e : enum(a, b, c)\nvar _ := e.a\n"
+
+---
+"a"@(FileId(1), 14..15) [Declared]: enum[DefId(LibraryId(0), LocalDefId(3))] ( "a"@(FileId(1), 14..15), "b"@(FileId(1), 17..18), "c"@(FileId(1), 20..21), )
+"b"@(FileId(1), 17..18) [Declared]: enum[DefId(LibraryId(0), LocalDefId(3))] ( "a"@(FileId(1), 14..15), "b"@(FileId(1), 17..18), "c"@(FileId(1), 20..21), )
+"c"@(FileId(1), 20..21) [Declared]: enum[DefId(LibraryId(0), LocalDefId(3))] ( "a"@(FileId(1), 14..15), "b"@(FileId(1), 17..18), "c"@(FileId(1), 20..21), )
+"e"@(FileId(1), 9..22) [Declared]: <error>
+"e"@(FileId(1), 5..6) [Resolved(Type)]: enum[DefId(LibraryId(0), LocalDefId(3))] ( "a"@(FileId(1), 14..15), "b"@(FileId(1), 17..18), "c"@(FileId(1), 20..21), )
+"_"@(FileId(1), 27..28) [Declared]: enum[DefId(LibraryId(0), LocalDefId(3))] ( "a"@(FileId(1), 14..15), "b"@(FileId(1), 17..18), "c"@(FileId(1), 20..21), )
+"<root>"@(dummy) [Declared]: <error>
+

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__enum_field_on_var.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__enum_field_on_var.snap
@@ -1,0 +1,16 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "type e : enum(a, b, c)\nvar a : e\na := a.a\n"
+
+---
+"a"@(FileId(1), 14..15) [Declared]: enum[DefId(LibraryId(0), LocalDefId(3))] ( "a"@(FileId(1), 14..15), "b"@(FileId(1), 17..18), "c"@(FileId(1), 20..21), )
+"b"@(FileId(1), 17..18) [Declared]: enum[DefId(LibraryId(0), LocalDefId(3))] ( "a"@(FileId(1), 14..15), "b"@(FileId(1), 17..18), "c"@(FileId(1), 20..21), )
+"c"@(FileId(1), 20..21) [Declared]: enum[DefId(LibraryId(0), LocalDefId(3))] ( "a"@(FileId(1), 14..15), "b"@(FileId(1), 17..18), "c"@(FileId(1), 20..21), )
+"e"@(FileId(1), 9..22) [Declared]: <error>
+"e"@(FileId(1), 5..6) [Resolved(Type)]: enum[DefId(LibraryId(0), LocalDefId(3))] ( "a"@(FileId(1), 14..15), "b"@(FileId(1), 17..18), "c"@(FileId(1), 20..21), )
+"a"@(FileId(1), 27..28) [Declared]: enum[DefId(LibraryId(0), LocalDefId(3))] ( "a"@(FileId(1), 14..15), "b"@(FileId(1), 17..18), "c"@(FileId(1), 20..21), )
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 40..41: no field named `a` in expression
+| error in file FileId(1) for 40..41: no field named `a` in here

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__equivalence_of_enums.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__equivalence_of_enums.snap
@@ -1,0 +1,25 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "type e : enum(v)\nvar a, b : e\n\n% compatible with itself\na := b\n% with its own variants\na := e.v\n\n% incompatible with different defs\ntype f : enum(v)\nvar c : f\na := c\na := f.v\n"
+
+---
+"v"@(FileId(1), 14..15) [Declared]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "v"@(FileId(1), 14..15), )
+"e"@(FileId(1), 9..16) [Declared]: <error>
+"e"@(FileId(1), 5..6) [Resolved(Type)]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "v"@(FileId(1), 14..15), )
+"a"@(FileId(1), 21..22) [Declared]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "v"@(FileId(1), 14..15), )
+"b"@(FileId(1), 24..25) [Declared]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "v"@(FileId(1), 14..15), )
+"v"@(FileId(1), 146..147) [Declared]: enum[DefId(LibraryId(0), LocalDefId(6))] ( "v"@(FileId(1), 146..147), )
+"f"@(FileId(1), 141..148) [Declared]: <error>
+"f"@(FileId(1), 137..138) [Resolved(Type)]: enum[DefId(LibraryId(0), LocalDefId(6))] ( "v"@(FileId(1), 146..147), )
+"c"@(FileId(1), 153..154) [Declared]: enum[DefId(LibraryId(0), LocalDefId(6))] ( "v"@(FileId(1), 146..147), )
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 161..163: mismatched types
+| note in file FileId(1) for 164..165: this is of type `enum f`
+| note in file FileId(1) for 159..160: this is of type `enum e`
+| info: `enum f` is not assignable into `enum e`
+error in file FileId(1) at 168..170: mismatched types
+| note in file FileId(1) for 171..174: this is of type `enum f`
+| note in file FileId(1) for 166..167: this is of type `enum e`
+| info: `enum f` is not assignable into `enum e`

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__equivalence_of_sets.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__equivalence_of_sets.snap
@@ -4,19 +4,19 @@ assertion_line: 42
 expression: "type sb : set of boolean\ntype sc : set of char\ntype sc2 : set of char\n\nvar v_sb : sb\nvar v_sc : sc\nvar v_sc2 : sc2\nvar v_anon : set of char\n\n% compat\nv_sb := v_sb\nv_sc := v_sc\nv_sc2 := v_sc2\n\n% incompatible - different elem types\nv_sc := v_sb\n% incompatible - different def locations\nv_sc := v_sc2\nv_sc := v_anon\n\n% compatible through aliases\ntype asc : sc\nvar v_asc : asc\nv_sc := v_asc\n"
 
 ---
-"<anonymous>"@(FileId(1), 10..24) [Declared]: <error>
-"sb"@(FileId(1), 5..7) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
-"<anonymous>"@(FileId(1), 35..46) [Declared]: <error>
-"sc"@(FileId(1), 30..32) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(3))] of char
-"<anonymous>"@(FileId(1), 58..69) [Declared]: <error>
-"sc2"@(FileId(1), 52..55) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(5))] of char
-"v_sb"@(FileId(1), 75..79) [Declared]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
-"v_sc"@(FileId(1), 89..93) [Declared]: set[DefId(LibraryId(0), LocalDefId(3))] of char
-"v_sc2"@(FileId(1), 103..108) [Declared]: set[DefId(LibraryId(0), LocalDefId(5))] of char
+"sb"@(FileId(1), 10..24) [Declared]: <error>
+"sb"@(FileId(1), 5..7) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
+"sc"@(FileId(1), 35..46) [Declared]: <error>
+"sc"@(FileId(1), 30..32) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(2))] of char
+"sc2"@(FileId(1), 58..69) [Declared]: <error>
+"sc2"@(FileId(1), 52..55) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(4))] of char
+"v_sb"@(FileId(1), 75..79) [Declared]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
+"v_sc"@(FileId(1), 89..93) [Declared]: set[DefId(LibraryId(0), LocalDefId(2))] of char
+"v_sc2"@(FileId(1), 103..108) [Declared]: set[DefId(LibraryId(0), LocalDefId(4))] of char
 "<anonymous>"@(FileId(1), 128..139) [Declared]: <error>
 "v_anon"@(FileId(1), 119..125) [Declared]: set[DefId(LibraryId(0), LocalDefId(9))] of char
-"asc"@(FileId(1), 348..351) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(11))] of set[DefId(LibraryId(0), LocalDefId(3))] of char
-"v_asc"@(FileId(1), 361..366) [Declared]: alias[DefId(LibraryId(0), LocalDefId(11))] of set[DefId(LibraryId(0), LocalDefId(3))] of char
+"asc"@(FileId(1), 348..351) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(11))] of set[DefId(LibraryId(0), LocalDefId(2))] of char
+"v_asc"@(FileId(1), 361..366) [Declared]: alias[DefId(LibraryId(0), LocalDefId(11))] of set[DefId(LibraryId(0), LocalDefId(2))] of char
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 235..237: mismatched types

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__set_member_op_in.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__set_member_op_in.snap
@@ -4,9 +4,9 @@ assertion_line: 42
 expression: "\n    type s : set of boolean\n    var a : s\n    var b : boolean\n\n    % should all produce booleans\n    var _v_res : boolean\n\n    _v_res := b in a\n    _v_res := true in a\n    % FIXME: add tests for range types\n    "
 
 ---
-"<anonymous>"@(FileId(1), 14..28) [Declared]: <error>
-"s"@(FileId(1), 10..11) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
-"a"@(FileId(1), 37..38) [Declared]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
+"s"@(FileId(1), 14..28) [Declared]: <error>
+"s"@(FileId(1), 10..11) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
+"a"@(FileId(1), 37..38) [Declared]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
 "b"@(FileId(1), 51..52) [Declared]: boolean
 "_v_res"@(FileId(1), 106..112) [Declared]: boolean
 "<root>"@(dummy) [Declared]: <error>

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__set_member_op_not_in.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__set_member_op_not_in.snap
@@ -4,9 +4,9 @@ assertion_line: 42
 expression: "\n    type s : set of boolean\n    var a : s\n    var b : boolean\n\n    % should all produce booleans\n    var _v_res : boolean\n\n    _v_res := b ~in a\n    _v_res := true ~in a\n    % FIXME: add tests for range types\n    "
 
 ---
-"<anonymous>"@(FileId(1), 14..28) [Declared]: <error>
-"s"@(FileId(1), 10..11) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
-"a"@(FileId(1), 37..38) [Declared]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
+"s"@(FileId(1), 14..28) [Declared]: <error>
+"s"@(FileId(1), 10..11) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
+"a"@(FileId(1), 37..38) [Declared]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
 "b"@(FileId(1), 51..52) [Declared]: boolean
 "_v_res"@(FileId(1), 106..112) [Declared]: boolean
 "<root>"@(dummy) [Declared]: <error>

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__set_member_op_wrong_types_in.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__set_member_op_wrong_types_in.snap
@@ -4,9 +4,9 @@ assertion_line: 42
 expression: "\n    type ts : set of boolean\n    var s : ts\n\n    % should all produce booleans\n    var _v_res : boolean\n\n    % not a set\n    _v_res := true in true\n    % incompatible element types\n    _v_res := 1 in s\n    "
 
 ---
-"<anonymous>"@(FileId(1), 15..29) [Declared]: <error>
-"ts"@(FileId(1), 10..12) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
-"s"@(FileId(1), 38..39) [Declared]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
+"ts"@(FileId(1), 15..29) [Declared]: <error>
+"ts"@(FileId(1), 10..12) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
+"s"@(FileId(1), 38..39) [Declared]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
 "_v_res"@(FileId(1), 88..94) [Declared]: boolean
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__set_member_op_wrong_types_not_in.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__set_member_op_wrong_types_not_in.snap
@@ -4,9 +4,9 @@ assertion_line: 42
 expression: "\n    type ts : set of boolean\n    var s : ts\n\n    % should all produce booleans\n    var _v_res : boolean\n\n    % not a set\n    _v_res := true ~in true\n    % incompatible element types\n    _v_res := 1 ~in s\n    "
 
 ---
-"<anonymous>"@(FileId(1), 15..29) [Declared]: <error>
-"ts"@(FileId(1), 10..12) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
-"s"@(FileId(1), 38..39) [Declared]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
+"ts"@(FileId(1), 15..29) [Declared]: <error>
+"ts"@(FileId(1), 10..12) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
+"s"@(FileId(1), 38..39) [Declared]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
 "_v_res"@(FileId(1), 88..94) [Declared]: boolean
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__set_ops_add.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__set_ops_add.snap
@@ -4,10 +4,10 @@ assertion_line: 42
 expression: "\n    type s : set of boolean\n    var a, b : s\n\n    % should all produce the same set\n    var _v_res : s\n\n    _v_res := a + b\n    _v_res := b + a\n    "
 
 ---
-"<anonymous>"@(FileId(1), 14..28) [Declared]: <error>
-"s"@(FileId(1), 10..11) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
-"a"@(FileId(1), 37..38) [Declared]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
-"b"@(FileId(1), 40..41) [Declared]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
-"_v_res"@(FileId(1), 93..99) [Declared]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
+"s"@(FileId(1), 14..28) [Declared]: <error>
+"s"@(FileId(1), 10..11) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
+"a"@(FileId(1), 37..38) [Declared]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
+"b"@(FileId(1), 40..41) [Declared]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
+"_v_res"@(FileId(1), 93..99) [Declared]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__set_ops_mul.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__set_ops_mul.snap
@@ -4,10 +4,10 @@ assertion_line: 42
 expression: "\n    type s : set of boolean\n    var a, b : s\n\n    % should all produce the same set\n    var _v_res : s\n\n    _v_res := a * b\n    _v_res := b * a\n    "
 
 ---
-"<anonymous>"@(FileId(1), 14..28) [Declared]: <error>
-"s"@(FileId(1), 10..11) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
-"a"@(FileId(1), 37..38) [Declared]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
-"b"@(FileId(1), 40..41) [Declared]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
-"_v_res"@(FileId(1), 93..99) [Declared]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
+"s"@(FileId(1), 14..28) [Declared]: <error>
+"s"@(FileId(1), 10..11) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
+"a"@(FileId(1), 37..38) [Declared]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
+"b"@(FileId(1), 40..41) [Declared]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
+"_v_res"@(FileId(1), 93..99) [Declared]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__set_ops_sub.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__set_ops_sub.snap
@@ -4,10 +4,10 @@ assertion_line: 42
 expression: "\n    type s : set of boolean\n    var a, b : s\n\n    % should all produce the same set\n    var _v_res : s\n\n    _v_res := a - b\n    _v_res := b - a\n    "
 
 ---
-"<anonymous>"@(FileId(1), 14..28) [Declared]: <error>
-"s"@(FileId(1), 10..11) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
-"a"@(FileId(1), 37..38) [Declared]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
-"b"@(FileId(1), 40..41) [Declared]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
-"_v_res"@(FileId(1), 93..99) [Declared]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
+"s"@(FileId(1), 14..28) [Declared]: <error>
+"s"@(FileId(1), 10..11) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
+"a"@(FileId(1), 37..38) [Declared]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
+"b"@(FileId(1), 40..41) [Declared]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
+"_v_res"@(FileId(1), 93..99) [Declared]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__set_ops_wrong_types_add.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__set_ops_wrong_types_add.snap
@@ -4,14 +4,14 @@ assertion_line: 42
 expression: "\n    type s1 : set of boolean\n    type s2 : set of boolean\n    var a : s1\n    var b : s2\n    var i : int\n\n    % should all produce the left set\n    var _v_res : s1\n\n    _v_res := a + b\n\n    % error types\n    _v_res := a + i\n    _v_res := i + a\n    "
 
 ---
-"<anonymous>"@(FileId(1), 15..29) [Declared]: <error>
-"s1"@(FileId(1), 10..12) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
-"<anonymous>"@(FileId(1), 44..58) [Declared]: <error>
-"s2"@(FileId(1), 39..41) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(3))] of boolean
-"a"@(FileId(1), 67..68) [Declared]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
-"b"@(FileId(1), 82..83) [Declared]: set[DefId(LibraryId(0), LocalDefId(3))] of boolean
+"s1"@(FileId(1), 15..29) [Declared]: <error>
+"s1"@(FileId(1), 10..12) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
+"s2"@(FileId(1), 44..58) [Declared]: <error>
+"s2"@(FileId(1), 39..41) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(2))] of boolean
+"a"@(FileId(1), 67..68) [Declared]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
+"b"@(FileId(1), 82..83) [Declared]: set[DefId(LibraryId(0), LocalDefId(2))] of boolean
 "i"@(FileId(1), 97..98) [Declared]: int
-"_v_res"@(FileId(1), 152..158) [Declared]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
+"_v_res"@(FileId(1), 152..158) [Declared]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 181..182: mismatched types for addition

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__set_ops_wrong_types_mul.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__set_ops_wrong_types_mul.snap
@@ -4,14 +4,14 @@ assertion_line: 42
 expression: "\n    type s1 : set of boolean\n    type s2 : set of boolean\n    var a : s1\n    var b : s2\n    var i : int\n\n    % should all produce the left set\n    var _v_res : s1\n\n    _v_res := a * b\n\n    % error types\n    _v_res := a * i\n    _v_res := i * a\n    "
 
 ---
-"<anonymous>"@(FileId(1), 15..29) [Declared]: <error>
-"s1"@(FileId(1), 10..12) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
-"<anonymous>"@(FileId(1), 44..58) [Declared]: <error>
-"s2"@(FileId(1), 39..41) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(3))] of boolean
-"a"@(FileId(1), 67..68) [Declared]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
-"b"@(FileId(1), 82..83) [Declared]: set[DefId(LibraryId(0), LocalDefId(3))] of boolean
+"s1"@(FileId(1), 15..29) [Declared]: <error>
+"s1"@(FileId(1), 10..12) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
+"s2"@(FileId(1), 44..58) [Declared]: <error>
+"s2"@(FileId(1), 39..41) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(2))] of boolean
+"a"@(FileId(1), 67..68) [Declared]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
+"b"@(FileId(1), 82..83) [Declared]: set[DefId(LibraryId(0), LocalDefId(2))] of boolean
 "i"@(FileId(1), 97..98) [Declared]: int
-"_v_res"@(FileId(1), 152..158) [Declared]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
+"_v_res"@(FileId(1), 152..158) [Declared]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 181..182: mismatched types for multiplication

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__set_ops_wrong_types_sub.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__set_ops_wrong_types_sub.snap
@@ -4,14 +4,14 @@ assertion_line: 42
 expression: "\n    type s1 : set of boolean\n    type s2 : set of boolean\n    var a : s1\n    var b : s2\n    var i : int\n\n    % should all produce the left set\n    var _v_res : s1\n\n    _v_res := a - b\n\n    % error types\n    _v_res := a - i\n    _v_res := i - a\n    "
 
 ---
-"<anonymous>"@(FileId(1), 15..29) [Declared]: <error>
-"s1"@(FileId(1), 10..12) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
-"<anonymous>"@(FileId(1), 44..58) [Declared]: <error>
-"s2"@(FileId(1), 39..41) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(3))] of boolean
-"a"@(FileId(1), 67..68) [Declared]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
-"b"@(FileId(1), 82..83) [Declared]: set[DefId(LibraryId(0), LocalDefId(3))] of boolean
+"s1"@(FileId(1), 15..29) [Declared]: <error>
+"s1"@(FileId(1), 10..12) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
+"s2"@(FileId(1), 44..58) [Declared]: <error>
+"s2"@(FileId(1), 39..41) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(2))] of boolean
+"a"@(FileId(1), 67..68) [Declared]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
+"b"@(FileId(1), 82..83) [Declared]: set[DefId(LibraryId(0), LocalDefId(2))] of boolean
 "i"@(FileId(1), 97..98) [Declared]: int
-"_v_res"@(FileId(1), 152..158) [Declared]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
+"_v_res"@(FileId(1), 152..158) [Declared]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 181..182: mismatched types for subtraction

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_enum_ty_from_type_alias.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_enum_ty_from_type_alias.snap
@@ -5,9 +5,9 @@ expression: "type e : enum(a, b, c)"
 
 ---
 "<anonymous>"@(FileId(1), 9..22) [Declared]: <error>
-"a"@(FileId(1), 14..15) [Declared]: <error>
-"b"@(FileId(1), 17..18) [Declared]: <error>
-"c"@(FileId(1), 20..21) [Declared]: <error>
+"a"@(FileId(1), 14..15) [Declared]: enum[DefId(LibraryId(0), LocalDefId(0))] ( "a"@(FileId(1), 14..15), "b"@(FileId(1), 17..18), "c"@(FileId(1), 20..21), )
+"b"@(FileId(1), 17..18) [Declared]: enum[DefId(LibraryId(0), LocalDefId(0))] ( "a"@(FileId(1), 14..15), "b"@(FileId(1), 17..18), "c"@(FileId(1), 20..21), )
+"c"@(FileId(1), 20..21) [Declared]: enum[DefId(LibraryId(0), LocalDefId(0))] ( "a"@(FileId(1), 14..15), "b"@(FileId(1), 17..18), "c"@(FileId(1), 20..21), )
 "e"@(FileId(1), 5..6) [Resolved(Type)]: enum[DefId(LibraryId(0), LocalDefId(4))] ( "a"@(FileId(1), 14..15), "b"@(FileId(1), 17..18), "c"@(FileId(1), 20..21), )
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_enum_ty_from_type_alias.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_enum_ty_from_type_alias.snap
@@ -1,0 +1,13 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "type e : enum(a, b, c)"
+
+---
+"<anonymous>"@(FileId(1), 9..22) [Declared]: <error>
+"a"@(FileId(1), 14..15) [Declared]: <error>
+"b"@(FileId(1), 17..18) [Declared]: <error>
+"c"@(FileId(1), 20..21) [Declared]: <error>
+"e"@(FileId(1), 5..6) [Resolved(Type)]: enum[DefId(LibraryId(0), LocalDefId(4))] ( "a"@(FileId(1), 14..15), "b"@(FileId(1), 17..18), "c"@(FileId(1), 20..21), )
+"<root>"@(dummy) [Declared]: <error>
+

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_enum_ty_from_type_alias.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_enum_ty_from_type_alias.snap
@@ -4,10 +4,10 @@ assertion_line: 42
 expression: "type e : enum(a, b, c)"
 
 ---
-"<anonymous>"@(FileId(1), 9..22) [Declared]: <error>
-"a"@(FileId(1), 14..15) [Declared]: enum[DefId(LibraryId(0), LocalDefId(0))] ( "a"@(FileId(1), 14..15), "b"@(FileId(1), 17..18), "c"@(FileId(1), 20..21), )
-"b"@(FileId(1), 17..18) [Declared]: enum[DefId(LibraryId(0), LocalDefId(0))] ( "a"@(FileId(1), 14..15), "b"@(FileId(1), 17..18), "c"@(FileId(1), 20..21), )
-"c"@(FileId(1), 20..21) [Declared]: enum[DefId(LibraryId(0), LocalDefId(0))] ( "a"@(FileId(1), 14..15), "b"@(FileId(1), 17..18), "c"@(FileId(1), 20..21), )
-"e"@(FileId(1), 5..6) [Resolved(Type)]: enum[DefId(LibraryId(0), LocalDefId(4))] ( "a"@(FileId(1), 14..15), "b"@(FileId(1), 17..18), "c"@(FileId(1), 20..21), )
+"a"@(FileId(1), 14..15) [Declared]: enum[DefId(LibraryId(0), LocalDefId(3))] ( "a"@(FileId(1), 14..15), "b"@(FileId(1), 17..18), "c"@(FileId(1), 20..21), )
+"b"@(FileId(1), 17..18) [Declared]: enum[DefId(LibraryId(0), LocalDefId(3))] ( "a"@(FileId(1), 14..15), "b"@(FileId(1), 17..18), "c"@(FileId(1), 20..21), )
+"c"@(FileId(1), 20..21) [Declared]: enum[DefId(LibraryId(0), LocalDefId(3))] ( "a"@(FileId(1), 14..15), "b"@(FileId(1), 17..18), "c"@(FileId(1), 20..21), )
+"e"@(FileId(1), 9..22) [Declared]: <error>
+"e"@(FileId(1), 5..6) [Resolved(Type)]: enum[DefId(LibraryId(0), LocalDefId(3))] ( "a"@(FileId(1), 14..15), "b"@(FileId(1), 17..18), "c"@(FileId(1), 20..21), )
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_enum_ty_from_var_decl.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_enum_ty_from_var_decl.snap
@@ -1,0 +1,11 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "var _ : enum(nice)"
+
+---
+"<anonymous>"@(FileId(1), 8..18) [Declared]: <error>
+"nice"@(FileId(1), 13..17) [Declared]: <error>
+"_"@(FileId(1), 4..5) [Declared]: enum[DefId(LibraryId(0), LocalDefId(0))] ( "nice"@(FileId(1), 13..17), )
+"<root>"@(dummy) [Declared]: <error>
+

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_enum_ty_from_var_decl.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_enum_ty_from_var_decl.snap
@@ -5,7 +5,7 @@ expression: "var _ : enum(nice)"
 
 ---
 "<anonymous>"@(FileId(1), 8..18) [Declared]: <error>
-"nice"@(FileId(1), 13..17) [Declared]: <error>
+"nice"@(FileId(1), 13..17) [Declared]: enum[DefId(LibraryId(0), LocalDefId(0))] ( "nice"@(FileId(1), 13..17), )
 "_"@(FileId(1), 4..5) [Declared]: enum[DefId(LibraryId(0), LocalDefId(0))] ( "nice"@(FileId(1), 13..17), )
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_enum_ty_from_var_decl.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_enum_ty_from_var_decl.snap
@@ -4,8 +4,8 @@ assertion_line: 42
 expression: "var _ : enum(nice)"
 
 ---
+"nice"@(FileId(1), 13..17) [Declared]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "nice"@(FileId(1), 13..17), )
 "<anonymous>"@(FileId(1), 8..18) [Declared]: <error>
-"nice"@(FileId(1), 13..17) [Declared]: enum[DefId(LibraryId(0), LocalDefId(0))] ( "nice"@(FileId(1), 13..17), )
-"_"@(FileId(1), 4..5) [Declared]: enum[DefId(LibraryId(0), LocalDefId(0))] ( "nice"@(FileId(1), 13..17), )
+"_"@(FileId(1), 4..5) [Declared]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "nice"@(FileId(1), 13..17), )
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_enum_ty_no_variants.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_enum_ty_no_variants.snap
@@ -1,0 +1,10 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "type e : enum()"
+
+---
+"<anonymous>"@(FileId(1), 9..15) [Declared]: <error>
+"e"@(FileId(1), 5..6) [Resolved(Type)]: enum[DefId(LibraryId(0), LocalDefId(1))] ( )
+"<root>"@(dummy) [Declared]: <error>
+

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_enum_ty_no_variants.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_enum_ty_no_variants.snap
@@ -4,7 +4,7 @@ assertion_line: 42
 expression: "type e : enum()"
 
 ---
-"<anonymous>"@(FileId(1), 9..15) [Declared]: <error>
-"e"@(FileId(1), 5..6) [Resolved(Type)]: enum[DefId(LibraryId(0), LocalDefId(1))] ( )
+"e"@(FileId(1), 9..15) [Declared]: <error>
+"e"@(FileId(1), 5..6) [Resolved(Type)]: enum[DefId(LibraryId(0), LocalDefId(0))] ( )
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_for_normal_enum_bounds.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_for_normal_enum_bounds.snap
@@ -1,0 +1,13 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "type e : enum(a, b, c) for : e.a .. e.c end for"
+
+---
+"a"@(FileId(1), 14..15) [Declared]: enum[DefId(LibraryId(0), LocalDefId(3))] ( "a"@(FileId(1), 14..15), "b"@(FileId(1), 17..18), "c"@(FileId(1), 20..21), )
+"b"@(FileId(1), 17..18) [Declared]: enum[DefId(LibraryId(0), LocalDefId(3))] ( "a"@(FileId(1), 14..15), "b"@(FileId(1), 17..18), "c"@(FileId(1), 20..21), )
+"c"@(FileId(1), 20..21) [Declared]: enum[DefId(LibraryId(0), LocalDefId(3))] ( "a"@(FileId(1), 14..15), "b"@(FileId(1), 17..18), "c"@(FileId(1), 20..21), )
+"e"@(FileId(1), 9..22) [Declared]: <error>
+"e"@(FileId(1), 5..6) [Resolved(Type)]: enum[DefId(LibraryId(0), LocalDefId(3))] ( "a"@(FileId(1), 14..15), "b"@(FileId(1), 17..18), "c"@(FileId(1), 20..21), )
+"<root>"@(dummy) [Declared]: <error>
+

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_get_stmt_invalid_opts_chars.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_get_stmt_invalid_opts_chars.snap
@@ -1,7 +1,7 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-assertion_line: 41
-expression: "var i : int\nvar n : nat\nvar r : real\nvar c : char\nvar b: boolean\n%type en: enum(a, b) var ef : en\n\nget i : 0\nget n : 0\nget r : 0\nget c : 0\nget b : 0\n%get ef : 0\n"
+assertion_line: 42
+expression: "var i : int\nvar n : nat\nvar r : real\nvar c : char\nvar b: boolean\ntype en: enum(a, b) var ef : en\n\nget i : 0\nget n : 0\nget r : 0\nget c : 0\nget b : 0\nget ef : 0\n"
 
 ---
 "i"@(FileId(1), 4..5) [Declared]: int
@@ -9,25 +9,34 @@ expression: "var i : int\nvar n : nat\nvar r : real\nvar c : char\nvar b: boolea
 "r"@(FileId(1), 28..29) [Declared]: real
 "c"@(FileId(1), 41..42) [Declared]: char
 "b"@(FileId(1), 54..55) [Declared]: boolean
+"a"@(FileId(1), 79..80) [Declared]: enum[DefId(LibraryId(0), LocalDefId(7))] ( "a"@(FileId(1), 79..80), "b"@(FileId(1), 82..83), )
+"b"@(FileId(1), 82..83) [Declared]: enum[DefId(LibraryId(0), LocalDefId(7))] ( "a"@(FileId(1), 79..80), "b"@(FileId(1), 82..83), )
+"en"@(FileId(1), 74..84) [Declared]: <error>
+"en"@(FileId(1), 70..72) [Resolved(Type)]: enum[DefId(LibraryId(0), LocalDefId(7))] ( "a"@(FileId(1), 79..80), "b"@(FileId(1), 82..83), )
+"ef"@(FileId(1), 89..91) [Declared]: enum[DefId(LibraryId(0), LocalDefId(7))] ( "a"@(FileId(1), 79..80), "b"@(FileId(1), 82..83), )
 "<root>"@(dummy) [Declared]: <error>
 
-error in file FileId(1) at 107..108: invalid get option
-| note in file FileId(1) for 103..104: cannot specify character width for `int`
-| error in file FileId(1) for 107..108: this is the invalid option
+error in file FileId(1) at 106..107: invalid get option
+| note in file FileId(1) for 102..103: cannot specify character width for `int`
+| error in file FileId(1) for 106..107: this is the invalid option
 | info: character width can only be specified for `string` and `char(N)` types
-error in file FileId(1) at 117..118: invalid get option
-| note in file FileId(1) for 113..114: cannot specify character width for `nat`
-| error in file FileId(1) for 117..118: this is the invalid option
+error in file FileId(1) at 116..117: invalid get option
+| note in file FileId(1) for 112..113: cannot specify character width for `nat`
+| error in file FileId(1) for 116..117: this is the invalid option
 | info: character width can only be specified for `string` and `char(N)` types
-error in file FileId(1) at 127..128: invalid get option
-| note in file FileId(1) for 123..124: cannot specify character width for `real`
-| error in file FileId(1) for 127..128: this is the invalid option
+error in file FileId(1) at 126..127: invalid get option
+| note in file FileId(1) for 122..123: cannot specify character width for `real`
+| error in file FileId(1) for 126..127: this is the invalid option
 | info: character width can only be specified for `string` and `char(N)` types
-error in file FileId(1) at 137..138: invalid get option
-| note in file FileId(1) for 133..134: cannot specify character width for `char`
-| error in file FileId(1) for 137..138: this is the invalid option
+error in file FileId(1) at 136..137: invalid get option
+| note in file FileId(1) for 132..133: cannot specify character width for `char`
+| error in file FileId(1) for 136..137: this is the invalid option
 | info: character width can only be specified for `string` and `char(N)` types
-error in file FileId(1) at 147..148: invalid get option
-| note in file FileId(1) for 143..144: cannot specify character width for `boolean`
-| error in file FileId(1) for 147..148: this is the invalid option
+error in file FileId(1) at 146..147: invalid get option
+| note in file FileId(1) for 142..143: cannot specify character width for `boolean`
+| error in file FileId(1) for 146..147: this is the invalid option
+| info: character width can only be specified for `string` and `char(N)` types
+error in file FileId(1) at 157..158: invalid get option
+| note in file FileId(1) for 152..154: cannot specify character width for `enum en`
+| error in file FileId(1) for 157..158: this is the invalid option
 | info: character width can only be specified for `string` and `char(N)` types

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_get_stmt_invalid_opts_lines.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_get_stmt_invalid_opts_lines.snap
@@ -1,7 +1,7 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-assertion_line: 41
-expression: "var i : int\nvar n : nat\nvar r : real\nvar c : char\nvar b: boolean\nvar cn : char(4)\n%type en: enum(a, b) var ef : en\n\nget i : *\nget n : *\nget r : *\nget c : *\nget b : *\nget cn : *\n%get ef : *\n"
+assertion_line: 42
+expression: "var i : int\nvar n : nat\nvar r : real\nvar c : char\nvar b: boolean\nvar cn : char(4)\ntype en: enum(a, b) var ef : en\n\nget i : *\nget n : *\nget r : *\nget c : *\nget b : *\nget cn : *\nget ef : *\n"
 
 ---
 "i"@(FileId(1), 4..5) [Declared]: int
@@ -10,23 +10,31 @@ expression: "var i : int\nvar n : nat\nvar r : real\nvar c : char\nvar b: boolea
 "c"@(FileId(1), 41..42) [Declared]: char
 "b"@(FileId(1), 54..55) [Declared]: boolean
 "cn"@(FileId(1), 69..71) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
+"a"@(FileId(1), 96..97) [Declared]: enum[DefId(LibraryId(0), LocalDefId(8))] ( "a"@(FileId(1), 96..97), "b"@(FileId(1), 99..100), )
+"b"@(FileId(1), 99..100) [Declared]: enum[DefId(LibraryId(0), LocalDefId(8))] ( "a"@(FileId(1), 96..97), "b"@(FileId(1), 99..100), )
+"en"@(FileId(1), 91..101) [Declared]: <error>
+"en"@(FileId(1), 87..89) [Resolved(Type)]: enum[DefId(LibraryId(0), LocalDefId(8))] ( "a"@(FileId(1), 96..97), "b"@(FileId(1), 99..100), )
+"ef"@(FileId(1), 106..108) [Declared]: enum[DefId(LibraryId(0), LocalDefId(8))] ( "a"@(FileId(1), 96..97), "b"@(FileId(1), 99..100), )
 "<root>"@(dummy) [Declared]: <error>
 
-error in file FileId(1) at 120..121: invalid get option used
-| error in file FileId(1) for 120..121: cannot specify line width for `int`
+error in file FileId(1) at 119..120: invalid get option used
+| error in file FileId(1) for 119..120: cannot specify line width for `int`
 | info: line width can only be specified for `string` types
-error in file FileId(1) at 130..131: invalid get option used
-| error in file FileId(1) for 130..131: cannot specify line width for `nat`
+error in file FileId(1) at 129..130: invalid get option used
+| error in file FileId(1) for 129..130: cannot specify line width for `nat`
 | info: line width can only be specified for `string` types
-error in file FileId(1) at 140..141: invalid get option used
-| error in file FileId(1) for 140..141: cannot specify line width for `real`
+error in file FileId(1) at 139..140: invalid get option used
+| error in file FileId(1) for 139..140: cannot specify line width for `real`
 | info: line width can only be specified for `string` types
-error in file FileId(1) at 150..151: invalid get option used
-| error in file FileId(1) for 150..151: cannot specify line width for `char`
+error in file FileId(1) at 149..150: invalid get option used
+| error in file FileId(1) for 149..150: cannot specify line width for `char`
 | info: line width can only be specified for `string` types
-error in file FileId(1) at 160..161: invalid get option used
-| error in file FileId(1) for 160..161: cannot specify line width for `boolean`
+error in file FileId(1) at 159..160: invalid get option used
+| error in file FileId(1) for 159..160: cannot specify line width for `boolean`
 | info: line width can only be specified for `string` types
-error in file FileId(1) at 170..172: invalid get option used
-| error in file FileId(1) for 170..172: cannot specify line width for `char(4)`
+error in file FileId(1) at 169..171: invalid get option used
+| error in file FileId(1) for 169..171: cannot specify line width for `char(4)`
+| info: line width can only be specified for `string` types
+error in file FileId(1) at 180..182: invalid get option used
+| error in file FileId(1) for 180..182: cannot specify line width for `enum en`
 | info: line width can only be specified for `string` types

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_get_stmt_normal_items.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_get_stmt_normal_items.snap
@@ -1,7 +1,7 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-assertion_line: 41
-expression: "var i : int\nvar n : nat\nvar r : real\nvar c : char\nvar b: boolean\nvar cn : char(4)\nvar s : string\nvar sn : string(4)\n%type en: enum(a, b) var ef : en\n\nget i\nget n\nget r\nget c\nget b\nget cn\nget s\nget sn\n%get ef\n"
+assertion_line: 42
+expression: "var i : int\nvar n : nat\nvar r : real\nvar c : char\nvar b: boolean\nvar cn : char(4)\nvar s : string\nvar sn : string(4)\ntype en: enum(a, b) var ef : en\n\nget i\nget n\nget r\nget c\nget b\nget cn\nget s\nget sn\nget ef\n"
 
 ---
 "i"@(FileId(1), 4..5) [Declared]: int
@@ -12,5 +12,10 @@ expression: "var i : int\nvar n : nat\nvar r : real\nvar c : char\nvar b: boolea
 "cn"@(FileId(1), 69..71) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
 "s"@(FileId(1), 86..87) [Declared]: string
 "sn"@(FileId(1), 101..103) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
+"a"@(FileId(1), 130..131) [Declared]: enum[DefId(LibraryId(0), LocalDefId(10))] ( "a"@(FileId(1), 130..131), "b"@(FileId(1), 133..134), )
+"b"@(FileId(1), 133..134) [Declared]: enum[DefId(LibraryId(0), LocalDefId(10))] ( "a"@(FileId(1), 130..131), "b"@(FileId(1), 133..134), )
+"en"@(FileId(1), 125..135) [Declared]: <error>
+"en"@(FileId(1), 121..123) [Resolved(Type)]: enum[DefId(LibraryId(0), LocalDefId(10))] ( "a"@(FileId(1), 130..131), "b"@(FileId(1), 133..134), )
+"ef"@(FileId(1), 140..142) [Declared]: enum[DefId(LibraryId(0), LocalDefId(10))] ( "a"@(FileId(1), 130..131), "b"@(FileId(1), 133..134), )
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_opaque_alias_of_set.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_opaque_alias_of_set.snap
@@ -6,11 +6,11 @@ expression: "var *_ : boolean\n\nmodule m\n    export opaque s, var a\n    type 
 ---
 "_"@(FileId(1), 5..6) [Declared]: boolean
 "m"@(FileId(1), 25..26) [Declared]: <error>
-"<anonymous>"@(FileId(1), 67..81) [Declared]: <error>
-"s"@(FileId(1), 63..64) [Resolved(Type)]: opaque[DefId(LibraryId(0), LocalDefId(3))] type to set[DefId(LibraryId(0), LocalDefId(3))] of boolean
-"a"@(FileId(1), 90..91) [Declared]: opaque[DefId(LibraryId(0), LocalDefId(3))] type to set[DefId(LibraryId(0), LocalDefId(3))] of boolean
-"s"@(FileId(1), 38..46) [ItemExport(LocalDefId(3))]: opaque[DefId(LibraryId(0), LocalDefId(3))] type to set[DefId(LibraryId(0), LocalDefId(3))] of boolean
-"a"@(FileId(1), 48..53) [ItemExport(LocalDefId(4))]: opaque[DefId(LibraryId(0), LocalDefId(3))] type to set[DefId(LibraryId(0), LocalDefId(3))] of boolean
+"s"@(FileId(1), 67..81) [Declared]: <error>
+"s"@(FileId(1), 63..64) [Resolved(Type)]: opaque[DefId(LibraryId(0), LocalDefId(3))] type to set[DefId(LibraryId(0), LocalDefId(2))] of boolean
+"a"@(FileId(1), 90..91) [Declared]: opaque[DefId(LibraryId(0), LocalDefId(3))] type to set[DefId(LibraryId(0), LocalDefId(2))] of boolean
+"s"@(FileId(1), 38..46) [ItemExport(LocalDefId(3))]: opaque[DefId(LibraryId(0), LocalDefId(3))] type to set[DefId(LibraryId(0), LocalDefId(2))] of boolean
+"a"@(FileId(1), 48..53) [ItemExport(LocalDefId(4))]: opaque[DefId(LibraryId(0), LocalDefId(3))] type to set[DefId(LibraryId(0), LocalDefId(2))] of boolean
 "vs"@(FileId(1), 147..149) [Declared]: <error>
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_opaque_ty_poke_opaque_set_cons_param.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_opaque_ty_poke_opaque_set_cons_param.snap
@@ -6,16 +6,16 @@ expression: "module m\n    export opaque t, ~.* s, make\n    type t : char\n    
 ---
 "m"@(FileId(1), 7..8) [Declared]: <error>
 "t"@(FileId(1), 51..52) [Resolved(Type)]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
-"<anonymous>"@(FileId(1), 73..81) [Declared]: <error>
-"s"@(FileId(1), 69..70) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(3))] of opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
+"s"@(FileId(1), 73..81) [Declared]: <error>
+"s"@(FileId(1), 69..70) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(2))] of opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
 "make"@(FileId(1), 91..95) [Declared]: function ( pass(value) char, ) -> opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
 "<unnamed>"@(dummy) [Declared]: <error>
 "c"@(FileId(1), 96..97) [Declared]: char
-"a"@(FileId(1), 173..174) [Declared]: set[DefId(LibraryId(0), LocalDefId(3))] of opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
+"a"@(FileId(1), 173..174) [Declared]: set[DefId(LibraryId(0), LocalDefId(2))] of opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
 "t"@(FileId(1), 20..28) [ItemExport(LocalDefId(1))]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
-"s"@(FileId(1), 30..35) [ItemExport(LocalDefId(3))]: set[DefId(LibraryId(0), LocalDefId(3))] of opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
+"s"@(FileId(1), 30..35) [ItemExport(LocalDefId(3))]: set[DefId(LibraryId(0), LocalDefId(2))] of opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
 "make"@(FileId(1), 37..41) [ItemExport(LocalDefId(4))]: function ( pass(value) char, ) -> opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
-"vs"@(FileId(1), 241..243) [Declared]: set[DefId(LibraryId(0), LocalDefId(3))] of opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
+"vs"@(FileId(1), 241..243) [Declared]: set[DefId(LibraryId(0), LocalDefId(2))] of opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 253..256: mismatched types

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_opaque_ty_poke_opaque_set_elem_ty.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_opaque_ty_poke_opaque_set_elem_ty.snap
@@ -6,17 +6,17 @@ expression: "module m\n    export opaque ~.* t, ~.* s, make\n    type t : char\n
 ---
 "m"@(FileId(1), 7..8) [Declared]: <error>
 "t"@(FileId(1), 55..56) [Resolved(Type)]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
-"<anonymous>"@(FileId(1), 77..85) [Declared]: <error>
-"s"@(FileId(1), 73..74) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(3))] of opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
+"s"@(FileId(1), 77..85) [Declared]: <error>
+"s"@(FileId(1), 73..74) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(2))] of opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
 "make"@(FileId(1), 94..98) [Declared]: function ( pass(value) char, ) -> opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
 "<unnamed>"@(dummy) [Declared]: <error>
 "c"@(FileId(1), 99..100) [Declared]: char
 "t"@(FileId(1), 20..32) [ItemExport(LocalDefId(1))]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
-"s"@(FileId(1), 34..39) [ItemExport(LocalDefId(3))]: set[DefId(LibraryId(0), LocalDefId(3))] of opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
+"s"@(FileId(1), 34..39) [ItemExport(LocalDefId(3))]: set[DefId(LibraryId(0), LocalDefId(2))] of opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
 "make"@(FileId(1), 41..45) [ItemExport(LocalDefId(4))]: function ( pass(value) char, ) -> opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
-"<anonymous>"@(FileId(1), 187..195) [Declared]: <error>
-"xs"@(FileId(1), 182..184) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(11))] of opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
-"vs"@(FileId(1), 200..202) [Declared]: set[DefId(LibraryId(0), LocalDefId(3))] of opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
+"xs"@(FileId(1), 187..195) [Declared]: <error>
+"xs"@(FileId(1), 182..184) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(10))] of opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
+"vs"@(FileId(1), 200..202) [Declared]: set[DefId(LibraryId(0), LocalDefId(2))] of opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
 "_"@(FileId(1), 239..240) [Declared]: boolean
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_put_stmt_invalid_extended_opts.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_put_stmt_invalid_extended_opts.snap
@@ -1,44 +1,57 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-assertion_line: 41
-expression: "% TODO: Uncomment enum lines once enum types are lowered & checked\nvar c : char\nvar cn : char(4)\nvar s : string\nvar sn : string(4)\n%type en: enum(a, b) var ef : en\n\nput c : 0 : 0 : 0\nput cn : 0 : 0 : 0\nput s : 0 : 0 : 0\nput sn : 0 : 0 : 0\n%put ef : 0 : 0 : 0\n"
+assertion_line: 42
+expression: "var c : char\nvar cn : char(4)\nvar s : string\nvar sn : string(4)\ntype en: enum(a, b) var ef : en\n\nput c : 0 : 0 : 0\nput cn : 0 : 0 : 0\nput s : 0 : 0 : 0\nput sn : 0 : 0 : 0\nput ef : 0 : 0 : 0\n"
 
 ---
-"c"@(FileId(1), 71..72) [Declared]: char
-"cn"@(FileId(1), 84..86) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
-"s"@(FileId(1), 101..102) [Declared]: string
-"sn"@(FileId(1), 116..118) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
+"c"@(FileId(1), 4..5) [Declared]: char
+"cn"@(FileId(1), 17..19) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
+"s"@(FileId(1), 34..35) [Declared]: string
+"sn"@(FileId(1), 49..51) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
+"a"@(FileId(1), 78..79) [Declared]: enum[DefId(LibraryId(0), LocalDefId(6))] ( "a"@(FileId(1), 78..79), "b"@(FileId(1), 81..82), )
+"b"@(FileId(1), 81..82) [Declared]: enum[DefId(LibraryId(0), LocalDefId(6))] ( "a"@(FileId(1), 78..79), "b"@(FileId(1), 81..82), )
+"en"@(FileId(1), 73..83) [Declared]: <error>
+"en"@(FileId(1), 69..71) [Resolved(Type)]: enum[DefId(LibraryId(0), LocalDefId(6))] ( "a"@(FileId(1), 78..79), "b"@(FileId(1), 81..82), )
+"ef"@(FileId(1), 88..90) [Declared]: enum[DefId(LibraryId(0), LocalDefId(6))] ( "a"@(FileId(1), 78..79), "b"@(FileId(1), 81..82), )
 "<root>"@(dummy) [Declared]: <error>
 
-error in file FileId(1) at 177..178: invalid put option
-| note in file FileId(1) for 169..170: cannot specify fraction width for `char`
-| error in file FileId(1) for 177..178: this is the invalid option
+error in file FileId(1) at 109..110: invalid put option
+| note in file FileId(1) for 101..102: cannot specify fraction width for `char`
+| error in file FileId(1) for 109..110: this is the invalid option
 | info: fraction width can only be specified for numeric put types
-error in file FileId(1) at 181..182: invalid put option
-| note in file FileId(1) for 169..170: cannot specify exponent width for `char`
-| error in file FileId(1) for 181..182: this is the invalid option
+error in file FileId(1) at 113..114: invalid put option
+| note in file FileId(1) for 101..102: cannot specify exponent width for `char`
+| error in file FileId(1) for 113..114: this is the invalid option
 | info: exponent width can only be specified for numeric types
-error in file FileId(1) at 196..197: invalid put option
-| note in file FileId(1) for 187..189: cannot specify fraction width for `char(4)`
-| error in file FileId(1) for 196..197: this is the invalid option
+error in file FileId(1) at 128..129: invalid put option
+| note in file FileId(1) for 119..121: cannot specify fraction width for `char(4)`
+| error in file FileId(1) for 128..129: this is the invalid option
 | info: fraction width can only be specified for numeric put types
-error in file FileId(1) at 200..201: invalid put option
-| note in file FileId(1) for 187..189: cannot specify exponent width for `char(4)`
-| error in file FileId(1) for 200..201: this is the invalid option
+error in file FileId(1) at 132..133: invalid put option
+| note in file FileId(1) for 119..121: cannot specify exponent width for `char(4)`
+| error in file FileId(1) for 132..133: this is the invalid option
 | info: exponent width can only be specified for numeric types
-error in file FileId(1) at 214..215: invalid put option
-| note in file FileId(1) for 206..207: cannot specify fraction width for `string`
-| error in file FileId(1) for 214..215: this is the invalid option
+error in file FileId(1) at 146..147: invalid put option
+| note in file FileId(1) for 138..139: cannot specify fraction width for `string`
+| error in file FileId(1) for 146..147: this is the invalid option
 | info: fraction width can only be specified for numeric put types
-error in file FileId(1) at 218..219: invalid put option
-| note in file FileId(1) for 206..207: cannot specify exponent width for `string`
-| error in file FileId(1) for 218..219: this is the invalid option
+error in file FileId(1) at 150..151: invalid put option
+| note in file FileId(1) for 138..139: cannot specify exponent width for `string`
+| error in file FileId(1) for 150..151: this is the invalid option
 | info: exponent width can only be specified for numeric types
-error in file FileId(1) at 233..234: invalid put option
-| note in file FileId(1) for 224..226: cannot specify fraction width for `string(4)`
-| error in file FileId(1) for 233..234: this is the invalid option
+error in file FileId(1) at 165..166: invalid put option
+| note in file FileId(1) for 156..158: cannot specify fraction width for `string(4)`
+| error in file FileId(1) for 165..166: this is the invalid option
 | info: fraction width can only be specified for numeric put types
-error in file FileId(1) at 237..238: invalid put option
-| note in file FileId(1) for 224..226: cannot specify exponent width for `string(4)`
-| error in file FileId(1) for 237..238: this is the invalid option
+error in file FileId(1) at 169..170: invalid put option
+| note in file FileId(1) for 156..158: cannot specify exponent width for `string(4)`
+| error in file FileId(1) for 169..170: this is the invalid option
+| info: exponent width can only be specified for numeric types
+error in file FileId(1) at 184..185: invalid put option
+| note in file FileId(1) for 175..177: cannot specify fraction width for `enum en`
+| error in file FileId(1) for 184..185: this is the invalid option
+| info: fraction width can only be specified for numeric put types
+error in file FileId(1) at 188..189: invalid put option
+| note in file FileId(1) for 175..177: cannot specify exponent width for `enum en`
+| error in file FileId(1) for 188..189: this is the invalid option
 | info: exponent width can only be specified for numeric types

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_put_stmt_normal_items.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_put_stmt_normal_items.snap
@@ -1,15 +1,20 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-assertion_line: 41
-expression: "% TODO: Uncomment enum lines once enum types are lowered & checked\nvar i : int\nvar n : nat\nvar r : real\nvar c : char\nvar cn : char(4)\nvar s : string\nvar sn : string(4)\n%type en: enum(a, b) var ef : en\n\nput i : 0\nput n : 0\nput r : 0\nput c : 0\nput cn : 0\nput s : 0\nput sn : 0\n%put ef : 0\n"
+assertion_line: 42
+expression: "var i : int\nvar n : nat\nvar r : real\nvar c : char\nvar cn : char(4)\nvar s : string\nvar sn : string(4)\ntype en: enum(a, b) var ef : en\n\nput i : 0\nput n : 0\nput r : 0\nput c : 0\nput cn : 0\nput s : 0\nput sn : 0\nput ef : 0\n"
 
 ---
-"i"@(FileId(1), 71..72) [Declared]: int
-"n"@(FileId(1), 83..84) [Declared]: nat
-"r"@(FileId(1), 95..96) [Declared]: real
-"c"@(FileId(1), 108..109) [Declared]: char
-"cn"@(FileId(1), 121..123) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
-"s"@(FileId(1), 138..139) [Declared]: string
-"sn"@(FileId(1), 153..155) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
+"i"@(FileId(1), 4..5) [Declared]: int
+"n"@(FileId(1), 16..17) [Declared]: nat
+"r"@(FileId(1), 28..29) [Declared]: real
+"c"@(FileId(1), 41..42) [Declared]: char
+"cn"@(FileId(1), 54..56) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
+"s"@(FileId(1), 71..72) [Declared]: string
+"sn"@(FileId(1), 86..88) [Declared]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
+"a"@(FileId(1), 115..116) [Declared]: enum[DefId(LibraryId(0), LocalDefId(9))] ( "a"@(FileId(1), 115..116), "b"@(FileId(1), 118..119), )
+"b"@(FileId(1), 118..119) [Declared]: enum[DefId(LibraryId(0), LocalDefId(9))] ( "a"@(FileId(1), 115..116), "b"@(FileId(1), 118..119), )
+"en"@(FileId(1), 110..120) [Declared]: <error>
+"en"@(FileId(1), 106..108) [Resolved(Type)]: enum[DefId(LibraryId(0), LocalDefId(9))] ( "a"@(FileId(1), 115..116), "b"@(FileId(1), 118..119), )
+"ef"@(FileId(1), 125..127) [Declared]: enum[DefId(LibraryId(0), LocalDefId(9))] ( "a"@(FileId(1), 115..116), "b"@(FileId(1), 118..119), )
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_cons_call_all.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_cons_call_all.snap
@@ -4,8 +4,8 @@ assertion_line: 42
 expression: "type s : set of boolean\nvar _ := s(all)\n"
 
 ---
-"<anonymous>"@(FileId(1), 9..23) [Declared]: <error>
-"s"@(FileId(1), 5..6) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
-"_"@(FileId(1), 28..29) [Declared]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
+"s"@(FileId(1), 9..23) [Declared]: <error>
+"s"@(FileId(1), 5..6) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
+"_"@(FileId(1), 28..29) [Declared]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_cons_call_all_err_extra_arg_end_range.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_cons_call_all_err_extra_arg_end_range.snap
@@ -4,10 +4,10 @@ assertion_line: 42
 expression: "type s : set of boolean\nvar _ := s(*, all, b .. * - b)\n"
 
 ---
-"<anonymous>"@(FileId(1), 9..23) [Declared]: <error>
-"s"@(FileId(1), 5..6) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
+"s"@(FileId(1), 9..23) [Declared]: <error>
+"s"@(FileId(1), 5..6) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
 "b"@(FileId(1), 43..44) [Undeclared]: <error>
-"_"@(FileId(1), 28..29) [Declared]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
+"_"@(FileId(1), 28..29) [Declared]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 33..34: constructor call has extra arguments

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_cons_call_all_err_extra_args_after.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_cons_call_all_err_extra_args_after.snap
@@ -4,10 +4,10 @@ assertion_line: 42
 expression: "type s : set of boolean\nvar b : boolean\nvar _ := s(all, b, b, b, b)\n"
 
 ---
-"<anonymous>"@(FileId(1), 9..23) [Declared]: <error>
-"s"@(FileId(1), 5..6) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
+"s"@(FileId(1), 9..23) [Declared]: <error>
+"s"@(FileId(1), 5..6) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
 "b"@(FileId(1), 28..29) [Declared]: boolean
-"_"@(FileId(1), 44..45) [Declared]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
+"_"@(FileId(1), 44..45) [Declared]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 49..50: constructor call has extra arguments

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_cons_call_all_err_extra_args_before.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_cons_call_all_err_extra_args_before.snap
@@ -4,10 +4,10 @@ assertion_line: 42
 expression: "type s : set of boolean\nvar b : boolean\nvar _ := s(b, b, b, b, all)\n"
 
 ---
-"<anonymous>"@(FileId(1), 9..23) [Declared]: <error>
-"s"@(FileId(1), 5..6) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
+"s"@(FileId(1), 9..23) [Declared]: <error>
+"s"@(FileId(1), 5..6) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
 "b"@(FileId(1), 28..29) [Declared]: boolean
-"_"@(FileId(1), 44..45) [Declared]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
+"_"@(FileId(1), 44..45) [Declared]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 49..50: constructor call has extra arguments

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_cons_call_all_err_extra_args_between.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_cons_call_all_err_extra_args_between.snap
@@ -4,10 +4,10 @@ assertion_line: 42
 expression: "type s : set of boolean\nvar b : boolean\nvar _ := s(b, b, all, b, b)\n"
 
 ---
-"<anonymous>"@(FileId(1), 9..23) [Declared]: <error>
-"s"@(FileId(1), 5..6) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
+"s"@(FileId(1), 9..23) [Declared]: <error>
+"s"@(FileId(1), 5..6) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
 "b"@(FileId(1), 28..29) [Declared]: boolean
-"_"@(FileId(1), 44..45) [Declared]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
+"_"@(FileId(1), 44..45) [Declared]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 49..50: constructor call has extra arguments

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_cons_call_all_err_extra_args_range.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_cons_call_all_err_extra_args_range.snap
@@ -4,10 +4,10 @@ assertion_line: 42
 expression: "type s : set of boolean\nvar b : boolean\nvar _ := s(1 .. 2, all, 3 .. 4)\n"
 
 ---
-"<anonymous>"@(FileId(1), 9..23) [Declared]: <error>
-"s"@(FileId(1), 5..6) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
+"s"@(FileId(1), 9..23) [Declared]: <error>
+"s"@(FileId(1), 5..6) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
 "b"@(FileId(1), 28..29) [Declared]: boolean
-"_"@(FileId(1), 44..45) [Declared]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
+"_"@(FileId(1), 44..45) [Declared]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 49..50: constructor call has extra arguments

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_cons_call_all_err_wrong_binding.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_cons_call_all_err_wrong_binding.snap
@@ -4,10 +4,10 @@ assertion_line: 42
 expression: "type s : set of boolean\ntype b : boolean\nvar _ := s(all, b)\n"
 
 ---
-"<anonymous>"@(FileId(1), 9..23) [Declared]: <error>
-"s"@(FileId(1), 5..6) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
+"s"@(FileId(1), 9..23) [Declared]: <error>
+"s"@(FileId(1), 5..6) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
 "b"@(FileId(1), 29..30) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(2))] of boolean
-"_"@(FileId(1), 45..46) [Declared]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
+"_"@(FileId(1), 45..46) [Declared]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 50..51: constructor call has extra arguments

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_cons_call_all_err_wrong_ty.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_cons_call_all_err_wrong_ty.snap
@@ -4,9 +4,9 @@ assertion_line: 42
 expression: "type s : set of boolean\nvar _ := s(all, 1)\n"
 
 ---
-"<anonymous>"@(FileId(1), 9..23) [Declared]: <error>
-"s"@(FileId(1), 5..6) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
-"_"@(FileId(1), 28..29) [Declared]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
+"s"@(FileId(1), 9..23) [Declared]: <error>
+"s"@(FileId(1), 5..6) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
+"_"@(FileId(1), 28..29) [Declared]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 33..34: constructor call has extra arguments

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_cons_call_args_err_not_from_ty.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_cons_call_args_err_not_from_ty.snap
@@ -4,9 +4,9 @@ assertion_line: 42
 expression: "type s : set of boolean\nvar k : s\nk := k()\n"
 
 ---
-"<anonymous>"@(FileId(1), 9..23) [Declared]: <error>
-"s"@(FileId(1), 5..6) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
-"k"@(FileId(1), 28..29) [Declared]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
+"s"@(FileId(1), 9..23) [Declared]: <error>
+"s"@(FileId(1), 5..6) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
+"k"@(FileId(1), 28..29) [Declared]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 39..40: cannot call or subscript `k`

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_cons_call_args_err_wrong_binding.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_cons_call_args_err_wrong_binding.snap
@@ -4,10 +4,10 @@ assertion_line: 42
 expression: "type s : set of boolean\ntype b : boolean\nvar _ := s(b)\n"
 
 ---
-"<anonymous>"@(FileId(1), 9..23) [Declared]: <error>
-"s"@(FileId(1), 5..6) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
+"s"@(FileId(1), 9..23) [Declared]: <error>
+"s"@(FileId(1), 5..6) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
 "b"@(FileId(1), 29..30) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(2))] of boolean
-"_"@(FileId(1), 45..46) [Declared]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
+"_"@(FileId(1), 45..46) [Declared]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 52..53: cannot use `b` as an expression

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_cons_call_args_err_wrong_ty.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_cons_call_args_err_wrong_ty.snap
@@ -4,9 +4,9 @@ assertion_line: 42
 expression: "type s : set of boolean\nvar _ := s(1, 2, 3)\n"
 
 ---
-"<anonymous>"@(FileId(1), 9..23) [Declared]: <error>
-"s"@(FileId(1), 5..6) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
-"_"@(FileId(1), 28..29) [Declared]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
+"s"@(FileId(1), 9..23) [Declared]: <error>
+"s"@(FileId(1), 5..6) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
+"_"@(FileId(1), 28..29) [Declared]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 35..36: mismatched types

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_cons_call_empty_set.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_cons_call_empty_set.snap
@@ -4,8 +4,8 @@ assertion_line: 42
 expression: "type s : set of boolean\nvar _ := s()\n"
 
 ---
-"<anonymous>"@(FileId(1), 9..23) [Declared]: <error>
-"s"@(FileId(1), 5..6) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
-"_"@(FileId(1), 28..29) [Declared]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
+"s"@(FileId(1), 9..23) [Declared]: <error>
+"s"@(FileId(1), 5..6) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
+"_"@(FileId(1), 28..29) [Declared]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_cons_call_err_as_stmt.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_cons_call_err_as_stmt.snap
@@ -4,8 +4,8 @@ assertion_line: 42
 expression: "type s : set of boolean\ns()\n"
 
 ---
-"<anonymous>"@(FileId(1), 9..23) [Declared]: <error>
-"s"@(FileId(1), 5..6) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
+"s"@(FileId(1), 9..23) [Declared]: <error>
+"s"@(FileId(1), 5..6) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 24..25: cannot use expression as a statement

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_cons_call_err_just_itself.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_cons_call_err_just_itself.snap
@@ -4,9 +4,9 @@ assertion_line: 42
 expression: "type s : set of boolean\nvar _ := s\ns\n"
 
 ---
-"<anonymous>"@(FileId(1), 9..23) [Declared]: <error>
-"s"@(FileId(1), 5..6) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
-"_"@(FileId(1), 28..29) [Declared]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
+"s"@(FileId(1), 9..23) [Declared]: <error>
+"s"@(FileId(1), 5..6) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
+"_"@(FileId(1), 28..29) [Declared]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 33..34: cannot use `s` as an expression

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_cons_call_normal.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_cons_call_normal.snap
@@ -4,8 +4,8 @@ assertion_line: 42
 expression: "type s : set of boolean\nvar _ := s(true, false, true, false)\n"
 
 ---
-"<anonymous>"@(FileId(1), 9..23) [Declared]: <error>
-"s"@(FileId(1), 5..6) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
-"_"@(FileId(1), 28..29) [Declared]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
+"s"@(FileId(1), 9..23) [Declared]: <error>
+"s"@(FileId(1), 5..6) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
+"_"@(FileId(1), 28..29) [Declared]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_ty_from_type_alias.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_ty_from_type_alias.snap
@@ -4,8 +4,8 @@ assertion_line: 42
 expression: "type s : set of boolean var _ : s"
 
 ---
-"<anonymous>"@(FileId(1), 9..23) [Declared]: <error>
-"s"@(FileId(1), 5..6) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
-"_"@(FileId(1), 28..29) [Declared]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
+"s"@(FileId(1), 9..23) [Declared]: <error>
+"s"@(FileId(1), 5..6) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
+"_"@(FileId(1), 28..29) [Declared]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_ty_large_range_integer.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_ty_large_range_integer.snap
@@ -5,10 +5,10 @@ expression: "type bogos : int\ntype _si : set of bogos\ntype _sn : set of nat\n"
 
 ---
 "bogos"@(FileId(1), 5..10) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of int
-"<anonymous>"@(FileId(1), 28..40) [Declared]: <error>
-"_si"@(FileId(1), 22..25) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(2))] of alias[DefId(LibraryId(0), LocalDefId(0))] of int
-"<anonymous>"@(FileId(1), 52..62) [Declared]: <error>
-"_sn"@(FileId(1), 46..49) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(4))] of nat
+"_si"@(FileId(1), 28..40) [Declared]: <error>
+"_si"@(FileId(1), 22..25) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(1))] of alias[DefId(LibraryId(0), LocalDefId(0))] of int
+"_sn"@(FileId(1), 52..62) [Declared]: <error>
+"_sn"@(FileId(1), 46..49) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(3))] of nat
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 35..40: element range is too large

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_ty_not_index_ty.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_ty_not_index_ty.snap
@@ -4,8 +4,8 @@ assertion_line: 42
 expression: "type _ : set of real"
 
 ---
-"<anonymous>"@(FileId(1), 9..20) [Declared]: <error>
-"_"@(FileId(1), 5..6) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(1))] of real
+"_"@(FileId(1), 9..20) [Declared]: <error>
+"_"@(FileId(1), 5..6) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(0))] of real
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 16..20: mismatched types

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_ty_valid_index_ty.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_ty_valid_index_ty.snap
@@ -1,15 +1,20 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
 assertion_line: 42
-expression: "% FIXME: Add corresponding test for range types\ntype r : char\ntype _a : set of r\ntype _b : set of boolean\ntype _c : set of char\n"
+expression: "% FIXME: Add corresponding test for range types\ntype r : char\ntype e : enum(v)\ntype _a : set of r\ntype _b : set of boolean\ntype _c : set of char\ntype _d : set of e\n"
 
 ---
 "r"@(FileId(1), 53..54) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of char
-"_a"@(FileId(1), 72..80) [Declared]: <error>
-"_a"@(FileId(1), 67..69) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(1))] of alias[DefId(LibraryId(0), LocalDefId(0))] of char
-"_b"@(FileId(1), 91..105) [Declared]: <error>
-"_b"@(FileId(1), 86..88) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(3))] of boolean
-"_c"@(FileId(1), 116..127) [Declared]: <error>
-"_c"@(FileId(1), 111..113) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(5))] of char
+"v"@(FileId(1), 76..77) [Declared]: enum[DefId(LibraryId(0), LocalDefId(2))] ( "v"@(FileId(1), 76..77), )
+"e"@(FileId(1), 71..78) [Declared]: <error>
+"e"@(FileId(1), 67..68) [Resolved(Type)]: enum[DefId(LibraryId(0), LocalDefId(2))] ( "v"@(FileId(1), 76..77), )
+"_a"@(FileId(1), 89..97) [Declared]: <error>
+"_a"@(FileId(1), 84..86) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(4))] of alias[DefId(LibraryId(0), LocalDefId(0))] of char
+"_b"@(FileId(1), 108..122) [Declared]: <error>
+"_b"@(FileId(1), 103..105) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(6))] of boolean
+"_c"@(FileId(1), 133..144) [Declared]: <error>
+"_c"@(FileId(1), 128..130) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(8))] of char
+"_d"@(FileId(1), 155..163) [Declared]: <error>
+"_d"@(FileId(1), 150..152) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(10))] of enum[DefId(LibraryId(0), LocalDefId(2))] ( "v"@(FileId(1), 76..77), )
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_ty_valid_index_ty.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_ty_valid_index_ty.snap
@@ -5,11 +5,11 @@ expression: "% FIXME: Add corresponding test for range types\ntype r : char\ntyp
 
 ---
 "r"@(FileId(1), 53..54) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of char
-"<anonymous>"@(FileId(1), 72..80) [Declared]: <error>
-"_a"@(FileId(1), 67..69) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(2))] of alias[DefId(LibraryId(0), LocalDefId(0))] of char
-"<anonymous>"@(FileId(1), 91..105) [Declared]: <error>
-"_b"@(FileId(1), 86..88) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(4))] of boolean
-"<anonymous>"@(FileId(1), 116..127) [Declared]: <error>
-"_c"@(FileId(1), 111..113) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(6))] of char
+"_a"@(FileId(1), 72..80) [Declared]: <error>
+"_a"@(FileId(1), 67..69) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(1))] of alias[DefId(LibraryId(0), LocalDefId(0))] of char
+"_b"@(FileId(1), 91..105) [Declared]: <error>
+"_b"@(FileId(1), 86..88) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(3))] of boolean
+"_c"@(FileId(1), 116..127) [Declared]: <error>
+"_c"@(FileId(1), 111..113) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(5))] of char
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/test.rs
+++ b/compiler/toc_analysis/src/typeck/test.rs
@@ -533,6 +533,27 @@ test_for_each_op! { comparison_op_charseqs,
     "#,
 }
 
+test_for_each_op! { comparison_op_enums,
+    [
+        ("<", less),
+        (">", greater),
+        ("<=", less_eq),
+        (">=", greater_eq),
+        ("=", equal),
+        ("not=", not_equal),
+    ] => r#"
+    type s : enum(a)
+    var a, b : s
+
+    % should all produce booleans
+    var _v_res : boolean
+
+    _v_res := a {0} b
+    _v_res := b {0} a
+    % enum variants are covered by equivalence rules
+    "#,
+}
+
 test_for_each_op! { comparison_op_sets,
     [
         ("<", less),
@@ -637,6 +658,32 @@ test_for_each_op! { comparison_op_wrong_types,
     _v_res := bs1 {0} as2
     _v_res := aas {0} as1
     _v_res := as1 {0} aas
+    "#
+}
+
+test_for_each_op! { comparison_op_wrong_types_enums,
+    [
+        ("<", less),
+        (">", greater),
+        ("<=", less_eq),
+        (">=", greater_eq),
+        ("=", equal),
+        ("not=", not_equal),
+    ] => r#"
+    % Different enums
+    type e1 : enum(v)
+    type e2 : enum(v)
+    var ae1 : e1
+    var be2 : e2
+    var aas : enum(v)
+
+    % should all produce boolean anyway
+    var _v_res : boolean
+
+    _v_res := ae1 {0} be2
+    _v_res := be1 {0} ae2
+    _v_res := aes {0} ae1
+    _v_res := ae1 {0} aes
     "#
 }
 
@@ -1406,7 +1453,7 @@ test_named_group! { equivalence_of,
         % but not the alias type
         i := a
         ",
-        // Over enum typs
+        // Over enum types
         enums => "
         type e : enum(v)
         var a, b : e

--- a/compiler/toc_analysis/src/typeck/test.rs
+++ b/compiler/toc_analysis/src/typeck/test.rs
@@ -1917,6 +1917,26 @@ test_named_group! { typeck_type_alias,
     ]
 }
 
+test_named_group! { test_enum_field,
+    [
+        // only associated with the type name
+        on_type => "
+        type e : enum(a, b, c)
+        var _ := e.a
+        ",
+        // not on instances of the type
+        on_var => "
+        type e : enum(a, b, c)
+        var a : e
+        a := a.a
+        ",
+        not_variant => "
+        type e : enum(a, b, c)
+        var _ := e.e
+        ",
+    ]
+}
+
 test_named_group! { typeck_bind_decl,
     [
         normal => "

--- a/compiler/toc_analysis/src/typeck/test.rs
+++ b/compiler/toc_analysis/src/typeck/test.rs
@@ -1599,7 +1599,6 @@ test_named_group! { equivalence_of,
 test_named_group! { typeck_put_stmt,
     [
         normal_items => r#"
-        % TODO: Uncomment enum lines once enum types are lowered & checked
         var i : int
         var n : nat
         var r : real
@@ -1607,7 +1606,7 @@ test_named_group! { typeck_put_stmt,
         var cn : char(4)
         var s : string
         var sn : string(4)
-        %type en: enum(a, b) var ef : en
+        type en: enum(a, b) var ef : en
 
         put i : 0
         put n : 0
@@ -1616,7 +1615,7 @@ test_named_group! { typeck_put_stmt,
         put cn : 0
         put s : 0
         put sn : 0
-        %put ef : 0
+        put ef : 0
         "#,
         valid_extended_opts => r#"
         var i : int
@@ -1633,18 +1632,17 @@ test_named_group! { typeck_put_stmt,
         put : o, w : o : u : o..
         ",
         invalid_extended_opts => r#"
-        % TODO: Uncomment enum lines once enum types are lowered & checked
         var c : char
         var cn : char(4)
         var s : string
         var sn : string(4)
-        %type en: enum(a, b) var ef : en
+        type en: enum(a, b) var ef : en
 
         put c : 0 : 0 : 0
         put cn : 0 : 0 : 0
         put s : 0 : 0 : 0
         put sn : 0 : 0 : 0
-        %put ef : 0 : 0 : 0
+        put ef : 0 : 0 : 0
         "#,
         wrong_type_stream => r#"
         var s : real
@@ -1686,7 +1684,6 @@ test_named_group! { typeck_put_stmt,
 
 test_named_group! { typeck_get_stmt,
     [
-        // TODO: Uncomment enum lines once enum types are lowered & checked
         normal_items => r#"
         var i : int
         var n : nat
@@ -1696,7 +1693,7 @@ test_named_group! { typeck_get_stmt,
         var cn : char(4)
         var s : string
         var sn : string(4)
-        %type en: enum(a, b) var ef : en
+        type en: enum(a, b) var ef : en
 
         get i
         get n
@@ -1706,7 +1703,7 @@ test_named_group! { typeck_get_stmt,
         get cn
         get s
         get sn
-        %get ef
+        get ef
         "#,
         valid_opts => r#"
         var cn : char(4)
@@ -1736,14 +1733,14 @@ test_named_group! { typeck_get_stmt,
         var r : real
         var c : char
         var b: boolean
-        %type en: enum(a, b) var ef : en
+        type en: enum(a, b) var ef : en
 
         get i : 0
         get n : 0
         get r : 0
         get c : 0
         get b : 0
-        %get ef : 0
+        get ef : 0
         "#,
         invalid_opts_lines => r#"
         var i : int
@@ -1752,7 +1749,7 @@ test_named_group! { typeck_get_stmt,
         var c : char
         var b: boolean
         var cn : char(4)
-        %type en: enum(a, b) var ef : en
+        type en: enum(a, b) var ef : en
 
         get i : *
         get n : *
@@ -1760,7 +1757,7 @@ test_named_group! { typeck_get_stmt,
         get c : *
         get b : *
         get cn : *
-        %get ef : *
+        get ef : *
         "#,
         wrong_type_stream => r#"
         var s : real
@@ -1856,8 +1853,7 @@ test_named_group! { typeck_for,
         normal_boolean_bounds => r#"for : false .. true end for"#,
         normal_char_bounds => r#"for : 'a' .. 'z' end for"#,
         normal_int_bounds => r#"for : 1 .. 10 end for"#,
-        // TODO: Uncomment once enum types are lowered
-        //normal_enum_bounds => r#"type e : enum(a, b, c) for : e.a .. e.c end for"#,
+        normal_enum_bounds => r#"type e : enum(a, b, c) for : e.a .. e.c end for"#,
         wrong_types_bounds_not_same => r#"for : 1 .. true end for"#,
         wrong_types_bounds_not_index => r#"for : "no" .. "yes" end for"#,
         // Specialize error message in case of {integer} combined with concrete type
@@ -2560,9 +2556,11 @@ test_named_group! { typeck_set_ty,
         valid_index_ty => "
         % FIXME: Add corresponding test for range types
         type r : char
+        type e : enum(v)
         type _a : set of r
         type _b : set of boolean
         type _c : set of char
+        type _d : set of e
         ",
         not_index_ty => "type _ : set of real",
         large_range_integer => "
@@ -2646,6 +2644,10 @@ test_named_group! { report_aliased_type,
         var y : f
         var _ : int := y
         "#,
+        // FIXME: add tests for the following types
+        // - set
+        // - record
+        // - union
     ]
 }
 

--- a/compiler/toc_analysis/src/typeck/test.rs
+++ b/compiler/toc_analysis/src/typeck/test.rs
@@ -1406,6 +1406,22 @@ test_named_group! { equivalence_of,
         % but not the alias type
         i := a
         ",
+        // Over enum typs
+        enums => "
+        type e : enum(v)
+        var a, b : e
+
+        % compatible with itself
+        a := b
+        % with its own variants
+        a := e.v
+
+        % incompatible with different defs
+        type f : enum(v)
+        var c : f
+        a := c
+        a := f.v
+        ",
         // Over set types
         sets => r#"
         type sb : set of boolean

--- a/compiler/toc_analysis/src/typeck/test.rs
+++ b/compiler/toc_analysis/src/typeck/test.rs
@@ -2462,6 +2462,14 @@ test_named_group! { typeck_opaque_alias,
     ]
 }
 
+test_named_group! { typeck_enum_ty,
+    [
+        from_type_alias => "type e : enum(a, b, c)",
+        from_var_decl => "var _ : enum(nice)",
+        no_variants => "type e : enum()",
+    ]
+}
+
 test_named_group! { typeck_set_ty,
     [
         from_type_alias => "type s : set of boolean var _ : s",

--- a/compiler/toc_hir/src/ids.rs
+++ b/compiler/toc_hir/src/ids.rs
@@ -146,3 +146,8 @@ impl StmtId {
 #[repr(transparent)]
 pub struct TypeId(pub(crate) TypeIndex);
 pub(crate) type TypeIndex = std::num::NonZeroU32;
+
+/// A type-local reference to a specific field
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(transparent)]
+pub struct FieldId(pub usize);

--- a/compiler/toc_hir/src/symbol.rs
+++ b/compiler/toc_hir/src/symbol.rs
@@ -10,6 +10,7 @@ pub use crate::ids::{DefId, LocalDefId};
 use crate::{
     ids::{ExportId, ItemId, LocalDefIndex, ModuleId},
     stmt::BodyStmt,
+    ty::{FieldId, TypeId},
 };
 
 pub mod syms;
@@ -115,6 +116,8 @@ pub enum DefOwner {
     ItemParam(ItemId, LocalDefId),
     /// Export from a given `Module`
     Export(ModuleId, ExportId),
+    /// Field on a given `Type`
+    Field(TypeId, FieldId),
     /// Owned by a `Stmt`
     Stmt(BodyStmt),
 }
@@ -147,6 +150,8 @@ pub enum BindingTo {
     Module,
     /// Binding to a subprogram
     Subprogram(SubprogramKind),
+    /// Binding to an enum field
+    EnumField,
 }
 
 impl BindingTo {
@@ -160,7 +165,7 @@ impl BindingTo {
     pub fn is_ref(self) -> bool {
         matches!(
             self,
-            Self::Storage(_) | Self::Register(_) | Self::Subprogram(_)
+            Self::Storage(_) | Self::Register(_) | Self::Subprogram(_) | Self::EnumField
         )
     }
 
@@ -200,6 +205,7 @@ impl std::fmt::Display for BindingTo {
             BindingTo::Subprogram(SubprogramKind::Procedure) => "a procedure",
             BindingTo::Subprogram(SubprogramKind::Function) => "a function",
             BindingTo::Subprogram(SubprogramKind::Process) => "a process",
+            BindingTo::EnumField => "an enum variant",
         };
 
         f.write_str(name)

--- a/compiler/toc_hir/src/ty.rs
+++ b/compiler/toc_hir/src/ty.rs
@@ -109,7 +109,7 @@ pub struct Enum {
     /// Definition uniquely identifying this type
     pub def_id: symbol::LocalDefId,
     /// Variants on this enum
-    pub variants: Vec<Spanned<Symbol>>,
+    pub variants: Vec<symbol::LocalDefId>,
 }
 
 #[derive(Debug, PartialEq, Eq, Hash)]

--- a/compiler/toc_hir/src/ty.rs
+++ b/compiler/toc_hir/src/ty.rs
@@ -5,7 +5,7 @@ use std::convert::TryInto;
 use indexmap::{IndexMap, IndexSet};
 use toc_span::{SpanId, Spanned};
 
-pub use crate::ids::TypeId;
+pub use crate::ids::{FieldId, TypeId};
 
 use crate::{
     body,

--- a/compiler/toc_hir/src/ty.rs
+++ b/compiler/toc_hir/src/ty.rs
@@ -55,6 +55,8 @@ pub enum TypeKind {
     Primitive(Primitive),
     /// Alias Type
     Alias(Alias),
+    /// Enum Type
+    Enum(Enum),
     /// Set type
     Set(Set),
     /// Pointer type
@@ -94,13 +96,20 @@ pub enum SeqLength {
     Expr(body::BodyId),
 }
 
-// FIXME: Use the proper representation of an item path
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub struct Alias {
     /// [`LocalDefId`](symbol::LocalDefId) to start working through
     pub base_def: Spanned<symbol::LocalDefId>,
     /// Names of each segment to lookup
     pub segments: Vec<Spanned<Symbol>>,
+}
+
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct Enum {
+    /// Definition uniquely identifying this type
+    pub def_id: symbol::LocalDefId,
+    /// Variants on this enum
+    pub variants: Vec<Spanned<Symbol>>,
 }
 
 #[derive(Debug, PartialEq, Eq, Hash)]

--- a/compiler/toc_hir/src/visitor.rs
+++ b/compiler/toc_hir/src/visitor.rs
@@ -58,6 +58,7 @@ pub trait HirVisitor {
     fn visit_missing_type(&self, id: ty::TypeId) {}
     fn visit_primitive(&self, id: ty::TypeId, ty: &ty::Primitive) {}
     fn visit_alias(&self, id: ty::TypeId, ty: &ty::Alias) {}
+    fn visit_enum(&self, id: ty::TypeId, ty: &ty::Enum) {}
     fn visit_set(&self, id: ty::TypeId, ty: &ty::Set) {}
     fn visit_pointer(&self, id: ty::TypeId, ty: &ty::Pointer) {}
     fn visit_subprogram_ty(&self, id: ty::TypeId, ty: &ty::Subprogram) {}
@@ -113,6 +114,7 @@ pub trait HirVisitor {
             ty::TypeKind::Missing => self.visit_missing_type(id),
             ty::TypeKind::Primitive(ty) => self.visit_primitive(id, ty),
             ty::TypeKind::Alias(ty) => self.visit_alias(id, ty),
+            ty::TypeKind::Enum(ty) => self.visit_enum(id, ty),
             ty::TypeKind::Set(ty) => self.visit_set(id, ty),
             ty::TypeKind::Pointer(ty) => self.visit_pointer(id, ty),
             ty::TypeKind::Subprogram(ty) => self.visit_subprogram_ty(id, ty),
@@ -568,6 +570,7 @@ impl<'hir> Walker<'hir> {
             ty::TypeKind::Missing => {}
             ty::TypeKind::Primitive(ty) => self.walk_primitive(ty),
             ty::TypeKind::Alias(_) => {}
+            ty::TypeKind::Enum(_) => {}
             ty::TypeKind::Set(ty) => self.walk_set(ty),
             ty::TypeKind::Pointer(ty) => self.walk_pointer(ty),
             ty::TypeKind::Subprogram(ty) => self.walk_subprogram_ty(ty),

--- a/compiler/toc_hir_codegen/src/lib.rs
+++ b/compiler/toc_hir_codegen/src/lib.rs
@@ -2403,6 +2403,7 @@ impl BodyCodeGenerator<'_> {
                 (Opcode::ASNSTR(), Opcode::ASNSTRINV())
             }
             ty::TypeKind::Opaque(_, ty) => return self.generate_assign(*ty, order), // defer to the opaque type
+            ty::TypeKind::Enum(..) => unimplemented!(),
             ty::TypeKind::Set(..) => unimplemented!(),
             ty::TypeKind::Pointer(..) => unimplemented!(),
             ty::TypeKind::Subprogram(..) => (Opcode::ASNADDR(), Opcode::ASNADDRINV()),
@@ -2469,6 +2470,7 @@ impl BodyCodeGenerator<'_> {
             ty::TypeKind::String | ty::TypeKind::StringN(_) => Opcode::FETCHSTR(),
             ty::TypeKind::CharN(_) => return None, // don't need to dereference the pointer to storage
             ty::TypeKind::Opaque(_, ty) => return self.pick_fetch_op(*ty), // defer to the opaque type
+            ty::TypeKind::Enum(..) => unimplemented!(),
             ty::TypeKind::Set(..) => unimplemented!(),
             ty::TypeKind::Pointer(..) => unimplemented!(),
             ty::TypeKind::Subprogram(..) => Opcode::FETCHADDR(),

--- a/compiler/toc_hir_db/src/query.rs
+++ b/compiler/toc_hir_db/src/query.rs
@@ -303,6 +303,12 @@ impl HirVisitor for DefCollector<'_> {
             self.add_owner(def_id, DefOwner::Stmt(id))
         }
     }
+
+    fn visit_enum(&self, id: ty::TypeId, ty: &ty::Enum) {
+        for (idx, &variant) in ty.variants.iter().enumerate() {
+            self.add_owner(variant, DefOwner::Field(id, ty::FieldId(idx)));
+        }
+    }
 }
 
 /// Library-local body collector

--- a/compiler/toc_hir_lowering/src/lower/ty.rs
+++ b/compiler/toc_hir_lowering/src/lower/ty.rs
@@ -1,7 +1,7 @@
 //! Lowering into `Type` HIR nodes
 use toc_hir::symbol::syms;
 use toc_hir::{symbol, ty};
-use toc_span::{HasSpanTable, Span};
+use toc_span::{HasSpanTable, Span, Spanned};
 use toc_syntax::ast::{self, AstNode};
 
 impl super::BodyLowering<'_, '_> {
@@ -26,7 +26,9 @@ impl super::BodyLowering<'_, '_> {
             ast::Type::NameType(ty) => self.lower_name_type(ty),
 
             ast::Type::RangeType(_) => self.unsupported_ty(span),
-            ast::Type::EnumType(_) => self.unsupported_ty(span),
+
+            ast::Type::EnumType(ty) => self.lower_enum_type(ty),
+
             ast::Type::ArrayType(_) => self.unsupported_ty(span),
 
             ast::Type::SetType(ty) => self.lower_set_type(ty),
@@ -109,17 +111,14 @@ impl super::BodyLowering<'_, '_> {
                     let def_id = self.ctx.use_sym(name.text().into(), span);
 
                     break Some(ty::TypeKind::Alias(ty::Alias {
-                        base_def: toc_span::Spanned::new(
-                            def_id,
-                            self.ctx.intern_range(name.text_range()),
-                        ),
+                        base_def: Spanned::new(def_id, self.ctx.intern_range(name.text_range())),
                         segments,
                     }));
                 }
                 ast::Expr::FieldExpr(field) => {
                     let name = field.name()?.identifier_token()?;
 
-                    segments.push(toc_span::Spanned::new(
+                    segments.push(Spanned::new(
                         name.text().into(),
                         self.ctx.intern_range(name.text_range()),
                     ));
@@ -140,6 +139,27 @@ impl super::BodyLowering<'_, '_> {
                 }
             }
         }
+    }
+
+    fn lower_enum_type(&mut self, ty: ast::EnumType) -> Option<ty::TypeKind> {
+        let span = self.ctx.intern_range(ty.syntax().text_range());
+        let def_id = self
+            .ctx
+            .library
+            .add_def(*syms::Anonymous, span, symbol::SymbolKind::Declared);
+        let variants = ty
+            .fields()
+            .unwrap()
+            .names()
+            .filter_map(|name| {
+                let sym = name.identifier_token()?.text().into();
+                let span = self.ctx.intern_range(name.syntax().text_range());
+
+                Some(Spanned::new(sym, span))
+            })
+            .collect();
+
+        Some(ty::TypeKind::Enum(ty::Enum { def_id, variants }))
     }
 
     fn lower_set_type(&mut self, ty: ast::SetType) -> Option<ty::TypeKind> {

--- a/compiler/toc_hir_lowering/src/lower/ty.rs
+++ b/compiler/toc_hir_lowering/src/lower/ty.rs
@@ -152,10 +152,14 @@ impl super::BodyLowering<'_, '_> {
             .unwrap()
             .names()
             .filter_map(|name| {
-                let sym = name.identifier_token()?.text().into();
                 let span = self.ctx.intern_range(name.syntax().text_range());
+                let name = name.identifier_token()?.text().into();
+                let def_id = self
+                    .ctx
+                    .library
+                    .add_def(name, span, symbol::SymbolKind::Declared);
 
-                Some(Spanned::new(sym, span))
+                Some(def_id)
             })
             .collect();
 

--- a/compiler/toc_hir_lowering/tests/lowering.rs
+++ b/compiler/toc_hir_lowering/tests/lowering.rs
@@ -1405,3 +1405,21 @@ fn lower_pointer_ty() {
     // Just unchecked
     assert_lower("type _ : unchecked int");
 }
+
+#[test]
+fn lower_enum_type() {
+    // one variant
+    assert_lower("type _ : enum(a)");
+    // multiple variants
+    assert_lower("type _ : enum(a, b, c, d)");
+
+    // missing end
+    assert_lower("type _ : enum(a, )");
+    // missing middle
+    assert_lower("type _ : enum(a, , d)");
+    // missing start
+    assert_lower("type _ : enum(, a)");
+
+    // no variants
+    assert_lower("type _ : enum(a)");
+}

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_enum_type-2.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_enum_type-2.snap
@@ -1,0 +1,14 @@
+---
+source: compiler/toc_hir_lowering/tests/lowering.rs
+assertion_line: 61
+expression: "type _ : enum(a, b, c, d)"
+
+---
+Library@(dummy)
+  Root@(dummy): FileId(1) -> ItemId(1)
+    Module@(FileId(1), 0..25): "<root>"@(dummy)
+      StmtBody@(FileId(1), 0..25): []
+        StmtItem@(FileId(1), 0..25): ItemId(0)
+          Type@(FileId(1), 0..25): "_"@(FileId(1), 5..6)
+            Enum@(FileId(1), 9..25): [ a,b,c,d ]
+

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_enum_type-2.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_enum_type-2.snap
@@ -10,5 +10,5 @@ Library@(dummy)
       StmtBody@(FileId(1), 0..25): []
         StmtItem@(FileId(1), 0..25): ItemId(0)
           Type@(FileId(1), 0..25): "_"@(FileId(1), 5..6)
-            Enum@(FileId(1), 9..25): [ a,b,c,d ]
+            Enum@(FileId(1), 9..25): "_"@(FileId(1), 9..25) [ a,b,c,d ]
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_enum_type-3.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_enum_type-3.snap
@@ -1,0 +1,16 @@
+---
+source: compiler/toc_hir_lowering/tests/lowering.rs
+assertion_line: 61
+expression: "type _ : enum(a, )"
+
+---
+Library@(dummy)
+  Root@(dummy): FileId(1) -> ItemId(1)
+    Module@(FileId(1), 0..18): "<root>"@(dummy)
+      StmtBody@(FileId(1), 0..18): []
+        StmtItem@(FileId(1), 0..18): ItemId(0)
+          Type@(FileId(1), 0..18): "_"@(FileId(1), 5..6)
+            Enum@(FileId(1), 9..18): [ a ]
+error in file FileId(1) at 17..18: unexpected token
+| error in file FileId(1) for 17..18: expected identifier, but found `)`
+

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_enum_type-3.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_enum_type-3.snap
@@ -10,7 +10,7 @@ Library@(dummy)
       StmtBody@(FileId(1), 0..18): []
         StmtItem@(FileId(1), 0..18): ItemId(0)
           Type@(FileId(1), 0..18): "_"@(FileId(1), 5..6)
-            Enum@(FileId(1), 9..18): [ a ]
+            Enum@(FileId(1), 9..18): "_"@(FileId(1), 9..18) [ a ]
 error in file FileId(1) at 17..18: unexpected token
 | error in file FileId(1) for 17..18: expected identifier, but found `)`
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_enum_type-4.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_enum_type-4.snap
@@ -10,7 +10,7 @@ Library@(dummy)
       StmtBody@(FileId(1), 0..21): []
         StmtItem@(FileId(1), 0..21): ItemId(0)
           Type@(FileId(1), 0..21): "_"@(FileId(1), 5..6)
-            Enum@(FileId(1), 9..21): [ a,d ]
+            Enum@(FileId(1), 9..21): "_"@(FileId(1), 9..21) [ a,d ]
 error in file FileId(1) at 17..18: unexpected token
 | error in file FileId(1) for 17..18: expected identifier, but found `,`
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_enum_type-4.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_enum_type-4.snap
@@ -1,0 +1,16 @@
+---
+source: compiler/toc_hir_lowering/tests/lowering.rs
+assertion_line: 61
+expression: "type _ : enum(a, , d)"
+
+---
+Library@(dummy)
+  Root@(dummy): FileId(1) -> ItemId(1)
+    Module@(FileId(1), 0..21): "<root>"@(dummy)
+      StmtBody@(FileId(1), 0..21): []
+        StmtItem@(FileId(1), 0..21): ItemId(0)
+          Type@(FileId(1), 0..21): "_"@(FileId(1), 5..6)
+            Enum@(FileId(1), 9..21): [ a,d ]
+error in file FileId(1) at 17..18: unexpected token
+| error in file FileId(1) for 17..18: expected identifier, but found `,`
+

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_enum_type-5.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_enum_type-5.snap
@@ -1,0 +1,16 @@
+---
+source: compiler/toc_hir_lowering/tests/lowering.rs
+assertion_line: 61
+expression: "type _ : enum(, a)"
+
+---
+Library@(dummy)
+  Root@(dummy): FileId(1) -> ItemId(1)
+    Module@(FileId(1), 0..18): "<root>"@(dummy)
+      StmtBody@(FileId(1), 0..18): []
+        StmtItem@(FileId(1), 0..18): ItemId(0)
+          Type@(FileId(1), 0..18): "_"@(FileId(1), 5..6)
+            Enum@(FileId(1), 9..18): [ a ]
+error in file FileId(1) at 14..15: unexpected token
+| error in file FileId(1) for 14..15: expected identifier, but found `,`
+

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_enum_type-5.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_enum_type-5.snap
@@ -10,7 +10,7 @@ Library@(dummy)
       StmtBody@(FileId(1), 0..18): []
         StmtItem@(FileId(1), 0..18): ItemId(0)
           Type@(FileId(1), 0..18): "_"@(FileId(1), 5..6)
-            Enum@(FileId(1), 9..18): [ a ]
+            Enum@(FileId(1), 9..18): "_"@(FileId(1), 9..18) [ a ]
 error in file FileId(1) at 14..15: unexpected token
 | error in file FileId(1) for 14..15: expected identifier, but found `,`
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_enum_type-6.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_enum_type-6.snap
@@ -1,0 +1,14 @@
+---
+source: compiler/toc_hir_lowering/tests/lowering.rs
+assertion_line: 61
+expression: "type _ : enum(a)"
+
+---
+Library@(dummy)
+  Root@(dummy): FileId(1) -> ItemId(1)
+    Module@(FileId(1), 0..16): "<root>"@(dummy)
+      StmtBody@(FileId(1), 0..16): []
+        StmtItem@(FileId(1), 0..16): ItemId(0)
+          Type@(FileId(1), 0..16): "_"@(FileId(1), 5..6)
+            Enum@(FileId(1), 9..16): [ a ]
+

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_enum_type-6.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_enum_type-6.snap
@@ -10,5 +10,5 @@ Library@(dummy)
       StmtBody@(FileId(1), 0..16): []
         StmtItem@(FileId(1), 0..16): ItemId(0)
           Type@(FileId(1), 0..16): "_"@(FileId(1), 5..6)
-            Enum@(FileId(1), 9..16): [ a ]
+            Enum@(FileId(1), 9..16): "_"@(FileId(1), 9..16) [ a ]
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_enum_type.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_enum_type.snap
@@ -1,0 +1,14 @@
+---
+source: compiler/toc_hir_lowering/tests/lowering.rs
+assertion_line: 61
+expression: "type _ : enum(a)"
+
+---
+Library@(dummy)
+  Root@(dummy): FileId(1) -> ItemId(1)
+    Module@(FileId(1), 0..16): "<root>"@(dummy)
+      StmtBody@(FileId(1), 0..16): []
+        StmtItem@(FileId(1), 0..16): ItemId(0)
+          Type@(FileId(1), 0..16): "_"@(FileId(1), 5..6)
+            Enum@(FileId(1), 9..16): [ a ]
+

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_enum_type.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_enum_type.snap
@@ -10,5 +10,5 @@ Library@(dummy)
       StmtBody@(FileId(1), 0..16): []
         StmtItem@(FileId(1), 0..16): ItemId(0)
           Type@(FileId(1), 0..16): "_"@(FileId(1), 5..6)
-            Enum@(FileId(1), 9..16): [ a ]
+            Enum@(FileId(1), 9..16): "_"@(FileId(1), 9..16) [ a ]
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_set_ty-2.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_set_ty-2.snap
@@ -10,7 +10,7 @@ Library@(dummy)
       StmtBody@(FileId(1), 0..15): []
         StmtItem@(FileId(1), 0..15): ItemId(0)
           Type@(FileId(1), 0..15): "_"@(FileId(1), 5..6)
-            Set@(FileId(1), 9..15): "<anonymous>"@(FileId(1), 9..15)
+            Set@(FileId(1), 9..15): "_"@(FileId(1), 9..15)
 error in file FileId(1) at 13..15: unexpected end of file
 | error in file FileId(1) for 13..15: expected type specifier after here
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_set_ty.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_set_ty.snap
@@ -10,6 +10,6 @@ Library@(dummy)
       StmtBody@(FileId(1), 0..23): []
         StmtItem@(FileId(1), 0..23): ItemId(0)
           Type@(FileId(1), 0..23): "_"@(FileId(1), 5..6)
-            Set@(FileId(1), 9..23): "<anonymous>"@(FileId(1), 9..23)
+            Set@(FileId(1), 9..23): "_"@(FileId(1), 9..23)
               Primitive@(FileId(1), 16..23): Boolean
 

--- a/compiler/toc_hir_pretty/src/graph.rs
+++ b/compiler/toc_hir_pretty/src/graph.rs
@@ -1206,6 +1206,17 @@ impl<'out, 'hir> HirVisitor for PrettyVisitor<'out, 'hir> {
         );
     }
 
+    fn visit_enum(&self, id: ty::TypeId, ty: &ty::Enum) {
+        let mut v_layout = vec![Layout::Node(self.display_def_id(ty.def_id))];
+        v_layout.extend(
+            ty.variants
+                .iter()
+                .map(|v| Layout::Node(v.item().name().into())),
+        );
+
+        self.emit_type(id, "Enum", Layout::Vbox(v_layout))
+    }
+
     fn visit_set(&self, id: ty::TypeId, ty: &ty::Set) {
         self.emit_type(
             id,

--- a/compiler/toc_hir_pretty/src/graph.rs
+++ b/compiler/toc_hir_pretty/src/graph.rs
@@ -1211,7 +1211,7 @@ impl<'out, 'hir> HirVisitor for PrettyVisitor<'out, 'hir> {
         v_layout.extend(
             ty.variants
                 .iter()
-                .map(|v| Layout::Node(v.item().name().into())),
+                .map(|&variant| Layout::Node(self.display_def_id(variant))),
         );
 
         self.emit_type(id, "Enum", Layout::Vbox(v_layout))

--- a/compiler/toc_hir_pretty/src/tree.rs
+++ b/compiler/toc_hir_pretty/src/tree.rs
@@ -509,14 +509,19 @@ impl<'out, 'hir> HirVisitor for PrettyVisitor<'out, 'hir> {
     }
     fn visit_enum(&self, id: ty::TypeId, ty: &ty::Enum) {
         let span = self.type_span(id);
-        let extra = itertools::intersperse(
+        let def_name = self.display_extra_def(ty.def_id);
+        let variants = itertools::intersperse(
             ty.variants
                 .iter()
                 .map(|&variant| self.library.local_def(variant).name.name()),
             ",",
         )
         .collect::<String>();
-        self.emit_node("Enum", span, Some(format_args!("[ {extra} ]")))
+        self.emit_node(
+            "Enum",
+            span,
+            Some(format_args!("{def_name} [ {variants} ]")),
+        )
     }
     fn visit_set(&self, id: ty::TypeId, ty: &ty::Set) {
         let span = self.type_span(id);

--- a/compiler/toc_hir_pretty/src/tree.rs
+++ b/compiler/toc_hir_pretty/src/tree.rs
@@ -507,6 +507,12 @@ impl<'out, 'hir> HirVisitor for PrettyVisitor<'out, 'hir> {
             .collect::<String>();
         self.emit_node("Alias", span, Some(format_args!("{extra}{segments}")))
     }
+    fn visit_enum(&self, id: ty::TypeId, ty: &ty::Enum) {
+        let span = self.type_span(id);
+        let extra = itertools::intersperse(ty.variants.iter().map(|v| v.item().name()), ",")
+            .collect::<String>();
+        self.emit_node("Enum", span, Some(format_args!("[ {extra} ]")))
+    }
     fn visit_set(&self, id: ty::TypeId, ty: &ty::Set) {
         let span = self.type_span(id);
         let extra = self.display_extra_def(ty.def_id);

--- a/compiler/toc_hir_pretty/src/tree.rs
+++ b/compiler/toc_hir_pretty/src/tree.rs
@@ -509,8 +509,13 @@ impl<'out, 'hir> HirVisitor for PrettyVisitor<'out, 'hir> {
     }
     fn visit_enum(&self, id: ty::TypeId, ty: &ty::Enum) {
         let span = self.type_span(id);
-        let extra = itertools::intersperse(ty.variants.iter().map(|v| v.item().name()), ",")
-            .collect::<String>();
+        let extra = itertools::intersperse(
+            ty.variants
+                .iter()
+                .map(|&variant| self.library.local_def(variant).name.name()),
+            ",",
+        )
+        .collect::<String>();
         self.emit_node("Enum", span, Some(format_args!("[ {extra} ]")))
     }
     fn visit_set(&self, id: ty::TypeId, ty: &ty::Set) {

--- a/compiler/toc_syntax/parsed_turing.ungram
+++ b/compiler/toc_syntax/parsed_turing.ungram
@@ -786,7 +786,7 @@ UnsizedBound =
   '*'
 
 EnumType =
-  'enum' '(' fields:( Name ( ',' Name )* ) ')'
+  'enum' '(' fields:NameList ')'
 
 ArrayType =
   'flexible'? 'array' RangeList 'of' elem_ty:Type

--- a/compiler/toc_syntax/src/ast/nodes.rs
+++ b/compiler/toc_syntax/src/ast/nodes.rs
@@ -3418,7 +3418,7 @@ impl AstNode for EnumType {
 impl EnumType {
     pub fn enum_token(&self) -> Option<SyntaxToken> { helper::token(&self.0, SyntaxKind::KwEnum) }
     pub fn l_paren_token(&self) -> Option<SyntaxToken> { helper::token(&self.0, SyntaxKind::LeftParen) }
-    pub fn fields(&self) -> impl Iterator<Item = Name> + '_ { helper::nodes(&self.0) }
+    pub fn fields(&self) -> Option<NameList> { helper::node(&self.0) }
     pub fn r_paren_token(&self) -> Option<SyntaxToken> { helper::token(&self.0, SyntaxKind::RightParen) }
 }
 #[derive(Debug, PartialEq, Eq, Hash)]

--- a/notes/TODO.md
+++ b/notes/TODO.md
@@ -20,8 +20,8 @@
     - [x] AssignStmt
     - [ ] OpenStmt
     - [ ] CloseStmt
-    - [X] PutStmt
-    - [X] GetStmt
+    - [x] PutStmt
+    - [x] GetStmt
     - [ ] ReadStmt
     - [ ] WriteStmt
     - [ ] SeekStmt
@@ -88,7 +88,7 @@
     - [x] PrimType
     - [ ] NameType
     - [ ] RangeType
-    - [ ] EnumType
+    - [x] EnumType
     - [ ] ArrayType
     - [x] SetType
     - [ ] RecordType
@@ -172,7 +172,7 @@
         - [x] Numeric
         - [x] Lexicographic (over charseqs)
         - [ ] Class hierarchy
-        - [ ] Enums
+        - [x] Enums
         - [x] Sets (sub/superset tests)
       - [x] String concatenation
       - [x] Set manipulation
@@ -197,7 +197,7 @@
       - [x] Just name
       - [x] Through module paths
     - [ ] Range
-    - [ ] Enum
+    - [x] Enum
     - [ ] Array
     - [x] Set
     - [ ] Record


### PR DESCRIPTION
This required a change in how we handle anonymous types, in that they should only steal the name, not the definition point as well.