### PR TITLE
Support implicit `for` bounds

### DIFF
--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_for_for_each_not_iterable.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_for_for_each_not_iterable.snap
@@ -1,0 +1,12 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "for : 1 end for"
+
+---
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 6..7: mismatched types
+| note in file FileId(1) for 6..7: this is of type `{integer}`
+| error in file FileId(1) for 6..7: `{integer}` is not iterable
+| info: only arrays types can be iterated over

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_for_implied_bounds_boolean.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_for_implied_bounds_boolean.snap
@@ -1,0 +1,10 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "type b : boolean for _ : b end for"
+
+---
+"b"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of boolean
+"_"@(FileId(1), 21..22) [Declared]: alias[DefId(LibraryId(0), LocalDefId(0))] of boolean
+"<root>"@(dummy) [Declared]: <error>
+

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_for_implied_bounds_char.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_for_implied_bounds_char.snap
@@ -1,0 +1,10 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "type b : char for _ : b end for"
+
+---
+"b"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of char
+"_"@(FileId(1), 18..19) [Declared]: alias[DefId(LibraryId(0), LocalDefId(0))] of char
+"<root>"@(dummy) [Declared]: <error>
+

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_for_implied_bounds_constrained.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_for_implied_bounds_constrained.snap
@@ -1,0 +1,10 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "type b : 1 .. 2 for _ : b end for"
+
+---
+"b"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1))))
+"_"@(FileId(1), 20..21) [Declared]: alias[DefId(LibraryId(0), LocalDefId(0))] of range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1))))
+"<root>"@(dummy) [Declared]: <error>
+

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_for_implied_bounds_enum.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_for_implied_bounds_enum.snap
@@ -1,0 +1,12 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "type b : enum(a) for _ : b end for"
+
+---
+"a"@(FileId(1), 14..15) [Declared]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "a"@(FileId(1), 14..15), )
+"b"@(FileId(1), 9..16) [Declared]: <error>
+"b"@(FileId(1), 5..6) [Resolved(Type)]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "a"@(FileId(1), 14..15), )
+"_"@(FileId(1), 21..22) [Declared]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "a"@(FileId(1), 14..15), )
+"<root>"@(dummy) [Declared]: <error>
+

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_for_implied_bounds_int_err.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_for_implied_bounds_int_err.snap
@@ -1,0 +1,13 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "type b : int for _ : b end for"
+
+---
+"b"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of int
+"_"@(FileId(1), 17..18) [Declared]: alias[DefId(LibraryId(0), LocalDefId(0))] of int
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 21..22: bound range is too large
+| error in file FileId(1) for 21..22: a range over all `b (alias of int)` values is too large
+| info: use a range type to shrink the range of the bound

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_for_implied_bounds_real_err.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_for_implied_bounds_real_err.snap
@@ -1,0 +1,14 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "type b : real for _ : b end for"
+
+---
+"b"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of real
+"_"@(FileId(1), 18..19) [Declared]: alias[DefId(LibraryId(0), LocalDefId(0))] of real
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 22..23: mismatched types
+| note in file FileId(1) for 22..23: this is of type `b (alias of real)`
+| error in file FileId(1) for 22..23: `real` is not an index type
+| info: range bound type must be an index type (an integer, `boolean`, `char`, enumerated type, or a range)

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_for_implied_not_ty.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_for_implied_not_ty.snap
@@ -1,0 +1,12 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "module b end b /**/ for : b end for"
+
+---
+"b"@(FileId(1), 7..8) [Declared]: <error>
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 26..27: cannot use `b` as a `for` bound
+| error in file FileId(1) for 26..27: `b` is a reference to a module, not a type
+| note in file FileId(1) for 7..8: `b` declared here

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_for_infer_err_counter_ty.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_for_infer_err_counter_ty.snap
@@ -1,0 +1,20 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "% Both should fail\nfor c : 1.0 .. () var k : int := c end for\nfor c : () .. 1.0 var k : int := c end for\n"
+
+---
+"c"@(FileId(1), 23..24) [Declared]: real
+"k"@(FileId(1), 41..42) [Declared]: int
+"c"@(FileId(1), 66..67) [Declared]: real
+"k"@(FileId(1), 84..85) [Declared]: int
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 52..53: mismatched types
+| note in file FileId(1) for 52..53: this is of type `real`
+| note in file FileId(1) for 45..48: this is of type `int`
+| info: `real` is not assignable into `int`
+error in file FileId(1) at 95..96: mismatched types
+| note in file FileId(1) for 95..96: this is of type `real`
+| note in file FileId(1) for 88..91: this is of type `int`
+| info: `real` is not assignable into `int`

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_for_infer_left_counter_ty.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_for_infer_left_counter_ty.snap
@@ -1,0 +1,16 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "% Biased towards left inference\nvar i : int\nfor c : i .. 1.0 var k : int := c end for\n"
+
+---
+"i"@(FileId(1), 36..37) [Declared]: int
+"c"@(FileId(1), 48..49) [Declared]: int
+"k"@(FileId(1), 65..66) [Declared]: int
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 52..60: mismatched types
+| note in file FileId(1) for 57..60: this is of type `real`
+| note in file FileId(1) for 52..53: this is of type `int`
+| error in file FileId(1) for 52..60: expected index types
+| info: range bounds types must both be index types (an integer, `boolean`, `char`, enumerated type, or a range)

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_opaque_ty_poke_opaque_for_bounds_explicit.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_opaque_ty_poke_opaque_for_bounds_explicit.snap
@@ -1,0 +1,20 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "module m\n    export opaque t, v\n    type t : int\n    var v : t\n    for _ : v .. v end for\nend m\n\nfor _ : m.v .. m.v end for\n"
+
+---
+"m"@(FileId(1), 7..8) [Declared]: <error>
+"t"@(FileId(1), 41..42) [Resolved(Type)]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
+"v"@(FileId(1), 57..58) [Declared]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
+"_"@(FileId(1), 71..72) [Declared]: alias[DefId(LibraryId(0), LocalDefId(1))] of int
+"t"@(FileId(1), 20..28) [ItemExport(LocalDefId(1))]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
+"v"@(FileId(1), 30..31) [ItemExport(LocalDefId(2))]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
+"_"@(FileId(1), 101..102) [Declared]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 105..115: mismatched types
+| note in file FileId(1) for 112..115: this is of type `t (an opaque type)`
+| note in file FileId(1) for 105..108: this is also of type `t (an opaque type)`
+| error in file FileId(1) for 105..115: expected index types
+| info: range bounds types must both be index types (an integer, `boolean`, `char`, enumerated type, or a range)

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_opaque_ty_poke_opaque_for_bounds_implicit.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_opaque_ty_poke_opaque_for_bounds_implicit.snap
@@ -1,0 +1,17 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "module m\n    export opaque t\n    type t : 1 .. 2\n    for _ : t end for\nend m\n\nfor _ : m.t end for\n"
+
+---
+"m"@(FileId(1), 7..8) [Declared]: <error>
+"t"@(FileId(1), 38..39) [Resolved(Type)]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1))))
+"_"@(FileId(1), 57..58) [Declared]: alias[DefId(LibraryId(0), LocalDefId(1))] of range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1))))
+"t"@(FileId(1), 20..28) [ItemExport(LocalDefId(1))]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1))))
+"_"@(FileId(1), 82..83) [Declared]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1))))
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 86..89: mismatched types
+| note in file FileId(1) for 86..89: this is of type `t (an opaque type)`
+| error in file FileId(1) for 86..89: `t (an opaque type)` is not an index type
+| info: range bound type must be an index type (an integer, `boolean`, `char`, enumerated type, or a range)

--- a/compiler/toc_analysis/src/typeck/test.rs
+++ b/compiler/toc_analysis/src/typeck/test.rs
@@ -1892,7 +1892,7 @@ test_named_group! { typeck_for,
         immut_counter => r#"for i : false .. true i := false end for"#,
 
         // Be resilient against missing bounds
-        missing_left_bound => "for : 1 .. end for", // FIXME(typo): swap to right bound
+        missing_left_bound => "for : .. 1 end for",
         missing_right_bound => "for : 1 .. end for",
 
         wrong_value_bounds => "

--- a/compiler/toc_analysis/src/typeck/test.rs
+++ b/compiler/toc_analysis/src/typeck/test.rs
@@ -1876,6 +1876,16 @@ test_named_group! { typeck_for,
         for c : 1.0 .. 1 var k : int := c end for
         for c : 1 .. 1.0 var k : int := c end for
         "#,
+        infer_err_counter_ty => "
+        % Both should fail
+        for c : 1.0 .. () var k : int := c end for
+        for c : () .. 1.0 var k : int := c end for
+        ",
+        infer_left_counter_ty => "
+        % Biased towards left inference
+        var i : int
+        for c : i .. 1.0 var k : int := c end for
+        ",
         normal_boolean_bounds => r#"for : false .. true end for"#,
         normal_char_bounds => r#"for : 'a' .. 'z' end for"#,
         normal_int_bounds => r#"for : 1 .. 10 end for"#,


### PR DESCRIPTION
Now that ranges/constrained tys are lowered, we can full cover them.
for-each loops still aren't supported yet, but the reference impl also doesn't support them.