### PR TITLE
Support array types

### DIFF
--- a/compiler/toc_analysis/src/const_eval.rs
+++ b/compiler/toc_analysis/src/const_eval.rs
@@ -25,6 +25,8 @@ mod value;
 
 use toc_hir::{body::BodyId, expr::BodyExpr, library::LibraryId};
 
+pub(crate) use errors::ErrorKind;
+
 pub use errors::ConstError;
 pub use integer::ConstInt;
 pub use value::ConstValue;

--- a/compiler/toc_analysis/src/const_eval/errors.rs
+++ b/compiler/toc_analysis/src/const_eval/errors.rs
@@ -29,6 +29,10 @@ impl ConstError {
         }
     }
 
+    pub(crate) fn kind(&self) -> &ErrorKind {
+        &self.kind
+    }
+
     /// Reports the detailed version of the `ConstError` to the given reporter
     pub fn report_to<DB: db::ConstEval + ?Sized>(
         &self,
@@ -93,7 +97,7 @@ impl ConstError {
 }
 
 #[derive(Debug, Clone, thiserror::Error, PartialEq, Eq, Hash)]
-pub(super) enum ErrorKind {
+pub(crate) enum ErrorKind {
     // Traversal errors
     /// Encountered an evaluation cycle
     #[allow(dead_code)] // TODO: add cycle fixup when we can generate cycles

--- a/compiler/toc_analysis/src/const_eval/query.rs
+++ b/compiler/toc_analysis/src/const_eval/query.rs
@@ -162,7 +162,9 @@ pub(crate) fn evaluate_const(
                         }
 
                         // If bounds of `left` is known, check if `right` is in the range
-                        if let Some((min, max)) = left_ty.min_int_of().zip(left_ty.max_int_of()) {
+                        if let Some((min, max)) =
+                            Option::zip(left_ty.min_int_of().ok(), left_ty.max_int_of().ok())
+                        {
                             // Since right is assignable into left, we can treat right as ConstInt
                             let as_ordinal = value.ordinal().ok_or_else(|| {
                                 // Definitely the wrong type

--- a/compiler/toc_analysis/src/ty.rs
+++ b/compiler/toc_analysis/src/ty.rs
@@ -103,7 +103,7 @@ pub enum TypeKind {
 // - collection
 
 /// Size variant of an `Int`.
-#[derive(Debug, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum IntSize {
     Int1,
     Int2,
@@ -113,7 +113,7 @@ pub enum IntSize {
 }
 
 /// Size variant of a Nat
-#[derive(Debug, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum NatSize {
     Nat1,
     Nat2,

--- a/compiler/toc_analysis/src/ty.rs
+++ b/compiler/toc_analysis/src/ty.rs
@@ -429,7 +429,7 @@ where
 
                     count = count
                         .checked_mul(index_count)
-                        .map_err(|err| NotInteger::ConstError(err))?;
+                        .map_err(NotInteger::ConstError)?;
                 }
 
                 Ok(count)
@@ -442,7 +442,7 @@ where
                 // Range is inclusive, so also add 1
                 max.checked_sub(min)
                     .and_then(|count| count.checked_add(ConstInt::ONE))
-                    .map_err(|err| NotInteger::ConstError(err))
+                    .map_err(NotInteger::ConstError)
             }
         }
     }
@@ -487,7 +487,7 @@ where
                 // Just the ordinal value of the start bound
                 self.db
                     .evaluate_const(start_bound.clone(), Default::default())
-                    .map_err(|err| NotInteger::ConstError(err))?
+                    .map_err(NotInteger::ConstError)?
                     .ordinal()
                     .ok_or(NotInteger::NotInteger)?
             }

--- a/compiler/toc_analysis/src/ty.rs
+++ b/compiler/toc_analysis/src/ty.rs
@@ -567,8 +567,10 @@ where
                                 .map_err(NotInteger::ConstError)?;
 
                         // Offset by the gathered count
-                        start_bound
-                            .checked_add(count)
+                        // Sub by 1 since it's an inclusive range
+                        count
+                            .checked_sub(ConstInt::ONE)
+                            .and_then(|count| count.checked_add(start_bound))
                             .map_err(NotInteger::ConstError)?
                     }
                 }

--- a/compiler/toc_analysis/src/ty.rs
+++ b/compiler/toc_analysis/src/ty.rs
@@ -171,11 +171,18 @@ pub enum NotFixedLen {
     ConstError(ConstError),
 }
 
+/// If dynamic (i.e. runtime-evaluable) expressions are allowed
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum AllowDyn {
+    No,
+    Yes,
+}
+
 /// End bound of a [`TypeKind::Constrained`]
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub enum EndBound {
     /// From a constant expression
-    Expr(Const),
+    Expr(Const, AllowDyn),
     /// From an element count
     Unsized(u32),
 }
@@ -485,7 +492,7 @@ where
                 let eval_params = Default::default();
 
                 match end_bound {
-                    EndBound::Expr(end_bound) => {
+                    EndBound::Expr(end_bound, _) => {
                         // Just the ordinal value of the end bound
                         self.db
                             .evaluate_const(end_bound.clone(), eval_params)

--- a/compiler/toc_analysis/src/ty.rs
+++ b/compiler/toc_analysis/src/ty.rs
@@ -187,6 +187,8 @@ pub enum EndBound {
     Expr(Const, AllowDyn),
     /// From an element count
     Unsized(u32),
+    /// Derived at runtime
+    Any,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -572,6 +574,10 @@ where
                             .checked_sub(ConstInt::ONE)
                             .and_then(|count| count.checked_add(start_bound))
                             .map_err(NotInteger::ConstError)?
+                    }
+                    EndBound::Any => {
+                        // FIXME: This should be a non-const error?
+                        return Err(NotInteger::NotInteger);
                     }
                 }
             }

--- a/compiler/toc_analysis/src/ty.rs
+++ b/compiler/toc_analysis/src/ty.rs
@@ -580,6 +580,7 @@ where
     }
 }
 
+// FIXME: replace with just constructing a WrongOperandType error
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum NotInteger {
     ConstError(ConstError),

--- a/compiler/toc_analysis/src/ty/db.rs
+++ b/compiler/toc_analysis/src/ty/db.rs
@@ -75,6 +75,12 @@ pub trait TypeInternExt {
         start: const_eval::Const,
         end: ty::EndBound,
     ) -> ty::TypeId;
+    fn mk_array(
+        &self,
+        sizing: ty::ArraySizing,
+        ranges: Vec<ty::TypeId>,
+        elem_ty: ty::TypeId,
+    ) -> ty::TypeId;
     fn mk_enum(&self, with_def: ty::WithDef, variants: Vec<DefId>) -> ty::TypeId;
     fn mk_set(&self, with_def: ty::WithDef, elem_ty: ty::TypeId) -> ty::TypeId;
     fn mk_pointer(&self, checked: ty::Checked, target_ty: ty::TypeId) -> ty::TypeId;

--- a/compiler/toc_analysis/src/ty/lower.rs
+++ b/compiler/toc_analysis/src/ty/lower.rs
@@ -32,6 +32,7 @@ pub(crate) fn ty_from_hir_ty(db: &dyn TypeDatabase, hir_id: InLibrary<hir_ty::Ty
         hir_ty::TypeKind::Alias(ty) => alias_ty(db, hir_id, ty),
         hir_ty::TypeKind::Constrained(ty) => constrained_ty(db, hir_id, ty),
         hir_ty::TypeKind::Enum(ty) => enum_ty(db, hir_id, ty),
+        hir_ty::TypeKind::Array(_ty) => db.mk_error(), // TODO(array-ty): Lower array types
         hir_ty::TypeKind::Set(ty) => set_ty(db, hir_id, ty),
         hir_ty::TypeKind::Pointer(ty) => pointer_ty(db, hir_id, ty),
         hir_ty::TypeKind::Subprogram(ty) => subprogram_ty(db, hir_id, ty),

--- a/compiler/toc_analysis/src/ty/lower.rs
+++ b/compiler/toc_analysis/src/ty/lower.rs
@@ -524,6 +524,7 @@ pub(crate) fn ty_from_expr(
             db.mk_error()
         }
         expr::ExprKind::Literal(expr) => literal_ty(db, expr),
+        expr::ExprKind::Init(_) => db.mk_error(), // always inferred from
         expr::ExprKind::Binary(expr) => binary_ty(db, body, expr, body_expr),
         expr::ExprKind::Unary(expr) => unary_ty(db, body, expr, body_expr),
         expr::ExprKind::All => db.mk_error(), // Special case calling

--- a/compiler/toc_analysis/src/ty/lower.rs
+++ b/compiler/toc_analysis/src/ty/lower.rs
@@ -713,6 +713,11 @@ fn call_expr_ty(
             db.binding_def(lhs_expr.into())
                 .map_or_else(|| db.mk_error(), |def_id| db.type_of(def_id.into()))
         }
+        TypeKind::Array(.., elem_ty) => {
+            // Array indexing
+            // Use the element type
+            *elem_ty
+        }
         _ => {
             // Not a callable subprogram
             db.mk_error()

--- a/compiler/toc_analysis/src/ty/lower.rs
+++ b/compiler/toc_analysis/src/ty/lower.rs
@@ -20,7 +20,7 @@ use crate::{
     },
 };
 
-use super::{IntSize, NatSize, RealSize, SeqSize};
+use super::{AllowDyn, IntSize, NatSize, RealSize, SeqSize};
 
 pub(crate) fn ty_from_hir_ty(db: &dyn TypeDatabase, hir_id: InLibrary<hir_ty::TypeId>) -> TypeId {
     let library = db.library(hir_id.0);
@@ -149,9 +149,16 @@ fn constrained_ty(
         base_tyref.id()
     };
 
+    let allow_dyn = if ty.allow_dyn {
+        AllowDyn::Yes
+    } else {
+        AllowDyn::No
+    };
     let start = Const::from_body(library_id, ty.start);
     let end = match ty.end {
-        hir_ty::ConstrainedEnd::Expr(end) => ty::EndBound::Expr(Const::from_body(library_id, end)),
+        hir_ty::ConstrainedEnd::Expr(end) => {
+            ty::EndBound::Expr(Const::from_body(library_id, end), allow_dyn)
+        }
         hir_ty::ConstrainedEnd::Unsized(sz) => ty::EndBound::Unsized(sz.item().unwrap_or(0)),
     };
 

--- a/compiler/toc_analysis/src/ty/lower.rs
+++ b/compiler/toc_analysis/src/ty/lower.rs
@@ -125,7 +125,7 @@ fn constrained_ty(
         let start_tyref = db.type_of(ty.start.in_library(library_id).into()).in_db(db);
         let end_tyref = match ty.end {
             hir_ty::ConstrainedEnd::Expr(end) => db.type_of(end.in_library(library_id).into()),
-            hir_ty::ConstrainedEnd::Unsized(_) => db.mk_error(),
+            _ => db.mk_error(),
         }
         .in_db(db);
 
@@ -160,6 +160,7 @@ fn constrained_ty(
             ty::EndBound::Expr(Const::from_body(library_id, end), allow_dyn)
         }
         hir_ty::ConstrainedEnd::Unsized(sz) => ty::EndBound::Unsized(sz.item().unwrap_or(0)),
+        hir_ty::ConstrainedEnd::Any(_) => ty::EndBound::Any,
     };
 
     db.mk_constrained(base_ty, start, end)

--- a/compiler/toc_analysis/src/ty/pretty.rs
+++ b/compiler/toc_analysis/src/ty/pretty.rs
@@ -250,13 +250,16 @@ where
             // intersperse comma
             let mut ranges = ranges.iter();
             if let Some(range_ty) = ranges.next() {
-                write!(out, " {}", range_ty.in_db(db))?;
+                write!(out, " ")?;
+                emit_display_ty(db, out, *range_ty, PokeAliases::Yes)?;
             }
             for range_ty in ranges {
-                write!(out, ", {}", range_ty.in_db(db))?;
+                write!(out, ", ")?;
+                emit_display_ty(db, out, *range_ty, PokeAliases::Yes)?;
             }
 
-            write!(out, " of {}", elem_ty.in_db(db))?;
+            write!(out, " of ")?;
+            emit_display_ty(db, out, *elem_ty, PokeAliases::No)?;
         }
         TypeKind::Enum(with_def, _) => {
             let def_id = match with_def {

--- a/compiler/toc_analysis/src/ty/pretty.rs
+++ b/compiler/toc_analysis/src/ty/pretty.rs
@@ -240,7 +240,7 @@ where
                         unreachable!("should not show errors! ({err:?})")
                     }
                 },
-                EndBound::Unsized(_) => write!(out, "*")?,
+                EndBound::Unsized(_) | EndBound::Any => write!(out, "*")?,
             }
         }
         TypeKind::Array(_is_flexible, ranges, elem_ty) => {

--- a/compiler/toc_analysis/src/ty/query.rs
+++ b/compiler/toc_analysis/src/ty/query.rs
@@ -330,6 +330,7 @@ pub(super) fn value_produced(
                     }
                     _ => Ok(ValueKind::Scalar),
                 },
+                // TODO: For ExprKind call (subprog refs & stuff)
                 _ => {
                     // Take from the expr's type (always produces a value)
                     let expr_ty = db.type_of((lib_id, body_expr).into());
@@ -656,6 +657,20 @@ where
         self.intern_type(
             Type {
                 kind: TypeKind::Constrained(base_ty, start, end),
+            }
+            .into(),
+        )
+    }
+
+    fn mk_array(
+        &self,
+        sizing: super::ArraySizing,
+        ranges: Vec<super::TypeId>,
+        elem_ty: super::TypeId,
+    ) -> super::TypeId {
+        self.intern_type(
+            Type {
+                kind: TypeKind::Array(sizing, ranges, elem_ty),
             }
             .into(),
         )

--- a/compiler/toc_analysis/src/ty/rules.rs
+++ b/compiler/toc_analysis/src/ty/rules.rs
@@ -160,6 +160,10 @@ impl TypeKind {
                 // Only if the base type is, but we don't have access to db
                 unreachable!("missing to_base_type")
             }
+            TypeKind::Array(..) => {
+                // Aggregate types of elements
+                false
+            }
             TypeKind::String | TypeKind::CharN(_) | TypeKind::StringN(_) => {
                 // Aggregate types of characters
                 false

--- a/compiler/toc_analysis/src/ty/rules.rs
+++ b/compiler/toc_analysis/src/ty/rules.rs
@@ -49,6 +49,10 @@ impl TypeKind {
         matches!(self, TypeKind::Alias(..))
     }
 
+    pub fn is_array(&self) -> bool {
+        matches!(self, TypeKind::Array(..))
+    }
+
     pub fn is_enum(&self) -> bool {
         matches!(self, TypeKind::Enum(..))
     }

--- a/compiler/toc_analysis/src/ty/rules.rs
+++ b/compiler/toc_analysis/src/ty/rules.rs
@@ -524,10 +524,106 @@ pub fn is_coercible_into_param<T: ?Sized + db::ConstEval>(
         return true;
     }
 
-    // FIXME: Be transitive over arrays and ranges
     match (left.kind(), right.kind()) {
+        // CharSeq-likes are coercible into the corresponding any-sized CharSeq
         (TypeKind::CharN(SeqSize::Any), _) => right.kind().is_char_like(),
         (TypeKind::StringN(SeqSize::Any), _) => right.kind().is_string_like(),
+        // Arrays are coercible if the ranges and elem ty are
+        (
+            TypeKind::Array(left_sizing, left_ranges, left_elem),
+            TypeKind::Array(right_sizing, right_ranges, right_elem),
+        ) => {
+            let same_flex = match (left_sizing, right_sizing) {
+                // If either is flexible, the other must be too
+                (ArraySizing::Flexible, other) | (other, ArraySizing::Flexible) => {
+                    *other == ArraySizing::Flexible
+                }
+                // The rest are equivalent
+                _ => true,
+            };
+
+            if !same_flex {
+                return false;
+            }
+
+            // Element types must be param-coercible
+            if !is_coercible_into_param(db, *left_elem, *right_elem) {
+                return false;
+            }
+
+            // Ranges must be the same length, and all ranges must be param-coercible types
+            left_ranges.len() == right_ranges.len()
+                && std::iter::zip(left_ranges.iter(), right_ranges.iter())
+                    .all(|(left, right)| is_coercible_into_param(db, *left, *right))
+        }
+        (
+            TypeKind::Constrained(left_base, left_start, left_end),
+            TypeKind::Constrained(right_base, right_start, right_end),
+        ) => {
+            // Base types must be param-coercible
+            if !is_coercible_into_param(db, *left_base, *right_base) {
+                return false;
+            }
+
+            // FIXME: use the correct eval params
+            let eval_params = Default::default();
+
+            let left_start = match db.evaluate_const(left_start.clone(), eval_params) {
+                Ok(v) => v,
+                Err(_) => return true, // invalid evaluations treated as equivalent types
+            };
+            let right_start = match db.evaluate_const(right_start.clone(), eval_params) {
+                Ok(v) => v,
+                Err(_) => return true, // invalid evaluations treated as equivalent types
+            };
+
+            // Bail if the start bounds weren't the same
+            if left_start != right_start {
+                return false;
+            }
+
+            // Fully equivalent if the end bounds are also the same
+            match (left_end, right_end) {
+                (
+                    ty::EndBound::Expr(left_end, left_dyn),
+                    ty::EndBound::Expr(right_end, right_dyn),
+                ) => {
+                    let eval_bound = |cons| {
+                        db.evaluate_const(cons, eval_params).map_err(|err| {
+                            if err.is_not_compile_time() {
+                                // Only treat as an invalid expression (and therefore equivalent) if
+                                // neither allow dynamic expressions, since dynamic expressions are
+                                // never equivalent
+                                matches!(left_dyn, AllowDyn::No)
+                                    && matches!(right_dyn, AllowDyn::No)
+                            } else {
+                                // invalid evaluations treated as equivalent types
+                                true
+                            }
+                        })
+                    };
+
+                    let left_end = match eval_bound(left_end.clone()) {
+                        Ok(v) => v,
+                        Err(equi) => return equi,
+                    };
+                    let right_end = match eval_bound(right_end.clone()) {
+                        Ok(v) => v,
+                        Err(equi) => return equi,
+                    };
+
+                    left_end == right_end
+                }
+                // Unsized bounds must be the same length (both are known to start at the same element)
+                (ty::EndBound::Unsized(left_end), ty::EndBound::Unsized(right_end)) => {
+                    left_end == right_end
+                }
+                // Any bound is trivially param-coercible into an `any`-sized bound
+                (ty::EndBound::Any, _) => true,
+                // Different end bound kinds
+                _ => false,
+            }
+        }
         _ => false,
     }
 }

--- a/compiler/toc_analysis/src/ty/rules.rs
+++ b/compiler/toc_analysis/src/ty/rules.rs
@@ -10,7 +10,7 @@ use crate::{
     ty::{self, NotFixedLen, SeqSize, TypeId, TypeKind},
 };
 
-use super::TyRef;
+use super::{AllowDyn, TyRef};
 
 impl TypeKind {
     // ???: Do we want to move all of these into `TyRef`?
@@ -344,16 +344,34 @@ pub fn is_equivalent<T: db::ConstEval + ?Sized>(db: &T, left: TypeId, right: Typ
                 return false;
             }
 
-            // Fully equivalent if the end bounds are the same
+            // Fully equivalent if the end bounds are also the same
             match (left_end, right_end) {
-                (ty::EndBound::Expr(left_end), ty::EndBound::Expr(right_end)) => {
-                    let left_end = match db.evaluate_const(left_end.clone(), eval_params) {
-                        Ok(v) => v,
-                        Err(_) => return true, // invalid evaluations treated as equivalent types
+                (
+                    ty::EndBound::Expr(left_end, left_dyn),
+                    ty::EndBound::Expr(right_end, right_dyn),
+                ) => {
+                    let eval_bound = |cons| {
+                        db.evaluate_const(cons, eval_params).map_err(|err| {
+                            if err.is_not_compile_time() {
+                                // Only treat as an invalid expression (and therefore equivalent) if
+                                // neither allow dynamic expressions, since dynamic expressions are
+                                // never equivalent
+                                matches!(left_dyn, AllowDyn::No)
+                                    && matches!(right_dyn, AllowDyn::No)
+                            } else {
+                                // invalid evaluations treated as equivalent types
+                                true
+                            }
+                        })
                     };
-                    let right_end = match db.evaluate_const(right_end.clone(), eval_params) {
+
+                    let left_end = match eval_bound(left_end.clone()) {
                         Ok(v) => v,
-                        Err(_) => return true, // invalid evaluations treated as equivalent types
+                        Err(equi) => return equi,
+                    };
+                    let right_end = match eval_bound(right_end.clone()) {
+                        Ok(v) => v,
+                        Err(equi) => return equi,
                     };
 
                     left_end == right_end

--- a/compiler/toc_analysis/src/typeck.rs
+++ b/compiler/toc_analysis/src/typeck.rs
@@ -960,7 +960,7 @@ impl TypeCheck<'_> {
                         None
                     }
                 }
-                body::BodyOwner::Type(_) => None,
+                _ => None,
             }
         } else {
             unreachable!()

--- a/compiler/toc_analysis/src/typeck.rs
+++ b/compiler/toc_analysis/src/typeck.rs
@@ -783,14 +783,22 @@ impl TypeCheck<'_> {
                     let bounds_tyref = bounds_ty.in_db(db).peel_opaque(in_module);
                     let bounds_base_ty = bounds_tyref.clone().peel_aliases();
 
-                    // FIXME(for-each): Specialize message for iterables
-                    self.state()
-                        .reporter
-                        .error_detailed("mismatched types", bounds_span)
-                        .with_note(format!("this is of type `{bounds_tyref}`"), bounds_span)
-                        .with_error(format!("`{bounds_base_ty}` is not iterable"), bounds_span)
-                        .with_info("only arrays types can be iterated over")
-                        .finish();
+                    if bounds_base_ty.kind().is_array() {
+                        // Specialize the message for iterables
+                        self.state().reporter.error(
+                            "unsupported operation",
+                            "for-each loops are not implemented yet",
+                            bounds_span,
+                        );
+                    } else {
+                        self.state()
+                            .reporter
+                            .error_detailed("mismatched types", bounds_span)
+                            .with_note(format!("this is of type `{bounds_tyref}`"), bounds_span)
+                            .with_error(format!("`{bounds_base_ty}` is not iterable"), bounds_span)
+                            .with_info("only arrays types can be iterated over")
+                            .finish();
+                    }
 
                     return;
                 }

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_array_param.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_array_param.snap
@@ -1,0 +1,14 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "type tp: proc(_ : array 1..2 of char(*))\nvar a : array 1..2 of char\nvar b : array 1..2 of char(42)\nvar p : tp\n\n% element type is also coercible\np(a)\np(b)\n"
+
+---
+"<unnamed>"@(dummy) [Declared]: <error>
+"_"@(FileId(1), 14..15) [Declared]: <error>
+"tp"@(FileId(1), 5..7) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(2))] of procedure ( pass(value) array ( range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No)), ) of char_n Any, ) -> void
+"a"@(FileId(1), 45..46) [Declared]: array ( range of `int` (Unevaluated(LibraryId(0), BodyId(2)) .. Expr(Unevaluated(LibraryId(0), BodyId(3)), Yes)), ) of char
+"b"@(FileId(1), 72..73) [Declared]: array ( range of `int` (Unevaluated(LibraryId(0), BodyId(4)) .. Expr(Unevaluated(LibraryId(0), BodyId(5)), Yes)), ) of char_n Fixed(Unevaluated(LibraryId(0), BodyId(6)))
+"p"@(FileId(1), 103..104) [Declared]: alias[DefId(LibraryId(0), LocalDefId(2))] of procedure ( pass(value) array ( range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No)), ) of char_n Any, ) -> void
+"<root>"@(dummy) [Declared]: <error>
+

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_constrained.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_constrained.snap
@@ -4,9 +4,9 @@ assertion_line: 42
 expression: "type c : 1 .. 2\nvar a, b : c := 2\nvar i : int\nvar n : nat\n% can be coerced into the base type\na := b\na := 1\na := i\na := n\n% coercible into the base type\ni := a\nn := a\n"
 
 ---
-"c"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1))))
-"a"@(FileId(1), 20..21) [Declared]: alias[DefId(LibraryId(0), LocalDefId(0))] of range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1))))
-"b"@(FileId(1), 23..24) [Declared]: alias[DefId(LibraryId(0), LocalDefId(0))] of range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1))))
+"c"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No))
+"a"@(FileId(1), 20..21) [Declared]: alias[DefId(LibraryId(0), LocalDefId(0))] of range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No))
+"b"@(FileId(1), 23..24) [Declared]: alias[DefId(LibraryId(0), LocalDefId(0))] of range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No))
 "i"@(FileId(1), 38..39) [Declared]: int
 "n"@(FileId(1), 50..51) [Declared]: nat
 "<root>"@(dummy) [Declared]: <error>

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_constrained_array_range.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_constrained_array_range.snap
@@ -1,0 +1,18 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "type tp : proc(var _ : array 1 .. * of int)\nvar a : array 1 .. 3 of int\nvar b : array 2 .. 3 of int\nvar p : tp\n\n% only coercible if start bound is the same\np(a) % success\np(b) % fail\n"
+
+---
+"<unnamed>"@(dummy) [Declared]: <error>
+"_"@(FileId(1), 19..20) [Declared]: <error>
+"tp"@(FileId(1), 5..7) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(2))] of procedure ( pass(var ref) array ( range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Any), ) of int, ) -> void
+"a"@(FileId(1), 48..49) [Declared]: array ( range of `int` (Unevaluated(LibraryId(0), BodyId(1)) .. Expr(Unevaluated(LibraryId(0), BodyId(2)), Yes)), ) of int
+"b"@(FileId(1), 76..77) [Declared]: array ( range of `int` (Unevaluated(LibraryId(0), BodyId(3)) .. Expr(Unevaluated(LibraryId(0), BodyId(4)), Yes)), ) of int
+"p"@(FileId(1), 104..105) [Declared]: alias[DefId(LibraryId(0), LocalDefId(2))] of procedure ( pass(var ref) array ( range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Any), ) of int, ) -> void
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 173..174: mismatched types
+| note in file FileId(1) for 173..174: this is of type `array 2 .. 3 of int`
+| note in file FileId(1) for 173..174: parameter expects type `array 1 .. * of int`
+| info: `array 2 .. 3 of int` is not equivalent to `array 1 .. * of int`

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_constrained_set_elem.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_constrained_set_elem.snap
@@ -5,10 +5,10 @@ expression: "type cs : set of 1 .. 2\nvar i : int\nvar n : int\nvar _ : boolean\
 
 ---
 "cs"@(FileId(1), 10..23) [Declared]: <error>
-"cs"@(FileId(1), 5..7) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(0))] of range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1))))
+"cs"@(FileId(1), 5..7) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(0))] of range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No))
 "i"@(FileId(1), 28..29) [Declared]: int
 "n"@(FileId(1), 40..41) [Declared]: int
 "_"@(FileId(1), 52..53) [Declared]: boolean
-"s"@(FileId(1), 69..70) [Declared]: set[DefId(LibraryId(0), LocalDefId(0))] of range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1))))
+"s"@(FileId(1), 69..70) [Declared]: set[DefId(LibraryId(0), LocalDefId(0))] of range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No))
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_dyn_array_param_err.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_dyn_array_param_err.snap
@@ -1,0 +1,17 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "% dyn arrays aren't allowed, since the range is expected to be known at compile-time\nvar c : int\nvar a : array 1..c of char\nproc p(_ : array 1..2 of char(*)) end p\n\np(a)\n"
+
+---
+"c"@(FileId(1), 89..90) [Declared]: int
+"a"@(FileId(1), 101..102) [Declared]: array ( range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), Yes)), ) of char
+"p"@(FileId(1), 129..130) [Declared]: procedure ( pass(value) array ( range of `int` (Unevaluated(LibraryId(0), BodyId(2)) .. Expr(Unevaluated(LibraryId(0), BodyId(3)), No)), ) of char_n Any, ) -> void
+"<unnamed>"@(dummy) [Declared]: <error>
+"_"@(FileId(1), 131..132) [Declared]: array ( range of `int` (Unevaluated(LibraryId(0), BodyId(2)) .. Expr(Unevaluated(LibraryId(0), BodyId(3)), No)), ) of char_n Any
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 167..168: mismatched types
+| note in file FileId(1) for 167..168: this is of type `array 1 .. {dynamic} of char`
+| note in file FileId(1) for 167..168: parameter expects type `array 1 .. 2 of char(*)`
+| info: `array 1 .. {dynamic} of char` is not assignable into `array 1 .. 2 of char(*)`

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__equivalence_of_arrays_elements.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__equivalence_of_arrays_elements.snap
@@ -1,0 +1,15 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "% over array elements\nvar a : array 0+1..1 of int\nvar b : array 0+1..1 of int1\nvar c : array 0+1..1 of int % trying to make unique types\n\n% element types must be equivalent\na := b\na := c\n"
+
+---
+"a"@(FileId(1), 26..27) [Declared]: array ( range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), Yes)), ) of int
+"b"@(FileId(1), 54..55) [Declared]: array ( range of `int` (Unevaluated(LibraryId(0), BodyId(2)) .. Expr(Unevaluated(LibraryId(0), BodyId(3)), Yes)), ) of int1
+"c"@(FileId(1), 83..84) [Declared]: array ( range of `int` (Unevaluated(LibraryId(0), BodyId(4)) .. Expr(Unevaluated(LibraryId(0), BodyId(5)), Yes)), ) of int
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 175..177: mismatched types
+| note in file FileId(1) for 178..179: this is of type `array 1 .. 1 of int1`
+| note in file FileId(1) for 173..174: this is of type `array 1 .. 1 of int`
+| info: `array 1 .. 1 of int1` is not assignable into `array 1 .. 1 of int`

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__equivalence_of_arrays_ranges.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__equivalence_of_arrays_ranges.snap
@@ -1,0 +1,22 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "% over array ranges\nvar a : array 0+1..1 of int\nvar b : array 0+2..2 of int\nvar c : array 0+1..1 of int\n\n% ranges must be equivalent\na := b % not equivalent\na := c % is equivalent\n\nvar d : array 0+1..1, 0+2..2 of char\nvar e : array 0+1..1 of char\nvar f : array 0+1..1, 0+2..2 of char\n\n% must have the same number of ranges\nd := e\nd := f\n"
+
+---
+"a"@(FileId(1), 24..25) [Declared]: array ( range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), Yes)), ) of int
+"b"@(FileId(1), 52..53) [Declared]: array ( range of `int` (Unevaluated(LibraryId(0), BodyId(2)) .. Expr(Unevaluated(LibraryId(0), BodyId(3)), Yes)), ) of int
+"c"@(FileId(1), 80..81) [Declared]: array ( range of `int` (Unevaluated(LibraryId(0), BodyId(4)) .. Expr(Unevaluated(LibraryId(0), BodyId(5)), Yes)), ) of int
+"d"@(FileId(1), 185..186) [Declared]: array ( range of `int` (Unevaluated(LibraryId(0), BodyId(6)) .. Expr(Unevaluated(LibraryId(0), BodyId(7)), Yes)), range of `int` (Unevaluated(LibraryId(0), BodyId(8)) .. Expr(Unevaluated(LibraryId(0), BodyId(9)), Yes)), ) of char
+"e"@(FileId(1), 222..223) [Declared]: array ( range of `int` (Unevaluated(LibraryId(0), BodyId(10)) .. Expr(Unevaluated(LibraryId(0), BodyId(11)), Yes)), ) of char
+"f"@(FileId(1), 251..252) [Declared]: array ( range of `int` (Unevaluated(LibraryId(0), BodyId(12)) .. Expr(Unevaluated(LibraryId(0), BodyId(13)), Yes)), range of `int` (Unevaluated(LibraryId(0), BodyId(14)) .. Expr(Unevaluated(LibraryId(0), BodyId(15)), Yes)), ) of char
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 135..137: mismatched types
+| note in file FileId(1) for 138..139: this is of type `array 2 .. 2 of int`
+| note in file FileId(1) for 133..134: this is of type `array 1 .. 1 of int`
+| info: `array 2 .. 2 of int` is not assignable into `array 1 .. 1 of int`
+error in file FileId(1) at 325..327: mismatched types
+| note in file FileId(1) for 328..329: this is of type `array 1 .. 1 of char`
+| note in file FileId(1) for 323..324: this is of type `array 1 .. 1, 2 .. 2 of char`
+| info: `array 1 .. 1 of char` is not assignable into `array 1 .. 1, 2 .. 2 of char`

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__equivalence_of_arrays_sizing.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__equivalence_of_arrays_sizing.snap
@@ -1,0 +1,37 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "% categories\n% - Static\n% - MaybeDyn-Static\n% - MaybeDyn-Dynamic\n% - Flexible\n% init-sized are implied Static\n\n% guarantee that these are static arrays\ntype tsta : array 0+1..1 of int\ntype tstb : array 0+1..1 of int\nvar c : int\n\nvar fxa : flexible array 0+1..1 of int\nvar fxb : flexible array 0+1..1 of int\nvar fxc : flexible array 0+1..2 of int\nvar fxd : flexible array 0+1..1 of int1\n\nvar dyna : array 0+1..c of int\nvar dynb : array 0+1..c of int\n\nvar msta : array 0+1..1 of int\nvar mstb : array 0+1..1 of int\n\nvar sta : tsta\nvar stb : tstb\n\n% identity\nsta := stb\nmsta := mstb\n\n% Static & MaybeDyn-Static are equivalent\nsta := msta\nmsta := sta\n\n% MaybeDyn-Dynamic is never equivalent to anything (except itself)\ndyna := dyna % succeed\ndyna := dynb % fail\n\n% usual equivalence rules apply for flexible arrays...\nfxa := fxb % same ranges\nfxa := fxc % different ranges\nfxa := fxd % different elem tys\n\n% except that arrays must be of the same flexibility\nsta := fxa\n"
+
+---
+"tsta"@(FileId(1), 157..161) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of array ( range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No)), ) of int
+"tstb"@(FileId(1), 189..193) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(1))] of array ( range of `int` (Unevaluated(LibraryId(0), BodyId(2)) .. Expr(Unevaluated(LibraryId(0), BodyId(3)), No)), ) of int
+"c"@(FileId(1), 220..221) [Declared]: int
+"fxa"@(FileId(1), 233..236) [Declared]: flexible array ( range of `int` (Unevaluated(LibraryId(0), BodyId(4)) .. Expr(Unevaluated(LibraryId(0), BodyId(5)), Yes)), ) of int
+"fxb"@(FileId(1), 272..275) [Declared]: flexible array ( range of `int` (Unevaluated(LibraryId(0), BodyId(6)) .. Expr(Unevaluated(LibraryId(0), BodyId(7)), Yes)), ) of int
+"fxc"@(FileId(1), 311..314) [Declared]: flexible array ( range of `int` (Unevaluated(LibraryId(0), BodyId(8)) .. Expr(Unevaluated(LibraryId(0), BodyId(9)), Yes)), ) of int
+"fxd"@(FileId(1), 350..353) [Declared]: flexible array ( range of `int` (Unevaluated(LibraryId(0), BodyId(10)) .. Expr(Unevaluated(LibraryId(0), BodyId(11)), Yes)), ) of int1
+"dyna"@(FileId(1), 391..395) [Declared]: array ( range of `int` (Unevaluated(LibraryId(0), BodyId(12)) .. Expr(Unevaluated(LibraryId(0), BodyId(13)), Yes)), ) of int
+"dynb"@(FileId(1), 422..426) [Declared]: array ( range of `int` (Unevaluated(LibraryId(0), BodyId(14)) .. Expr(Unevaluated(LibraryId(0), BodyId(15)), Yes)), ) of int
+"msta"@(FileId(1), 454..458) [Declared]: array ( range of `int` (Unevaluated(LibraryId(0), BodyId(16)) .. Expr(Unevaluated(LibraryId(0), BodyId(17)), Yes)), ) of int
+"mstb"@(FileId(1), 485..489) [Declared]: array ( range of `int` (Unevaluated(LibraryId(0), BodyId(18)) .. Expr(Unevaluated(LibraryId(0), BodyId(19)), Yes)), ) of int
+"sta"@(FileId(1), 517..520) [Declared]: alias[DefId(LibraryId(0), LocalDefId(0))] of array ( range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No)), ) of int
+"stb"@(FileId(1), 532..535) [Declared]: alias[DefId(LibraryId(0), LocalDefId(1))] of array ( range of `int` (Unevaluated(LibraryId(0), BodyId(2)) .. Expr(Unevaluated(LibraryId(0), BodyId(3)), No)), ) of int
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 742..744: mismatched types
+| note in file FileId(1) for 745..749: this is of type `array 1 .. {dynamic} of int`
+| note in file FileId(1) for 737..741: this is of type `array 1 .. {dynamic} of int`
+| info: `array 1 .. {dynamic} of int` is not assignable into `array 1 .. {dynamic} of int`
+error in file FileId(1) at 842..844: mismatched types
+| note in file FileId(1) for 845..848: this is of type `flexible array 1 .. 2 of int`
+| note in file FileId(1) for 838..841: this is of type `flexible array 1 .. 1 of int`
+| info: `flexible array 1 .. 2 of int` is not assignable into `flexible array 1 .. 1 of int`
+error in file FileId(1) at 872..874: mismatched types
+| note in file FileId(1) for 875..878: this is of type `flexible array 1 .. 1 of int1`
+| note in file FileId(1) for 868..871: this is of type `flexible array 1 .. 1 of int`
+| info: `flexible array 1 .. 1 of int1` is not assignable into `flexible array 1 .. 1 of int`
+error in file FileId(1) at 958..960: mismatched types
+| note in file FileId(1) for 961..964: this is of type `flexible array 1 .. 1 of int`
+| note in file FileId(1) for 954..957: this is of type `tsta (alias of array 1 .. 1 of int)`
+| info: `flexible array 1 .. 1 of int` is not assignable into `array 1 .. 1 of int`

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__equivalence_of_constraineds.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__equivalence_of_constraineds.snap
@@ -1,0 +1,23 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "% using array types as a proxy for constrained ty equivalence\ntype r1 : 1..2\ntype r2 : 3..4\n\nvar a : array r1 of int\nvar b : array r2 of int\nvar c : array (1+1-1)..(4 div 2) of int\n\n% bounds must be equal\na := b\n% if they evaluate to the same values, they're equivalent\na := c\n\nvar d : array 0..0 of int\nvar e : array false..false of int\n\n% base types must be the same\nd := e\n"
+
+---
+"r1"@(FileId(1), 67..69) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No))
+"r2"@(FileId(1), 82..84) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(1))] of range of `int` (Unevaluated(LibraryId(0), BodyId(2)) .. Expr(Unevaluated(LibraryId(0), BodyId(3)), No))
+"a"@(FileId(1), 97..98) [Declared]: array ( alias[DefId(LibraryId(0), LocalDefId(0))] of range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No)), ) of int
+"b"@(FileId(1), 121..122) [Declared]: array ( alias[DefId(LibraryId(0), LocalDefId(1))] of range of `int` (Unevaluated(LibraryId(0), BodyId(2)) .. Expr(Unevaluated(LibraryId(0), BodyId(3)), No)), ) of int
+"c"@(FileId(1), 145..146) [Declared]: array ( range of `int` (Unevaluated(LibraryId(0), BodyId(4)) .. Expr(Unevaluated(LibraryId(0), BodyId(5)), Yes)), ) of int
+"d"@(FileId(1), 282..283) [Declared]: array ( range of `int` (Unevaluated(LibraryId(0), BodyId(6)) .. Expr(Unevaluated(LibraryId(0), BodyId(7)), Yes)), ) of int
+"e"@(FileId(1), 308..309) [Declared]: array ( range of `boolean` (Unevaluated(LibraryId(0), BodyId(8)) .. Expr(Unevaluated(LibraryId(0), BodyId(9)), Yes)), ) of int
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 207..209: mismatched types
+| note in file FileId(1) for 210..211: this is of type `array 3 .. 4 of int`
+| note in file FileId(1) for 205..206: this is of type `array 1 .. 2 of int`
+| info: `array 3 .. 4 of int` is not assignable into `array 1 .. 2 of int`
+error in file FileId(1) at 371..373: mismatched types
+| note in file FileId(1) for 374..375: this is of type `array false .. false of int`
+| note in file FileId(1) for 369..370: this is of type `array 0 .. 0 of int`
+| info: `array false .. false of int` is not assignable into `array 0 .. 0 of int`

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__require_positive_size_in_constvar.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__require_positive_size_in_constvar.snap
@@ -4,7 +4,7 @@ assertion_line: 42
 expression: "var _ : 1 .. 0"
 
 ---
-"_"@(FileId(1), 4..5) [Declared]: range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1))))
+"_"@(FileId(1), 4..5) [Declared]: range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No))
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 8..14: element range is too small

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__require_positive_size_in_pointer_ty.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__require_positive_size_in_pointer_ty.snap
@@ -4,7 +4,7 @@ assertion_line: 42
 expression: "type _ : ^1..0"
 
 ---
-"_"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of pointer to range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1))))
+"_"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of pointer to range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No))
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 10..14: element range is too small

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__require_positive_size_in_set_ty.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__require_positive_size_in_set_ty.snap
@@ -5,7 +5,7 @@ expression: "type _ : set of 1..0"
 
 ---
 "_"@(FileId(1), 9..20) [Declared]: <error>
-"_"@(FileId(1), 5..6) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(0))] of range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1))))
+"_"@(FileId(1), 5..6) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(0))] of range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No))
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 16..20: element range is too small

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__require_positive_size_in_subprogram_param.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__require_positive_size_in_subprogram_param.snap
@@ -4,9 +4,9 @@ assertion_line: 42
 expression: "proc p(_:1..0) end p"
 
 ---
-"p"@(FileId(1), 5..6) [Declared]: procedure ( pass(value) range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)))), ) -> void
+"p"@(FileId(1), 5..6) [Declared]: procedure ( pass(value) range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No)), ) -> void
 "<unnamed>"@(dummy) [Declared]: <error>
-"_"@(FileId(1), 7..8) [Declared]: range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1))))
+"_"@(FileId(1), 7..8) [Declared]: range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No))
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 9..13: element range is too small

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__require_positive_size_in_subprogram_result.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__require_positive_size_in_subprogram_result.snap
@@ -4,7 +4,7 @@ assertion_line: 42
 expression: "fcn _() : 1..0 end _"
 
 ---
-"_"@(FileId(1), 4..5) [Declared]: function ( ) -> range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1))))
+"_"@(FileId(1), 4..5) [Declared]: function ( ) -> range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No))
 "<unnamed>"@(dummy) [Declared]: <error>
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__require_positive_size_in_subprogram_ty_param.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__require_positive_size_in_subprogram_ty_param.snap
@@ -6,7 +6,7 @@ expression: "type _ : proc p(_:1..0)"
 ---
 "<unnamed>"@(dummy) [Declared]: <error>
 "_"@(FileId(1), 16..17) [Declared]: <error>
-"_"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(2))] of procedure ( pass(value) range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)))), ) -> void
+"_"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(2))] of procedure ( pass(value) range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No)), ) -> void
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 18..22: element range is too small

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__require_positive_size_in_subprogram_ty_result.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__require_positive_size_in_subprogram_ty_result.snap
@@ -5,7 +5,7 @@ expression: "type _ : fcn _() : 1..0"
 
 ---
 "<unnamed>"@(dummy) [Declared]: <error>
-"_"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(1))] of function ( ) -> range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1))))
+"_"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(1))] of function ( ) -> range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No))
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 19..23: element range is too small

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__require_positive_size_in_type_decl.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__require_positive_size_in_type_decl.snap
@@ -4,7 +4,7 @@ assertion_line: 42
 expression: "type _ : 1 .. 0"
 
 ---
-"_"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1))))
+"_"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No))
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 9..15: element range is too small

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__require_positive_size_with_negative_size.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__require_positive_size_with_negative_size.snap
@@ -4,7 +4,7 @@ assertion_line: 42
 expression: "var _ : 2 .. 0"
 
 ---
-"_"@(FileId(1), 4..5) [Declared]: range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1))))
+"_"@(FileId(1), 4..5) [Declared]: range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No))
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 8..14: element range is too small

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__require_positive_size_with_overflowing_size.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__require_positive_size_with_overflowing_size.snap
@@ -5,7 +5,7 @@ expression: "const min : int4 := -16#7FFFFFFF - 1\nvar _ : min..(16#7FFFFFFF + 1
 
 ---
 "min"@(FileId(1), 6..9) [Declared]: int4
-"_"@(FileId(1), 41..42) [Declared]: range of `int4` (Unevaluated(LibraryId(0), BodyId(1)) .. Expr(Unevaluated(LibraryId(0), BodyId(2))))
+"_"@(FileId(1), 41..42) [Declared]: range of `int4` (Unevaluated(LibraryId(0), BodyId(1)) .. Expr(Unevaluated(LibraryId(0), BodyId(2)), No))
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 45..67: invalid range size

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_indexing_call_err_extra_for_multiple.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_indexing_call_err_extra_for_multiple.snap
@@ -1,0 +1,12 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "var a : array 1..2, 3..4 of int\nvar _ := a(1,2,3,4)"
+
+---
+"a"@(FileId(1), 4..5) [Declared]: array ( range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), Yes)), range of `int` (Unevaluated(LibraryId(0), BodyId(2)) .. Expr(Unevaluated(LibraryId(0), BodyId(3)), Yes)), ) of int
+"_"@(FileId(1), 36..37) [Declared]: int
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 41..42: expected 2 arguments, found 4
+| error in file FileId(1) for 41..42: subscript has 2 extra arguments

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_indexing_call_err_extra_for_single.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_indexing_call_err_extra_for_single.snap
@@ -1,0 +1,12 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "var a : array 1..2 of int\nvar _ := a(1,2,3,4)"
+
+---
+"a"@(FileId(1), 4..5) [Declared]: array ( range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), Yes)), ) of int
+"_"@(FileId(1), 30..31) [Declared]: int
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 35..36: expected 1 argument, found 4
+| error in file FileId(1) for 35..36: subscript has 3 extra arguments

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_indexing_call_err_from_type_binding.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_indexing_call_err_from_type_binding.snap
@@ -1,0 +1,14 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "type a : array 1..1 of int\na(1) := 1"
+
+---
+"a"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of array ( range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No)), ) of int
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 27..28: cannot call or subscript `a`
+| note in file FileId(1) for 27..28: this is of type `a (alias of array 1 .. 1 of int)`
+| info: only array variables can be subscripted
+error in file FileId(1) at 32..34: cannot assign into expression
+| error in file FileId(1) for 27..31: not a reference to a variable

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_indexing_call_err_missing_for_multiple.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_indexing_call_err_missing_for_multiple.snap
@@ -1,0 +1,12 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "var a : array 1..2, 3..4 of int\nvar _ := a(1)"
+
+---
+"a"@(FileId(1), 4..5) [Declared]: array ( range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), Yes)), range of `int` (Unevaluated(LibraryId(0), BodyId(2)) .. Expr(Unevaluated(LibraryId(0), BodyId(3)), Yes)), ) of int
+"_"@(FileId(1), 36..37) [Declared]: int
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 41..42: expected 2 arguments, found 1
+| error in file FileId(1) for 41..42: subscript is missing 1 argument

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_indexing_call_err_missing_for_single.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_indexing_call_err_missing_for_single.snap
@@ -1,0 +1,12 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "var a : array 1..2 of int\nvar _ := a()"
+
+---
+"a"@(FileId(1), 4..5) [Declared]: array ( range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), Yes)), ) of int
+"_"@(FileId(1), 30..31) [Declared]: int
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 35..36: expected 1 argument, found 0
+| error in file FileId(1) for 35..36: subscript is missing 1 argument

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_indexing_call_err_wrong_binding.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_indexing_call_err_wrong_binding.snap
@@ -1,0 +1,14 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "type i : int\nvar a : array 1..2 of int\nvar _ : int := a(i)"
+
+---
+"i"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of int
+"a"@(FileId(1), 17..18) [Declared]: array ( range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), Yes)), ) of int
+"_"@(FileId(1), 43..44) [Declared]: int
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 56..57: cannot pass `i` to this parameter
+| error in file FileId(1) for 56..57: `i` is a reference to a type, not a variable
+| note in file FileId(1) for 5..6: `i` declared here

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_indexing_call_err_wrong_ty.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_indexing_call_err_wrong_ty.snap
@@ -1,0 +1,18 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "var a : array 1..2, 'c'..'d' of int\nvar _ : int := a(1.0, true)"
+
+---
+"a"@(FileId(1), 4..5) [Declared]: array ( range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), Yes)), range of `char` (Unevaluated(LibraryId(0), BodyId(2)) .. Expr(Unevaluated(LibraryId(0), BodyId(3)), Yes)), ) of int
+"_"@(FileId(1), 40..41) [Declared]: int
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 53..56: mismatched types
+| note in file FileId(1) for 53..56: this is of type `real`
+| note in file FileId(1) for 53..56: parameter expects type `1 .. 2`
+| info: `real` is not assignable into `1 .. 2`
+error in file FileId(1) at 58..62: mismatched types
+| note in file FileId(1) for 58..62: this is of type `boolean`
+| note in file FileId(1) for 58..62: parameter expects type `'c' .. 'd'`
+| info: `boolean` is not assignable into `'c' .. 'd'`

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_indexing_call_from_const_ref.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_indexing_call_from_const_ref.snap
@@ -1,0 +1,11 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "const a : array 1..* of int := init(1)\na(1) := 1"
+
+---
+"a"@(FileId(1), 6..7) [Declared]: array ( range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Unsized(1)), ) of int
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 44..46: cannot assign into expression
+| error in file FileId(1) for 39..43: not a reference to a variable

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_indexing_call_from_var_ref.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_indexing_call_from_var_ref.snap
@@ -1,0 +1,9 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "var a : array 1..* of int := init(1)\na(1) := 1"
+
+---
+"a"@(FileId(1), 4..5) [Declared]: array ( range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Unsized(1)), ) of int
+"<root>"@(dummy) [Declared]: <error>
+

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_indexing_call_multi_index.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_indexing_call_multi_index.snap
@@ -1,0 +1,10 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "var a : array 1..2, 'c'..'d' of int\nvar _ : int := a(1, 'c')"
+
+---
+"a"@(FileId(1), 4..5) [Declared]: array ( range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), Yes)), range of `char` (Unevaluated(LibraryId(0), BodyId(2)) .. Expr(Unevaluated(LibraryId(0), BodyId(3)), Yes)), ) of int
+"_"@(FileId(1), 40..41) [Declared]: int
+"<root>"@(dummy) [Declared]: <error>
+

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_indexing_call_single_index.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_indexing_call_single_index.snap
@@ -1,0 +1,10 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "var a : array 1..2 of int\nvar _ : int := a(1)"
+
+---
+"a"@(FileId(1), 4..5) [Declared]: array ( range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), Yes)), ) of int
+"_"@(FileId(1), 30..31) [Declared]: int
+"<root>"@(dummy) [Declared]: <error>
+

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_ty_dynamic_size.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_ty_dynamic_size.snap
@@ -1,0 +1,10 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "var c : int var _ : array 1 .. c of int"
+
+---
+"c"@(FileId(1), 4..5) [Declared]: int
+"_"@(FileId(1), 16..17) [Declared]: array ( range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), Yes)), ) of int
+"<root>"@(dummy) [Declared]: <error>
+

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_ty_flexible_dynamic.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_ty_flexible_dynamic.snap
@@ -1,0 +1,10 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "var c : int\nvar _ : flexible array 1 .. c of int"
+
+---
+"c"@(FileId(1), 4..5) [Declared]: int
+"_"@(FileId(1), 16..17) [Declared]: flexible array ( range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), Yes)), ) of int
+"<root>"@(dummy) [Declared]: <error>
+

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_ty_flexible_size.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_ty_flexible_size.snap
@@ -1,0 +1,9 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "var _ : flexible array 1 .. 0 of int"
+
+---
+"_"@(FileId(1), 4..5) [Declared]: flexible array ( range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), Yes)), ) of int
+"<root>"@(dummy) [Declared]: <error>
+

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_ty_init_less_one.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_ty_init_less_one.snap
@@ -1,0 +1,11 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "var a : array 1..3 of int := init(1,2)"
+
+---
+"a"@(FileId(1), 4..5) [Declared]: array ( range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), Yes)), ) of int
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 29..38: expected 3 elements, found 2
+| error in file FileId(1) for 29..38: `init` list is missing 1 element

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_ty_init_less_two.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_ty_init_less_two.snap
@@ -1,0 +1,11 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "var a : array 1..3 of int := init(1)"
+
+---
+"a"@(FileId(1), 4..5) [Declared]: array ( range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), Yes)), ) of int
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 29..36: expected 3 elements, found 1
+| error in file FileId(1) for 29..36: `init` list is missing 2 elements

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_ty_init_mismatched_ty.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_ty_init_mismatched_ty.snap
@@ -1,0 +1,13 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "var a : array 1..1 of int := init(1.0)"
+
+---
+"a"@(FileId(1), 4..5) [Declared]: array ( range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), Yes)), ) of int
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 34..37: mismatched types
+| note in file FileId(1) for 34..37: this is of type `real`
+| note in file FileId(1) for 8..25: array expects type `int`
+| info: `real` is not assignable into `int`

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_ty_init_more_one.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_ty_init_more_one.snap
@@ -1,0 +1,11 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "var a : array 1..3 of int := init(1,2,3,4)"
+
+---
+"a"@(FileId(1), 4..5) [Declared]: array ( range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), Yes)), ) of int
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 29..42: expected 3 elements, found 4
+| error in file FileId(1) for 29..42: `init` list has 1 extra element

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_ty_init_more_two.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_ty_init_more_two.snap
@@ -1,0 +1,11 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "var a : array 1..3 of int := init(1,2,3,4,5)"
+
+---
+"a"@(FileId(1), 4..5) [Declared]: array ( range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), Yes)), ) of int
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 29..44: expected 3 elements, found 5
+| error in file FileId(1) for 29..44: `init` list has 2 extra elements

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_ty_init_not_comp_time.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_ty_init_not_comp_time.snap
@@ -1,0 +1,13 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "var c : int\nvar a : array 1..1 of int := init(c)"
+
+---
+"c"@(FileId(1), 4..5) [Declared]: int
+"a"@(FileId(1), 16..17) [Declared]: array ( range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), Yes)), ) of int
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 46..47: cannot compute `c` at compile-time
+| error in file FileId(1) for 46..47: `c` is a reference to a variable, not a constant
+| note in file FileId(1) for 4..5: `c` declared here

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_ty_init_on_dynamic.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_ty_init_on_dynamic.snap
@@ -1,0 +1,13 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "var c : int\nvar a : array 1..c of int := init(1)"
+
+---
+"c"@(FileId(1), 4..5) [Declared]: int
+"a"@(FileId(1), 16..17) [Declared]: array ( range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), Yes)), ) of int
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 41..48: cannot use `init` here
+| error in file FileId(1) for 41..48: `init` initializer cannot be used for dynamically sized arrays
+| info: dynamically-sized `array`s cannot initialized using `init` since their size is not known at compile-time

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_ty_init_on_flexible.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_ty_init_on_flexible.snap
@@ -1,0 +1,13 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "var a : flexible array 1..1 of int := init(1)"
+
+---
+"a"@(FileId(1), 4..5) [Declared]: flexible array ( range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), Yes)), ) of int
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 38..45: cannot use `init` here
+| error in file FileId(1) for 38..45: `init` initializer cannot be used for `flexible array 1 .. 1 of int`
+| note in file FileId(1) for 8..34: `flexible array 1 .. 1 of int` does not support aggregate initialzation
+| info: `flexible array`s cannot initialized using `init` since their size is not known at compile-time

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_ty_init_on_init_sized.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_ty_init_on_init_sized.snap
@@ -1,0 +1,9 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "var a : array 1..* of int := init(1,2,3,4,5)"
+
+---
+"a"@(FileId(1), 4..5) [Declared]: array ( range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Unsized(5)), ) of int
+"<root>"@(dummy) [Declared]: <error>
+

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_ty_init_on_static.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_ty_init_on_static.snap
@@ -1,0 +1,9 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "var a : array 1..1 of int := init(1)"
+
+---
+"a"@(FileId(1), 4..5) [Declared]: array ( range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), Yes)), ) of int
+"<root>"@(dummy) [Declared]: <error>
+

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_ty_init_on_too_large.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_ty_init_on_too_large.snap
@@ -1,0 +1,16 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "const mx : nat4 := 16#FFFFFFFF\nvar a : array 0..mx, 0..mx of int := init(1,2,3)"
+
+---
+"mx"@(FileId(1), 6..8) [Declared]: nat4
+"a"@(FileId(1), 35..36) [Declared]: array ( range of `nat4` (Unevaluated(LibraryId(0), BodyId(1)) .. Expr(Unevaluated(LibraryId(0), BodyId(2)), Yes)), range of `nat4` (Unevaluated(LibraryId(0), BodyId(3)) .. Expr(Unevaluated(LibraryId(0), BodyId(4)), Yes)), ) of int
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 39..64: `array` has too many elements
+| error in file FileId(1) for 39..64: overflow while computing element count
+error in file FileId(1) at 45..50: invalid range size
+| error in file FileId(1) for 45..50: range size is too large
+error in file FileId(1) at 52..57: invalid range size
+| error in file FileId(1) for 52..57: range size is too large

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_ty_init_sized.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_ty_init_sized.snap
@@ -1,0 +1,9 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "var _ : array 1 .. * of int := init(1, 2, 3)"
+
+---
+"_"@(FileId(1), 4..5) [Declared]: array ( range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Unsized(3)), ) of int
+"<root>"@(dummy) [Declared]: <error>
+

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_ty_negative_flexible_size.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_ty_negative_flexible_size.snap
@@ -1,0 +1,12 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "type _ : flexible array 1..-1 of int"
+
+---
+"_"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of flexible array ( range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No)), ) of int
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 24..29: element range is too small
+| note in file FileId(1) for 24..29: computed range size is -1
+| error in file FileId(1) for 24..29: negative sized ranges cannot be used in `array` types

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_ty_negative_static_size.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_ty_negative_static_size.snap
@@ -1,0 +1,12 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "type _ : array 1..-1 of int"
+
+---
+"_"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of array ( range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No)), ) of int
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 15..20: element range is too small
+| note in file FileId(1) for 15..20: computed range size is -1
+| error in file FileId(1) for 15..20: negative sized ranges cannot be used in `array` types

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_ty_not_dynamic_size.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_ty_not_dynamic_size.snap
@@ -1,0 +1,13 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "var c : int\ntype _ : array 1 .. c of int"
+
+---
+"c"@(FileId(1), 4..5) [Declared]: int
+"_"@(FileId(1), 17..18) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(1))] of array ( range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No)), ) of int
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 32..33: cannot compute `c` at compile-time
+| error in file FileId(1) for 32..33: `c` is a reference to a variable, not a constant
+| note in file FileId(1) for 4..5: `c` declared here

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_ty_not_index_ty.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_ty_not_index_ty.snap
@@ -1,0 +1,12 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "type _ : array real of real"
+
+---
+"_"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of array ( real, ) of real
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 15..19: mismatched types
+| error in file FileId(1) for 15..19: `real` is not an index type
+| info: an index type is an integer, a `boolean`, a `char`, an enumerated type, or a range

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_ty_positive_flexible_size.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_ty_positive_flexible_size.snap
@@ -1,0 +1,9 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "var _ : flexible array 1..1 of int"
+
+---
+"_"@(FileId(1), 4..5) [Declared]: flexible array ( range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), Yes)), ) of int
+"<root>"@(dummy) [Declared]: <error>
+

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_ty_positive_static_size.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_ty_positive_static_size.snap
@@ -1,0 +1,9 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "type _ : array 1..1 of int"
+
+---
+"_"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of array ( range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No)), ) of int
+"<root>"@(dummy) [Declared]: <error>
+

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_ty_sizing_int.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_ty_sizing_int.snap
@@ -1,0 +1,12 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "type _ : array int, 1..2 of int"
+
+---
+"_"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of array ( int, range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No)), ) of int
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 15..18: index range is too large
+| error in file FileId(1) for 15..18: a range over all `int` values is too large
+| info: use a range type to shrink the range of elements

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_ty_sizing_int1.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_ty_sizing_int1.snap
@@ -1,0 +1,9 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "type _ : array int1, 1..2 of int"
+
+---
+"_"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of array ( int1, range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No)), ) of int
+"<root>"@(dummy) [Declared]: <error>
+

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_ty_sizing_int2.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_ty_sizing_int2.snap
@@ -1,0 +1,9 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "type _ : array int2, 1..2 of int"
+
+---
+"_"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of array ( int2, range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No)), ) of int
+"<root>"@(dummy) [Declared]: <error>
+

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_ty_sizing_large.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_ty_sizing_large.snap
@@ -1,0 +1,11 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "type _ : array -16#7FFFFFFF..16#7FFFFFFF, 1..2 of int"
+
+---
+"_"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of array ( range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No)), range of `int` (Unevaluated(LibraryId(0), BodyId(2)) .. Expr(Unevaluated(LibraryId(0), BodyId(3)), No)), ) of int
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 9..53: `array` has too many elements
+| error in file FileId(1) for 9..53: overflow while computing element count

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_ty_sizing_nat.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_ty_sizing_nat.snap
@@ -1,0 +1,12 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "type _ : array nat, 1..2 of int"
+
+---
+"_"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of array ( nat, range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No)), ) of int
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 15..18: index range is too large
+| error in file FileId(1) for 15..18: a range over all `nat` values is too large
+| info: use a range type to shrink the range of elements

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_ty_sizing_nat1.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_ty_sizing_nat1.snap
@@ -1,0 +1,9 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "type _ : array nat1, 1..2 of int"
+
+---
+"_"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of array ( nat1, range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No)), ) of int
+"<root>"@(dummy) [Declared]: <error>
+

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_ty_sizing_nat2.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_ty_sizing_nat2.snap
@@ -1,0 +1,9 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "type _ : array nat2, 1..2 of int"
+
+---
+"_"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of array ( nat2, range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No)), ) of int
+"<root>"@(dummy) [Declared]: <error>
+

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_ty_sizing_overflow.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_ty_sizing_overflow.snap
@@ -1,0 +1,11 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "type _ : array 0..16#7FFFFFFF, 0..16#7FFFFFFF of int"
+
+---
+"_"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of array ( range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No)), range of `int` (Unevaluated(LibraryId(0), BodyId(2)) .. Expr(Unevaluated(LibraryId(0), BodyId(3)), No)), ) of int
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 9..52: `array` has too many elements
+| error in file FileId(1) for 9..52: overflow while computing element count

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_ty_static_size.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_ty_static_size.snap
@@ -1,0 +1,9 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "type _ : array 1 .. 3 of int"
+
+---
+"_"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of array ( range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No)), ) of int
+"<root>"@(dummy) [Declared]: <error>
+

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_ty_zero_flexible_size.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_ty_zero_flexible_size.snap
@@ -1,0 +1,9 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "type _ : flexible array 1..0 of int"
+
+---
+"_"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of flexible array ( range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No)), ) of int
+"<root>"@(dummy) [Declared]: <error>
+

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_ty_zero_static_size.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_array_ty_zero_static_size.snap
@@ -1,0 +1,12 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "type _ : array 1..0 of int"
+
+---
+"_"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of array ( range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No)), ) of int
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 15..19: element range is too small
+| note in file FileId(1) for 15..19: computed range size is 0
+| error in file FileId(1) for 15..19: zero sized ranges cannot be used in `array` types that aren't `flexible`

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_constrained_ty_double_constrained.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_constrained_ty_double_constrained.snap
@@ -4,7 +4,7 @@ assertion_line: 42
 expression: "const c : 1 .. 2 := 1\ntype _ : c .. c"
 
 ---
-"c"@(FileId(1), 6..7) [Declared]: range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1))))
-"_"@(FileId(1), 27..28) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(1))] of range of `int` (Unevaluated(LibraryId(0), BodyId(3)) .. Expr(Unevaluated(LibraryId(0), BodyId(4))))
+"c"@(FileId(1), 6..7) [Declared]: range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No))
+"_"@(FileId(1), 27..28) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(1))] of range of `int` (Unevaluated(LibraryId(0), BodyId(3)) .. Expr(Unevaluated(LibraryId(0), BodyId(4)), No))
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_constrained_ty_from_booleans.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_constrained_ty_from_booleans.snap
@@ -4,6 +4,6 @@ assertion_line: 42
 expression: "type c : false .. true"
 
 ---
-"c"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of range of `boolean` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1))))
+"c"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of range of `boolean` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No))
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_constrained_ty_from_chars.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_constrained_ty_from_chars.snap
@@ -4,6 +4,6 @@ assertion_line: 42
 expression: "type c : 'a' .. 'c'"
 
 ---
-"c"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of range of `char` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1))))
+"c"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of range of `char` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No))
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_constrained_ty_from_enums.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_constrained_ty_from_enums.snap
@@ -8,6 +8,6 @@ expression: "type e : enum(uwu, owo)\ntype c : e.uwu .. e.owo"
 "owo"@(FileId(1), 19..22) [Declared]: enum[DefId(LibraryId(0), LocalDefId(2))] ( "uwu"@(FileId(1), 14..17), "owo"@(FileId(1), 19..22), )
 "e"@(FileId(1), 9..23) [Declared]: <error>
 "e"@(FileId(1), 5..6) [Resolved(Type)]: enum[DefId(LibraryId(0), LocalDefId(2))] ( "uwu"@(FileId(1), 14..17), "owo"@(FileId(1), 19..22), )
-"c"@(FileId(1), 29..30) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(4))] of range of `enum[DefId(LibraryId(0), LocalDefId(2))] ( "uwu"@(FileId(1), 14..17), "owo"@(FileId(1), 19..22), )` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1))))
+"c"@(FileId(1), 29..30) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(4))] of range of `enum[DefId(LibraryId(0), LocalDefId(2))] ( "uwu"@(FileId(1), 14..17), "owo"@(FileId(1), 19..22), )` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No))
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_constrained_ty_from_ints.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_constrained_ty_from_ints.snap
@@ -4,6 +4,6 @@ assertion_line: 42
 expression: "type c : 1 .. 1"
 
 ---
-"c"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1))))
+"c"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No))
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_constrained_ty_in_err_msg.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_constrained_ty_in_err_msg.snap
@@ -4,7 +4,7 @@ assertion_line: 42
 expression: "var _ : 1 .. 2 := 'c'"
 
 ---
-"_"@(FileId(1), 4..5) [Declared]: range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1))))
+"_"@(FileId(1), 4..5) [Declared]: range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No))
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 18..21: mismatched types

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_constrained_ty_mismatched_tys.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_constrained_ty_mismatched_tys.snap
@@ -4,7 +4,7 @@ assertion_line: 42
 expression: "type c : 1 .. true"
 
 ---
-"c"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1))))
+"c"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No))
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 9..18: mismatched types

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_constrained_ty_missing_both.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_constrained_ty_missing_both.snap
@@ -4,6 +4,6 @@ assertion_line: 42
 expression: "type c : .. "
 
 ---
-"c"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of range of `<error>` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1))))
+"c"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of range of `<error>` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No))
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_constrained_ty_missing_end.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_constrained_ty_missing_end.snap
@@ -4,6 +4,6 @@ assertion_line: 42
 expression: "type c : 1 .. "
 
 ---
-"c"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1))))
+"c"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No))
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_constrained_ty_missing_start.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_constrained_ty_missing_start.snap
@@ -4,6 +4,6 @@ assertion_line: 42
 expression: "type c : .. 2"
 
 ---
-"c"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1))))
+"c"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No))
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_constrained_ty_not_constexprs.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_constrained_ty_not_constexprs.snap
@@ -5,7 +5,7 @@ expression: "var c := 1\ntype _ : c .. c"
 
 ---
 "c"@(FileId(1), 4..5) [Declared]: int
-"_"@(FileId(1), 16..17) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(1))] of range of `int` (Unevaluated(LibraryId(0), BodyId(1)) .. Expr(Unevaluated(LibraryId(0), BodyId(2))))
+"_"@(FileId(1), 16..17) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(1))] of range of `int` (Unevaluated(LibraryId(0), BodyId(1)) .. Expr(Unevaluated(LibraryId(0), BodyId(2)), No))
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 20..21: cannot compute `c` at compile-time

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_constrained_ty_not_index_ty_both.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_constrained_ty_not_index_ty_both.snap
@@ -4,7 +4,7 @@ assertion_line: 42
 expression: "type _ : 1.0 .. 1.0"
 
 ---
-"_"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of range of `real` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1))))
+"_"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of range of `real` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No))
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 9..19: mismatched types

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_constrained_ty_not_index_ty_l.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_constrained_ty_not_index_ty_l.snap
@@ -4,7 +4,7 @@ assertion_line: 42
 expression: "type _ : 1.0 .. 1"
 
 ---
-"_"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of range of `real` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1))))
+"_"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of range of `real` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No))
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 9..17: mismatched types

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_constrained_ty_not_index_ty_r.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_constrained_ty_not_index_ty_r.snap
@@ -4,7 +4,7 @@ assertion_line: 42
 expression: "type _ : 1 .. 1.0"
 
 ---
-"_"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of range of `real` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1))))
+"_"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of range of `real` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No))
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 9..17: mismatched types

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_constrained_ty_outside_ty_range_signed.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_constrained_ty_outside_ty_range_signed.snap
@@ -5,7 +5,7 @@ expression: "const min : int1 := -16#7F\ntype _ : min .. 16#80\n"
 
 ---
 "min"@(FileId(1), 6..9) [Declared]: int1
-"_"@(FileId(1), 32..33) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(1))] of range of `int1` (Unevaluated(LibraryId(0), BodyId(1)) .. Expr(Unevaluated(LibraryId(0), BodyId(2))))
+"_"@(FileId(1), 32..33) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(1))] of range of `int1` (Unevaluated(LibraryId(0), BodyId(1)) .. Expr(Unevaluated(LibraryId(0), BodyId(2)), No))
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 43..48: computed value is outside the type's range

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_constrained_ty_outside_ty_range_unsigned.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_constrained_ty_outside_ty_range_unsigned.snap
@@ -5,7 +5,7 @@ expression: "const max : nat1 := 1\ntype _ : -1 .. max\n"
 
 ---
 "max"@(FileId(1), 6..9) [Declared]: nat1
-"_"@(FileId(1), 27..28) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(1))] of range of `nat1` (Unevaluated(LibraryId(0), BodyId(1)) .. Expr(Unevaluated(LibraryId(0), BodyId(2))))
+"_"@(FileId(1), 27..28) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(1))] of range of `nat1` (Unevaluated(LibraryId(0), BodyId(1)) .. Expr(Unevaluated(LibraryId(0), BodyId(2)), No))
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 31..33: computed value is outside the type's range

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_for_for_each_unimpl.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_for_for_each_unimpl.snap
@@ -1,0 +1,11 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+assertion_line: 42
+expression: "var a : array 1 .. 2 of int\nfor : a end for\n"
+
+---
+"a"@(FileId(1), 4..5) [Declared]: array ( range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), Yes)), ) of int
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 34..35: unsupported operation
+| error in file FileId(1) for 34..35: for-each loops are not implemented yet

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_for_implied_bounds_constrained.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_for_implied_bounds_constrained.snap
@@ -4,7 +4,7 @@ assertion_line: 42
 expression: "type b : 1 .. 2 for _ : b end for"
 
 ---
-"b"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1))))
-"_"@(FileId(1), 20..21) [Declared]: alias[DefId(LibraryId(0), LocalDefId(0))] of range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1))))
+"b"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No))
+"_"@(FileId(1), 20..21) [Declared]: alias[DefId(LibraryId(0), LocalDefId(0))] of range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No))
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_opaque_ty_poke_opaque_for_bounds_implicit.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_opaque_ty_poke_opaque_for_bounds_implicit.snap
@@ -5,10 +5,10 @@ expression: "module m\n    export opaque t\n    type t : 1 .. 2\n    for _ : t e
 
 ---
 "m"@(FileId(1), 7..8) [Declared]: <error>
-"t"@(FileId(1), 38..39) [Resolved(Type)]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1))))
-"_"@(FileId(1), 57..58) [Declared]: alias[DefId(LibraryId(0), LocalDefId(1))] of range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1))))
-"t"@(FileId(1), 20..28) [ItemExport(LocalDefId(1))]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1))))
-"_"@(FileId(1), 82..83) [Declared]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1))))
+"t"@(FileId(1), 38..39) [Resolved(Type)]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No))
+"_"@(FileId(1), 57..58) [Declared]: alias[DefId(LibraryId(0), LocalDefId(1))] of range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No))
+"t"@(FileId(1), 20..28) [ItemExport(LocalDefId(1))]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No))
+"_"@(FileId(1), 82..83) [Declared]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No))
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 86..89: mismatched types

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_cons_call_args_err_not_from_ty.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_cons_call_args_err_not_from_ty.snap
@@ -11,5 +11,4 @@ expression: "type s : set of boolean\nvar k : s\nk := k()\n"
 
 error in file FileId(1) at 39..40: cannot call or subscript `k`
 | note in file FileId(1) for 39..40: this is of type `set s (of boolean)`
-| error in file FileId(1) for 39..40: `set s (of boolean)` is not callable
 | info: sets can only be constructed from their type names

--- a/compiler/toc_analysis/src/typeck/test.rs
+++ b/compiler/toc_analysis/src/typeck/test.rs
@@ -1414,7 +1414,37 @@ test_named_group! { assignability_into,
         _ := i in s
         _ := n in s
         ",
-        // FIXME: add coercion tests for range element types and set member ops
+        // note: `constrained_array_range` and `array_param` also test that param-coercion
+        // is applicable to both by-value and by-reference parameters
+        constrained_array_range => "
+        type tp : proc(var _ : array 1 .. * of int)
+        var a : array 1 .. 3 of int
+        var b : array 2 .. 3 of int
+        var p : tp
+
+        % only coercible if start bound is the same
+        p(a) % success
+        p(b) % fail
+        ",
+        array_param => "
+        type tp: proc(_ : array 1..2 of char(*))
+        var a : array 1..2 of char
+        var b : array 1..2 of char(42)
+        var p : tp
+
+        % element type is also coercible
+        p(a)
+        p(b)
+        ",
+        dyn_array_param_err => "
+        % dyn arrays aren't allowed, since the range is expected to be known at compile-time
+        var c : int
+        var a : array 1..c of char
+        proc p(_ : array 1..2 of char(*)) end p
+
+        p(a)
+        ",
+        // FIXME: add coercion tests for set member ops
     ]
 }
 

--- a/compiler/toc_analysis/src/typeck/test.rs
+++ b/compiler/toc_analysis/src/typeck/test.rs
@@ -2709,6 +2709,17 @@ test_named_group! { typeck_array_ty,
         positive_flexible_size => "var _ : flexible array 1..1 of int",
         zero_flexible_size => "type _ : flexible array 1..0 of int",
         negative_flexible_size => "type _ : flexible array 1..-1 of int",
+
+        // array sizing
+        sizing_int1 => "type _ : array int1, 1..2 of int",
+        sizing_nat1 => "type _ : array nat1, 1..2 of int",
+        sizing_int2 => "type _ : array int2, 1..2 of int",
+        sizing_nat2 => "type _ : array nat2, 1..2 of int",
+        sizing_int => "type _ : array int, 1..2 of int",
+        sizing_nat => "type _ : array nat, 1..2 of int",
+        // until we have 64-bit types or widen ints during computation, this will always be an overflow
+        sizing_large => "type _ : array -16#7FFFFFFF..16#7FFFFFFF, 1..2 of int",
+        sizing_overflow => "type _ : array 0..16#7FFFFFFF, 0..16#7FFFFFFF of int",
     ]
 }
 
@@ -2720,6 +2731,9 @@ test_named_group! { typeck_array_ty_init,
         var a : array 1..c of int := init(1)",
         on_static => "var a : array 1..1 of int := init(1)",
         on_init_sized => "var a : array 1..* of int := init(1,2,3,4,5)",
+        on_too_large => "
+        const mx : nat4 := 16#FFFFFFFF
+        var a : array 0..mx, 0..mx of int := init(1,2,3)",
 
         more_two => "var a : array 1..3 of int := init(1,2,3,4,5)",
         more_one => "var a : array 1..3 of int := init(1,2,3,4)",
@@ -2730,8 +2744,6 @@ test_named_group! { typeck_array_ty_init,
         var c : int
         var a : array 1..1 of int := init(c)",
         mismatched_ty => "var a : array 1..1 of int := init(1.0)",
-
-        // TODO: add test for dealing with too large of an array
     ]
 }
 

--- a/compiler/toc_analysis/src/typeck/test.rs
+++ b/compiler/toc_analysis/src/typeck/test.rs
@@ -2700,7 +2700,15 @@ test_named_group! { typeck_array_ty,
         type _ : array 1 .. c of int",
 
         // not index ty
+        not_index_ty => "type _ : array real of real",
         // range sizing
+        positive_static_size => "type _ : array 1..1 of int",
+        zero_static_size => "type _ : array 1..0 of int",
+        negative_static_size => "type _ : array 1..-1 of int",
+        // Only flexible arrays allow zero-sized ranges
+        positive_flexible_size => "var _ : flexible array 1..1 of int",
+        zero_flexible_size => "type _ : flexible array 1..0 of int",
+        negative_flexible_size => "type _ : flexible array 1..-1 of int",
     ]
 }
 

--- a/compiler/toc_analysis/src/typeck/test.rs
+++ b/compiler/toc_analysis/src/typeck/test.rs
@@ -2462,6 +2462,49 @@ test_named_group! { typeck_set_cons_call,
     ]
 }
 
+test_named_group! { typeck_array_indexing_call,
+    [
+        single_index => "
+        var a : array 1..2 of int
+        var _ : int := a(1)",
+        multi_index => "
+        var a : array 1..2, 'c'..'d' of int
+        var _ : int := a(1, 'c')",
+
+        err_extra_for_single => "
+        var a : array 1..2 of int
+        var _ := a(1,2,3,4)",
+        err_extra_for_multiple => "
+        var a : array 1..2, 3..4 of int
+        var _ := a(1,2,3,4)",
+        err_missing_for_single => "
+        var a : array 1..2 of int
+        var _ := a()",
+        err_missing_for_multiple => "
+        var a : array 1..2, 3..4 of int
+        var _ := a(1)",
+
+        err_wrong_ty => "
+        var a : array 1..2, 'c'..'d' of int
+        var _ : int := a(1.0, true)",
+        err_wrong_binding => "
+        type i : int
+        var a : array 1..2 of int
+        var _ : int := a(i)",
+
+        // mutability is inherited
+        from_const_ref => "
+        const a : array 1..* of int := init(1)
+        a(1) := 1",
+        from_var_ref => "
+        var a : array 1..* of int := init(1)
+        a(1) := 1",
+        err_from_type_binding => "
+        type a : array 1..1 of int
+        a(1) := 1",
+    ]
+}
+
 test_named_group! { typeck_return_stmt,
     [
         in_top_level => "return",

--- a/compiler/toc_analysis/src/typeck/test.rs
+++ b/compiler/toc_analysis/src/typeck/test.rs
@@ -2022,7 +2022,10 @@ test_named_group! { typeck_for,
         //   - is int (error, range too large)
         //   - other
         for_each_not_iterable => "for : 1 end for",
-        // FIXME: Add test for `for-each` on array (only iterable so far)
+        for_each_unimpl => "
+        var a : array 1 .. 2 of int
+        for : a end for
+        ",
 
         implied_bounds_boolean => "type b : boolean for _ : b end for",
         implied_bounds_char => "type b : char for _ : b end for",

--- a/compiler/toc_analysis/src/typeck/test.rs
+++ b/compiler/toc_analysis/src/typeck/test.rs
@@ -2682,6 +2682,28 @@ test_named_group! { typeck_constrained_ty,
     ]
 }
 
+test_named_group! { typeck_array_ty,
+    [
+        static_size => "type _ : array 1 .. 3 of int",
+        dynamic_size => "
+        var c : int
+        var _ : array 1 .. c of int",
+        flexible_size => "var _ : flexible array 1 .. 0 of int",
+        flexible_dynamic => "
+        var c : int
+        var _ : flexible array 1 .. c of int",
+        init_sized => "var _ : array 1 .. * of int := init(1, 2, 3)",
+
+        // not dyn
+        not_dynamic_size => "
+        var c : int
+        type _ : array 1 .. c of int",
+
+        // not index ty
+        // range sizing
+    ]
+}
+
 test_named_group! { typeck_enum_ty,
     [
         from_type_alias => "type e : enum(a, b, c)",
@@ -2789,6 +2811,7 @@ test_named_group! { report_aliased_type,
         // - set
         // - record
         // - union
+        // - array
     ]
 }
 

--- a/compiler/toc_analysis/src/typeck/test.rs
+++ b/compiler/toc_analysis/src/typeck/test.rs
@@ -2712,6 +2712,29 @@ test_named_group! { typeck_array_ty,
     ]
 }
 
+test_named_group! { typeck_array_ty_init,
+    [
+        on_flexible => "var a : flexible array 1..1 of int := init(1)",
+        on_dynamic => "
+        var c : int
+        var a : array 1..c of int := init(1)",
+        on_static => "var a : array 1..1 of int := init(1)",
+        on_init_sized => "var a : array 1..* of int := init(1,2,3,4,5)",
+
+        more_two => "var a : array 1..3 of int := init(1,2,3,4,5)",
+        more_one => "var a : array 1..3 of int := init(1,2,3,4)",
+        less_one => "var a : array 1..3 of int := init(1,2)",
+        less_two => "var a : array 1..3 of int := init(1)",
+
+        not_comp_time => "
+        var c : int
+        var a : array 1..1 of int := init(c)",
+        mismatched_ty => "var a : array 1..1 of int := init(1.0)",
+
+        // TODO: add test for dealing with too large of an array
+    ]
+}
+
 test_named_group! { typeck_enum_ty,
     [
         from_type_alias => "type e : enum(a, b, c)",

--- a/compiler/toc_hir/src/body.rs
+++ b/compiler/toc_hir/src/body.rs
@@ -58,6 +58,8 @@ pub enum BodyKind {
 pub enum BodyOwner {
     Item(item::ItemId),
     Type(ty::TypeId),
+    Expr(expr::BodyExpr),
+    // Stmts can be body owners, but `case` currently users normal exprs
 }
 
 /// Mapping between a [`BodyId`] and the corresponding [`BodyOwner`]

--- a/compiler/toc_hir/src/expr.rs
+++ b/compiler/toc_hir/src/expr.rs
@@ -1,7 +1,10 @@
 //! Expression nodes
 use toc_span::{SpanId, Spanned};
 
-use crate::symbol::{self, Symbol};
+use crate::{
+    body,
+    symbol::{self, Symbol},
+};
 
 pub use crate::ids::{BodyExpr, ExprId};
 
@@ -19,7 +22,8 @@ pub enum ExprKind {
     /// Literal values
     Literal(Literal),
     //ObjClass(ObjClass),
-    //Init(Init),
+    /// Aggregate initialization expression, containing initialization values
+    Init(Init),
     //Nil(Nil),
     //SizeOf(SizeOf),
     Binary(Binary),
@@ -79,6 +83,12 @@ impl PartialEq for Literal {
 // Literal::Real satisfies the requirements for `Eq` by comparing
 // the raw bit representations
 impl Eq for Literal {}
+
+/// Aggregate initialization
+#[derive(Debug, PartialEq, Eq)]
+pub struct Init {
+    pub exprs: Vec<body::BodyId>,
+}
 
 /// Binary operator expression
 #[derive(Debug, PartialEq, Eq)]

--- a/compiler/toc_hir/src/ty.rs
+++ b/compiler/toc_hir/src/ty.rs
@@ -114,6 +114,8 @@ pub struct Constrained {
     pub start: body::BodyId,
     /// Maximum accepted value, based on a [`ConstrainedEnd`]
     pub end: ConstrainedEnd,
+    /// If the constrained range allows a dynamic (i.e. runtime-inferred) end bound,
+    pub allow_dyn: bool,
 }
 
 /// Possible ending values of a constrained range

--- a/compiler/toc_hir/src/ty.rs
+++ b/compiler/toc_hir/src/ty.rs
@@ -126,6 +126,8 @@ pub enum ConstrainedEnd {
     /// An unsized bound, where the element count is taken from
     /// the closest `init` initializer
     Unsized(Spanned<Option<u32>>),
+    /// Upper bound is determined at runtime
+    Any(SpanId),
 }
 
 #[derive(Debug, PartialEq, Eq, Hash)]

--- a/compiler/toc_hir/src/ty.rs
+++ b/compiler/toc_hir/src/ty.rs
@@ -59,6 +59,8 @@ pub enum TypeKind {
     Constrained(Constrained),
     /// Enum Type
     Enum(Enum),
+    /// Array type
+    Array(Array),
     /// Set type
     Set(Set),
     /// Pointer type
@@ -130,6 +132,34 @@ pub struct Enum {
     pub def_id: symbol::LocalDefId,
     /// Variants on this enum
     pub variants: Vec<symbol::LocalDefId>,
+}
+
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct Array {
+    /// Specification of the array's size
+    pub sizing: ArraySize,
+    /// Types of each of the array's dimensions
+    pub ranges: Vec<TypeId>,
+    /// Type of the array's elements
+    pub elem_ty: TypeId,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ArraySize {
+    /// Array size is not fixed, and zero-sized ranges are allowed.
+    /// Initialization from dynamic values is implied to be allowed.
+    Flexible,
+    /// Array size is fixed, but allowed to be derived from runtime values
+    MaybeDyn,
+    /// Array size is fixed, and must be known at compile-time
+    Static,
+}
+
+impl ArraySize {
+    /// If the size specification allows dynamic values in the size computation
+    pub fn allow_dyn(self) -> bool {
+        matches!(self, Self::Flexible | Self::MaybeDyn)
+    }
 }
 
 #[derive(Debug, PartialEq, Eq, Hash)]

--- a/compiler/toc_hir/src/visitor.rs
+++ b/compiler/toc_hir/src/visitor.rs
@@ -45,6 +45,7 @@ pub trait HirVisitor {
     fn visit_expr(&self, id: BodyExpr, expr: &expr::Expr) {}
     fn visit_missing_expr(&self, id: BodyExpr) {}
     fn visit_literal(&self, id: BodyExpr, expr: &expr::Literal) {}
+    fn visit_init_expr(&self, id: BodyExpr, expr: &expr::Init) {}
     fn visit_binary(&self, id: BodyExpr, expr: &expr::Binary) {}
     fn visit_unary(&self, id: BodyExpr, expr: &expr::Unary) {}
     fn visit_all_expr(&self, id: BodyExpr) {}
@@ -100,6 +101,7 @@ pub trait HirVisitor {
         match &expr.kind {
             expr::ExprKind::Missing => self.visit_missing_expr(id),
             expr::ExprKind::Literal(expr) => self.visit_literal(id, expr),
+            expr::ExprKind::Init(expr) => self.visit_init_expr(id, expr),
             expr::ExprKind::Binary(expr) => self.visit_binary(id, expr),
             expr::ExprKind::Unary(expr) => self.visit_unary(id, expr),
             expr::ExprKind::All => self.visit_all_expr(id),
@@ -519,6 +521,7 @@ impl<'hir> Walker<'hir> {
         match &expr.kind {
             expr::ExprKind::Missing => {}
             expr::ExprKind::Literal(_) => {}
+            expr::ExprKind::Init(node) => self.walk_init_expr(in_body, node),
             expr::ExprKind::Binary(node) => self.walk_binary(in_body, node),
             expr::ExprKind::Unary(node) => self.walk_unary(in_body, node),
             expr::ExprKind::All => {}
@@ -527,6 +530,12 @@ impl<'hir> Walker<'hir> {
             expr::ExprKind::Field(node) => self.walk_field(in_body, node),
             expr::ExprKind::Deref(node) => self.walk_deref(in_body, node),
             expr::ExprKind::Call(node) => self.walk_call_expr(in_body, node),
+        }
+    }
+
+    fn walk_init_expr(&mut self, _in_body: body::BodyId, node: &expr::Init) {
+        for &body_id in &node.exprs {
+            self.enter_body(body_id, self.lib.body(body_id));
         }
     }
 

--- a/compiler/toc_hir_codegen/src/lib.rs
+++ b/compiler/toc_hir_codegen/src/lib.rs
@@ -940,7 +940,7 @@ impl BodyCodeGenerator<'_> {
                 .expect("from stmt thing")
             {
                 hir_body::BodyOwner::Item(item_id) => item_id,
-                hir_body::BodyOwner::Type(_) => unreachable!(),
+                hir_body::BodyOwner::Type(_) | hir_body::BodyOwner::Expr(_) => unreachable!(),
             };
             let item_ty = gen
                 .db
@@ -997,7 +997,7 @@ impl BodyCodeGenerator<'_> {
             .expect("unowned body");
         let item_owner = match item_owner {
             hir_body::BodyOwner::Item(item) => item,
-            hir_body::BodyOwner::Type(_) => unreachable!(),
+            hir_body::BodyOwner::Type(_) | hir_body::BodyOwner::Expr(_) => unreachable!(),
         };
         let item_ty = db
             .type_of((self.library_id, item_owner).into())
@@ -2404,6 +2404,7 @@ impl BodyCodeGenerator<'_> {
             }
             ty::TypeKind::Opaque(_, ty) => return self.generate_assign(*ty, order), // defer to the opaque type
             ty::TypeKind::Constrained(..) => unimplemented!(),
+            ty::TypeKind::Array(..) => unimplemented!(),
             ty::TypeKind::Enum(..) => unimplemented!(),
             ty::TypeKind::Set(..) => unimplemented!(),
             ty::TypeKind::Pointer(..) => unimplemented!(),
@@ -2472,6 +2473,7 @@ impl BodyCodeGenerator<'_> {
             ty::TypeKind::CharN(_) => return None, // don't need to dereference the pointer to storage
             ty::TypeKind::Opaque(_, ty) => return self.pick_fetch_op(*ty), // defer to the opaque type
             ty::TypeKind::Constrained(..) => unimplemented!(),
+            ty::TypeKind::Array(..) => unimplemented!(),
             ty::TypeKind::Enum(..) => unimplemented!(),
             ty::TypeKind::Set(..) => unimplemented!(),
             ty::TypeKind::Pointer(..) => unimplemented!(),

--- a/compiler/toc_hir_lowering/src/lower/expr.rs
+++ b/compiler/toc_hir_lowering/src/lower/expr.rs
@@ -46,7 +46,9 @@ impl super::BodyLowering<'_, '_> {
             ast::Expr::LiteralExpr(expr) => self.lower_literal_expr(expr),
 
             ast::Expr::ObjClassExpr(_) => self.unsupported_expr(span),
-            ast::Expr::InitExpr(_) => self.unsupported_expr(span),
+
+            ast::Expr::InitExpr(expr) => self.lower_init_expr(expr),
+
             ast::Expr::NilExpr(_) => self.unsupported_expr(span),
             ast::Expr::SizeOfExpr(_) => self.unsupported_expr(span),
 
@@ -130,6 +132,17 @@ impl super::BodyLowering<'_, '_> {
         };
 
         Some(expr::ExprKind::Literal(value))
+    }
+
+    fn lower_init_expr(&mut self, expr: ast::InitExpr) -> Option<expr::ExprKind> {
+        let exprs = expr
+            .expr_list()
+            .unwrap()
+            .exprs()
+            .map(|expr| self.lower_expr_body(expr))
+            .collect();
+
+        Some(expr::ExprKind::Init(expr::Init { exprs }))
     }
 
     fn lower_binary_expr(&mut self, expr: ast::BinaryExpr) -> Option<expr::ExprKind> {

--- a/compiler/toc_hir_lowering/src/lower/ty.rs
+++ b/compiler/toc_hir_lowering/src/lower/ty.rs
@@ -294,7 +294,7 @@ impl super::BodyLowering<'_, '_> {
                 let is_init_sized = range
                     .end()
                     .map(|end| matches!(end, ast::EndBound::UnsizedBound(_)))
-                    .is_some();
+                    .unwrap_or(false);
 
                 is_init_sized.then(|| range)
             } else {

--- a/compiler/toc_hir_lowering/tests/lowering.rs
+++ b/compiler/toc_hir_lowering/tests/lowering.rs
@@ -1453,7 +1453,7 @@ fn lower_array_types() {
     // One bound
     assert_lower("type _ : array char of int");
     // Multiple bounds
-    assert_lower("type _ : array char, boolean of int");
+    assert_lower("type _ : array char, boolean, 1..2 of int");
     // No bounds
     assert_lower("type _ : array of int");
 

--- a/compiler/toc_hir_lowering/tests/lowering.rs
+++ b/compiler/toc_hir_lowering/tests/lowering.rs
@@ -1482,6 +1482,25 @@ fn lower_array_types_init_sized() {
 }
 
 #[test]
+fn lower_array_types_any_sized() {
+    // Same restrictions as init-sized, just in param decl context
+
+    // Any-sized
+    assert_lower("type _ : proc uwu(_ : array 1 .. * of int)");
+    // Only 1 any-sized range allowed
+    assert_lower("type _ : proc uwu(_ : array 1 .. *, 1 .. * of int)");
+    // Any-sized range must be the first
+    // ranges before
+    assert_lower("type _ : proc uwu(_ : array 1 .. *, char of int)");
+    assert_lower("type _ : proc uwu(_ : array 1 .. *, char,,char of int)");
+    // ranges after
+    assert_lower("type _ : proc uwu(_ : array char, 1 .. * of int)");
+    assert_lower("type _ : proc uwu(_ : array char,,char, 1 .. * of int)");
+    // both
+    assert_lower("type _ : proc uwu(_ : array char, 1 .. *, char of int)");
+}
+
+#[test]
 fn lower_init_expr() {
     // Ok with non-aggregate types (check deferred to typeck)
     assert_lower("var _ : int := init(1, 2, 3, 4)");

--- a/compiler/toc_hir_lowering/tests/lowering.rs
+++ b/compiler/toc_hir_lowering/tests/lowering.rs
@@ -1480,3 +1480,13 @@ fn lower_array_types_init_sized() {
     // both
     assert_lower("var _ : array char, 1 .. *, char of int := init(1)");
 }
+
+#[test]
+fn lower_init_expr() {
+    // Ok with non-aggregate types (check deferred to typeck)
+    assert_lower("var _ : int := init(1, 2, 3, 4)");
+    // Type spec required (handled by AST validation)
+    assert_lower("var _ := init(1, 2, 3, 4)");
+    // Can't be used outside of a ConstVar decl (handled by AST validation)
+    assert_lower("var a : int a := init(1, 2, 3, 4)");
+}

--- a/compiler/toc_hir_lowering/tests/lowering.rs
+++ b/compiler/toc_hir_lowering/tests/lowering.rs
@@ -1435,9 +1435,7 @@ fn lower_constrained_type_sized() {
     assert_lower("var _ : ..");
 }
 
-// FIXME: Uncomment once array types are being lowered
-// #[test]
-#[allow(unused)] // waiting on array types to be lowered
+#[test]
 fn lower_constrained_type_unsized() {
     // Valid everything
     assert_lower("var _ : array 1 .. * of int := init(1, 2, 3)");
@@ -1464,4 +1462,21 @@ fn lower_array_types() {
 
     // Flexible
     assert_lower("var _ : flexible array 1 .. 0 of int");
+}
+
+#[test]
+fn lower_array_types_init_sized() {
+    // Init-sized
+    assert_lower("var _ : array 1 .. * of int := init(1)");
+    // Only 1 init-sized range allowed
+    assert_lower("var _ : array 1 .. *, 1 .. * of int := init(1)");
+    // Init-sized range must be the first
+    // ranges before
+    assert_lower("var _ : array 1 .. *, char of int := init(1)");
+    assert_lower("var _ : array 1 .. *, char,,char of int := init(1)");
+    // ranges after
+    assert_lower("var _ : array char, 1 .. * of int := init(1)");
+    assert_lower("var _ : array char,,char, 1 .. * of int := init(1)");
+    // both
+    assert_lower("var _ : array char, 1 .. *, char of int := init(1)");
 }

--- a/compiler/toc_hir_lowering/tests/lowering.rs
+++ b/compiler/toc_hir_lowering/tests/lowering.rs
@@ -1449,3 +1449,19 @@ fn lower_constrained_type_unsized() {
     assert_lower("var _ : 1 .. *");
     assert_lower("type _ : 1 .. *");
 }
+
+#[test]
+fn lower_array_types() {
+    // One bound
+    assert_lower("type _ : array char of int");
+    // Multiple bounds
+    assert_lower("type _ : array char, boolean of int");
+    // No bounds
+    assert_lower("type _ : array of int");
+
+    // Maybe dyn
+    assert_lower("var _ : array boolean of int");
+
+    // Flexible
+    assert_lower("var _ : flexible array 1 .. 0 of int");
+}

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_array_types-2.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_array_types-2.snap
@@ -1,0 +1,17 @@
+---
+source: compiler/toc_hir_lowering/tests/lowering.rs
+assertion_line: 61
+expression: "type _ : array char, boolean of int"
+
+---
+Library@(dummy)
+  Root@(dummy): FileId(1) -> ItemId(1)
+    Module@(FileId(1), 0..35): "<root>"@(dummy)
+      StmtBody@(FileId(1), 0..35): []
+        StmtItem@(FileId(1), 0..35): ItemId(0)
+          Type@(FileId(1), 0..35): "_"@(FileId(1), 5..6)
+            Array@(FileId(1), 9..35): Static
+              Primitive@(FileId(1), 15..19): Char
+              Primitive@(FileId(1), 21..28): Boolean
+              Primitive@(FileId(1), 32..35): Int
+

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_array_types-2.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_array_types-2.snap
@@ -1,17 +1,22 @@
 ---
 source: compiler/toc_hir_lowering/tests/lowering.rs
 assertion_line: 61
-expression: "type _ : array char, boolean of int"
+expression: "type _ : array char, boolean, 1..2 of int"
 
 ---
 Library@(dummy)
   Root@(dummy): FileId(1) -> ItemId(1)
-    Module@(FileId(1), 0..35): "<root>"@(dummy)
-      StmtBody@(FileId(1), 0..35): []
-        StmtItem@(FileId(1), 0..35): ItemId(0)
-          Type@(FileId(1), 0..35): "_"@(FileId(1), 5..6)
-            Array@(FileId(1), 9..35): Static
+    Module@(FileId(1), 0..41): "<root>"@(dummy)
+      StmtBody@(FileId(1), 0..41): []
+        StmtItem@(FileId(1), 0..41): ItemId(0)
+          Type@(FileId(1), 0..41): "_"@(FileId(1), 5..6)
+            Array@(FileId(1), 9..41): Static
               Primitive@(FileId(1), 15..19): Char
               Primitive@(FileId(1), 21..28): Boolean
-              Primitive@(FileId(1), 32..35): Int
+              Constrained@(FileId(1), 30..34): end => Expr
+                ExprBody@(FileId(1), 30..31)
+                  Literal@(FileId(1), 30..31): Integer(1)
+                ExprBody@(FileId(1), 33..34)
+                  Literal@(FileId(1), 33..34): Integer(2)
+              Primitive@(FileId(1), 38..41): Int
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_array_types-3.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_array_types-3.snap
@@ -1,0 +1,17 @@
+---
+source: compiler/toc_hir_lowering/tests/lowering.rs
+assertion_line: 61
+expression: "type _ : array of int"
+
+---
+Library@(dummy)
+  Root@(dummy): FileId(1) -> ItemId(1)
+    Module@(FileId(1), 0..21): "<root>"@(dummy)
+      StmtBody@(FileId(1), 0..21): []
+        StmtItem@(FileId(1), 0..21): ItemId(0)
+          Type@(FileId(1), 0..21): "_"@(FileId(1), 5..6)
+            Array@(FileId(1), 9..21): Static
+              Primitive@(FileId(1), 18..21): Int
+error in file FileId(1) at 15..17: unexpected token
+| error in file FileId(1) for 15..17: expected type specifier, but found `of`
+

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_array_types-4.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_array_types-4.snap
@@ -1,0 +1,16 @@
+---
+source: compiler/toc_hir_lowering/tests/lowering.rs
+assertion_line: 61
+expression: "var _ : array boolean of int"
+
+---
+Library@(dummy)
+  Root@(dummy): FileId(1) -> ItemId(1)
+    Module@(FileId(1), 0..28): "<root>"@(dummy)
+      StmtBody@(FileId(1), 0..28): []
+        StmtItem@(FileId(1), 0..28): ItemId(0)
+          ConstVar@(FileId(1), 0..28): var "_"@(FileId(1), 4..5)
+            Array@(FileId(1), 8..28): MaybeDyn
+              Primitive@(FileId(1), 14..21): Boolean
+              Primitive@(FileId(1), 25..28): Int
+

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_array_types-5.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_array_types-5.snap
@@ -1,0 +1,20 @@
+---
+source: compiler/toc_hir_lowering/tests/lowering.rs
+assertion_line: 61
+expression: "var _ : flexible array 1 .. 0 of int"
+
+---
+Library@(dummy)
+  Root@(dummy): FileId(1) -> ItemId(1)
+    Module@(FileId(1), 0..36): "<root>"@(dummy)
+      StmtBody@(FileId(1), 0..36): []
+        StmtItem@(FileId(1), 0..36): ItemId(0)
+          ConstVar@(FileId(1), 0..36): var "_"@(FileId(1), 4..5)
+            Array@(FileId(1), 8..36): Flexible
+              Constrained@(FileId(1), 23..29): end => Expr
+                ExprBody@(FileId(1), 23..24)
+                  Literal@(FileId(1), 23..24): Integer(1)
+                ExprBody@(FileId(1), 28..29)
+                  Literal@(FileId(1), 28..29): Integer(0)
+              Primitive@(FileId(1), 33..36): Int
+

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_array_types.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_array_types.snap
@@ -1,0 +1,16 @@
+---
+source: compiler/toc_hir_lowering/tests/lowering.rs
+assertion_line: 61
+expression: "type _ : array char of int"
+
+---
+Library@(dummy)
+  Root@(dummy): FileId(1) -> ItemId(1)
+    Module@(FileId(1), 0..26): "<root>"@(dummy)
+      StmtBody@(FileId(1), 0..26): []
+        StmtItem@(FileId(1), 0..26): ItemId(0)
+          Type@(FileId(1), 0..26): "_"@(FileId(1), 5..6)
+            Array@(FileId(1), 9..26): Static
+              Primitive@(FileId(1), 15..19): Char
+              Primitive@(FileId(1), 23..26): Int
+

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_array_types_any_sized-2.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_array_types_any_sized-2.snap
@@ -1,0 +1,24 @@
+---
+source: compiler/toc_hir_lowering/tests/lowering.rs
+assertion_line: 61
+expression: "type _ : proc uwu(_ : array 1 .. *, 1 .. * of int)"
+
+---
+Library@(dummy)
+  Root@(dummy): FileId(1) -> ItemId(1)
+    Module@(FileId(1), 0..50): "<root>"@(dummy)
+      StmtBody@(FileId(1), 0..50): []
+        StmtItem@(FileId(1), 0..50): ItemId(0)
+          Type@(FileId(1), 0..50): "_"@(FileId(1), 5..6)
+            Procedure@(FileId(1), 9..50): [...]
+              Array@(FileId(1), 22..49): Static
+                Constrained@(FileId(1), 28..34): end => Any
+                  ExprBody@(FileId(1), 28..29)
+                    Literal@(FileId(1), 28..29): Integer(1)
+                Primitive@(FileId(1), 46..49): Int
+              Void@(FileId(1), 9..50)
+error in file FileId(1) at 28..34: extra ranges specified
+| error in file FileId(1) for 36..42: extra ranges after
+| note in file FileId(1) for 28..34: this must be the only range present
+| info: any-sized arrays must have this range be the only range present
+

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_array_types_any_sized-3.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_array_types_any_sized-3.snap
@@ -1,0 +1,24 @@
+---
+source: compiler/toc_hir_lowering/tests/lowering.rs
+assertion_line: 61
+expression: "type _ : proc uwu(_ : array 1 .. *, char of int)"
+
+---
+Library@(dummy)
+  Root@(dummy): FileId(1) -> ItemId(1)
+    Module@(FileId(1), 0..48): "<root>"@(dummy)
+      StmtBody@(FileId(1), 0..48): []
+        StmtItem@(FileId(1), 0..48): ItemId(0)
+          Type@(FileId(1), 0..48): "_"@(FileId(1), 5..6)
+            Procedure@(FileId(1), 9..48): [...]
+              Array@(FileId(1), 22..47): Static
+                Constrained@(FileId(1), 28..34): end => Any
+                  ExprBody@(FileId(1), 28..29)
+                    Literal@(FileId(1), 28..29): Integer(1)
+                Primitive@(FileId(1), 44..47): Int
+              Void@(FileId(1), 9..48)
+error in file FileId(1) at 28..34: extra ranges specified
+| error in file FileId(1) for 36..40: extra ranges after
+| note in file FileId(1) for 28..34: this must be the only range present
+| info: any-sized arrays must have this range be the only range present
+

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_array_types_any_sized-4.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_array_types_any_sized-4.snap
@@ -1,0 +1,26 @@
+---
+source: compiler/toc_hir_lowering/tests/lowering.rs
+assertion_line: 61
+expression: "type _ : proc uwu(_ : array 1 .. *, char,,char of int)"
+
+---
+Library@(dummy)
+  Root@(dummy): FileId(1) -> ItemId(1)
+    Module@(FileId(1), 0..54): "<root>"@(dummy)
+      StmtBody@(FileId(1), 0..54): []
+        StmtItem@(FileId(1), 0..54): ItemId(0)
+          Type@(FileId(1), 0..54): "_"@(FileId(1), 5..6)
+            Procedure@(FileId(1), 9..54): [...]
+              Array@(FileId(1), 22..53): Static
+                Constrained@(FileId(1), 28..34): end => Any
+                  ExprBody@(FileId(1), 28..29)
+                    Literal@(FileId(1), 28..29): Integer(1)
+                Primitive@(FileId(1), 50..53): Int
+              Void@(FileId(1), 9..54)
+error in file FileId(1) at 28..34: extra ranges specified
+| error in file FileId(1) for 36..46: extra ranges after
+| note in file FileId(1) for 28..34: this must be the only range present
+| info: any-sized arrays must have this range be the only range present
+error in file FileId(1) at 41..42: unexpected token
+| error in file FileId(1) for 41..42: expected type specifier, but found `,`
+

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_array_types_any_sized-5.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_array_types_any_sized-5.snap
@@ -1,0 +1,24 @@
+---
+source: compiler/toc_hir_lowering/tests/lowering.rs
+assertion_line: 61
+expression: "type _ : proc uwu(_ : array char, 1 .. * of int)"
+
+---
+Library@(dummy)
+  Root@(dummy): FileId(1) -> ItemId(1)
+    Module@(FileId(1), 0..48): "<root>"@(dummy)
+      StmtBody@(FileId(1), 0..48): []
+        StmtItem@(FileId(1), 0..48): ItemId(0)
+          Type@(FileId(1), 0..48): "_"@(FileId(1), 5..6)
+            Procedure@(FileId(1), 9..48): [...]
+              Array@(FileId(1), 22..47): Static
+                Constrained@(FileId(1), 34..40): end => Any
+                  ExprBody@(FileId(1), 34..35)
+                    Literal@(FileId(1), 34..35): Integer(1)
+                Primitive@(FileId(1), 44..47): Int
+              Void@(FileId(1), 9..48)
+error in file FileId(1) at 34..40: extra ranges specified
+| error in file FileId(1) for 28..32: extra ranges before
+| note in file FileId(1) for 34..40: this must be the only range present
+| info: any-sized arrays must have this range be the only range present
+

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_array_types_any_sized-6.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_array_types_any_sized-6.snap
@@ -1,0 +1,26 @@
+---
+source: compiler/toc_hir_lowering/tests/lowering.rs
+assertion_line: 61
+expression: "type _ : proc uwu(_ : array char,,char, 1 .. * of int)"
+
+---
+Library@(dummy)
+  Root@(dummy): FileId(1) -> ItemId(1)
+    Module@(FileId(1), 0..54): "<root>"@(dummy)
+      StmtBody@(FileId(1), 0..54): []
+        StmtItem@(FileId(1), 0..54): ItemId(0)
+          Type@(FileId(1), 0..54): "_"@(FileId(1), 5..6)
+            Procedure@(FileId(1), 9..54): [...]
+              Array@(FileId(1), 22..53): Static
+                Constrained@(FileId(1), 40..46): end => Any
+                  ExprBody@(FileId(1), 40..41)
+                    Literal@(FileId(1), 40..41): Integer(1)
+                Primitive@(FileId(1), 50..53): Int
+              Void@(FileId(1), 9..54)
+error in file FileId(1) at 33..34: unexpected token
+| error in file FileId(1) for 33..34: expected type specifier, but found `,`
+error in file FileId(1) at 40..46: extra ranges specified
+| error in file FileId(1) for 28..38: extra ranges before
+| note in file FileId(1) for 40..46: this must be the only range present
+| info: any-sized arrays must have this range be the only range present
+

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_array_types_any_sized-7.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_array_types_any_sized-7.snap
@@ -1,0 +1,25 @@
+---
+source: compiler/toc_hir_lowering/tests/lowering.rs
+assertion_line: 61
+expression: "type _ : proc uwu(_ : array char, 1 .. *, char of int)"
+
+---
+Library@(dummy)
+  Root@(dummy): FileId(1) -> ItemId(1)
+    Module@(FileId(1), 0..54): "<root>"@(dummy)
+      StmtBody@(FileId(1), 0..54): []
+        StmtItem@(FileId(1), 0..54): ItemId(0)
+          Type@(FileId(1), 0..54): "_"@(FileId(1), 5..6)
+            Procedure@(FileId(1), 9..54): [...]
+              Array@(FileId(1), 22..53): Static
+                Constrained@(FileId(1), 34..40): end => Any
+                  ExprBody@(FileId(1), 34..35)
+                    Literal@(FileId(1), 34..35): Integer(1)
+                Primitive@(FileId(1), 50..53): Int
+              Void@(FileId(1), 9..54)
+error in file FileId(1) at 34..40: extra ranges specified
+| error in file FileId(1) for 28..32: extra ranges before
+| error in file FileId(1) for 42..46: extra ranges after
+| note in file FileId(1) for 34..40: this must be the only range present
+| info: any-sized arrays must have this range be the only range present
+

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_array_types_any_sized.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_array_types_any_sized.snap
@@ -1,0 +1,20 @@
+---
+source: compiler/toc_hir_lowering/tests/lowering.rs
+assertion_line: 61
+expression: "type _ : proc uwu(_ : array 1 .. * of int)"
+
+---
+Library@(dummy)
+  Root@(dummy): FileId(1) -> ItemId(1)
+    Module@(FileId(1), 0..42): "<root>"@(dummy)
+      StmtBody@(FileId(1), 0..42): []
+        StmtItem@(FileId(1), 0..42): ItemId(0)
+          Type@(FileId(1), 0..42): "_"@(FileId(1), 5..6)
+            Procedure@(FileId(1), 9..42): [...]
+              Array@(FileId(1), 22..41): Static
+                Constrained@(FileId(1), 28..34): end => Any
+                  ExprBody@(FileId(1), 28..29)
+                    Literal@(FileId(1), 28..29): Integer(1)
+                Primitive@(FileId(1), 38..41): Int
+              Void@(FileId(1), 9..42)
+

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_array_types_init_sized-2.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_array_types_init_sized-2.snap
@@ -1,0 +1,25 @@
+---
+source: compiler/toc_hir_lowering/tests/lowering.rs
+assertion_line: 61
+expression: "var _ : array 1 .. *, 1 .. * of int := init(1)"
+
+---
+Library@(dummy)
+  Root@(dummy): FileId(1) -> ItemId(1)
+    Module@(FileId(1), 0..46): "<root>"@(dummy)
+      StmtBody@(FileId(1), 0..46): []
+        StmtItem@(FileId(1), 0..46): ItemId(0)
+          ConstVar@(FileId(1), 0..46): var "_"@(FileId(1), 4..5)
+            Array@(FileId(1), 8..35): MaybeDyn
+              Constrained@(FileId(1), 14..20): end => Unsized(Some(1))
+                ExprBody@(FileId(1), 14..15)
+                  Literal@(FileId(1), 14..15): Integer(1)
+              Primitive@(FileId(1), 32..35): Int
+            ExprBody@(FileId(1), 39..46)
+error in file FileId(1) at 14..20: extra ranges specified
+| error in file FileId(1) for 22..28: extra ranges after
+| note in file FileId(1) for 14..20: this must be the only range present
+| info: `init`-sized arrays must have this range be the only range present
+error in file FileId(1) at 39..46: unsupported expression
+| error in file FileId(1) for 39..46: this expression is not supported yet
+

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_array_types_init_sized-2.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_array_types_init_sized-2.snap
@@ -16,10 +16,11 @@ Library@(dummy)
                   Literal@(FileId(1), 14..15): Integer(1)
               Primitive@(FileId(1), 32..35): Int
             ExprBody@(FileId(1), 39..46)
+              InitExpr@(FileId(1), 39..46)
+                ExprBody@(FileId(1), 44..45)
+                  Literal@(FileId(1), 44..45): Integer(1)
 error in file FileId(1) at 14..20: extra ranges specified
 | error in file FileId(1) for 22..28: extra ranges after
 | note in file FileId(1) for 14..20: this must be the only range present
 | info: `init`-sized arrays must have this range be the only range present
-error in file FileId(1) at 39..46: unsupported expression
-| error in file FileId(1) for 39..46: this expression is not supported yet
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_array_types_init_sized-3.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_array_types_init_sized-3.snap
@@ -1,0 +1,25 @@
+---
+source: compiler/toc_hir_lowering/tests/lowering.rs
+assertion_line: 61
+expression: "var _ : array 1 .. *, char of int := init(1)"
+
+---
+Library@(dummy)
+  Root@(dummy): FileId(1) -> ItemId(1)
+    Module@(FileId(1), 0..44): "<root>"@(dummy)
+      StmtBody@(FileId(1), 0..44): []
+        StmtItem@(FileId(1), 0..44): ItemId(0)
+          ConstVar@(FileId(1), 0..44): var "_"@(FileId(1), 4..5)
+            Array@(FileId(1), 8..33): MaybeDyn
+              Constrained@(FileId(1), 14..20): end => Unsized(Some(1))
+                ExprBody@(FileId(1), 14..15)
+                  Literal@(FileId(1), 14..15): Integer(1)
+              Primitive@(FileId(1), 30..33): Int
+            ExprBody@(FileId(1), 37..44)
+error in file FileId(1) at 14..20: extra ranges specified
+| error in file FileId(1) for 22..26: extra ranges after
+| note in file FileId(1) for 14..20: this must be the only range present
+| info: `init`-sized arrays must have this range be the only range present
+error in file FileId(1) at 37..44: unsupported expression
+| error in file FileId(1) for 37..44: this expression is not supported yet
+

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_array_types_init_sized-3.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_array_types_init_sized-3.snap
@@ -16,10 +16,11 @@ Library@(dummy)
                   Literal@(FileId(1), 14..15): Integer(1)
               Primitive@(FileId(1), 30..33): Int
             ExprBody@(FileId(1), 37..44)
+              InitExpr@(FileId(1), 37..44)
+                ExprBody@(FileId(1), 42..43)
+                  Literal@(FileId(1), 42..43): Integer(1)
 error in file FileId(1) at 14..20: extra ranges specified
 | error in file FileId(1) for 22..26: extra ranges after
 | note in file FileId(1) for 14..20: this must be the only range present
 | info: `init`-sized arrays must have this range be the only range present
-error in file FileId(1) at 37..44: unsupported expression
-| error in file FileId(1) for 37..44: this expression is not supported yet
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_array_types_init_sized-4.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_array_types_init_sized-4.snap
@@ -16,12 +16,13 @@ Library@(dummy)
                   Literal@(FileId(1), 14..15): Integer(1)
               Primitive@(FileId(1), 36..39): Int
             ExprBody@(FileId(1), 43..50)
+              InitExpr@(FileId(1), 43..50)
+                ExprBody@(FileId(1), 48..49)
+                  Literal@(FileId(1), 48..49): Integer(1)
 error in file FileId(1) at 14..20: extra ranges specified
 | error in file FileId(1) for 22..32: extra ranges after
 | note in file FileId(1) for 14..20: this must be the only range present
 | info: `init`-sized arrays must have this range be the only range present
 error in file FileId(1) at 27..28: unexpected token
 | error in file FileId(1) for 27..28: expected type specifier, but found `,`
-error in file FileId(1) at 43..50: unsupported expression
-| error in file FileId(1) for 43..50: this expression is not supported yet
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_array_types_init_sized-4.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_array_types_init_sized-4.snap
@@ -1,0 +1,27 @@
+---
+source: compiler/toc_hir_lowering/tests/lowering.rs
+assertion_line: 61
+expression: "var _ : array 1 .. *, char,,char of int := init(1)"
+
+---
+Library@(dummy)
+  Root@(dummy): FileId(1) -> ItemId(1)
+    Module@(FileId(1), 0..50): "<root>"@(dummy)
+      StmtBody@(FileId(1), 0..50): []
+        StmtItem@(FileId(1), 0..50): ItemId(0)
+          ConstVar@(FileId(1), 0..50): var "_"@(FileId(1), 4..5)
+            Array@(FileId(1), 8..39): MaybeDyn
+              Constrained@(FileId(1), 14..20): end => Unsized(Some(1))
+                ExprBody@(FileId(1), 14..15)
+                  Literal@(FileId(1), 14..15): Integer(1)
+              Primitive@(FileId(1), 36..39): Int
+            ExprBody@(FileId(1), 43..50)
+error in file FileId(1) at 14..20: extra ranges specified
+| error in file FileId(1) for 22..32: extra ranges after
+| note in file FileId(1) for 14..20: this must be the only range present
+| info: `init`-sized arrays must have this range be the only range present
+error in file FileId(1) at 27..28: unexpected token
+| error in file FileId(1) for 27..28: expected type specifier, but found `,`
+error in file FileId(1) at 43..50: unsupported expression
+| error in file FileId(1) for 43..50: this expression is not supported yet
+

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_array_types_init_sized-5.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_array_types_init_sized-5.snap
@@ -1,0 +1,25 @@
+---
+source: compiler/toc_hir_lowering/tests/lowering.rs
+assertion_line: 61
+expression: "var _ : array char, 1 .. * of int := init(1)"
+
+---
+Library@(dummy)
+  Root@(dummy): FileId(1) -> ItemId(1)
+    Module@(FileId(1), 0..44): "<root>"@(dummy)
+      StmtBody@(FileId(1), 0..44): []
+        StmtItem@(FileId(1), 0..44): ItemId(0)
+          ConstVar@(FileId(1), 0..44): var "_"@(FileId(1), 4..5)
+            Array@(FileId(1), 8..33): MaybeDyn
+              Constrained@(FileId(1), 20..26): end => Unsized(Some(1))
+                ExprBody@(FileId(1), 20..21)
+                  Literal@(FileId(1), 20..21): Integer(1)
+              Primitive@(FileId(1), 30..33): Int
+            ExprBody@(FileId(1), 37..44)
+error in file FileId(1) at 20..26: extra ranges specified
+| error in file FileId(1) for 14..18: extra ranges before
+| note in file FileId(1) for 20..26: this must be the only range present
+| info: `init`-sized arrays must have this range be the only range present
+error in file FileId(1) at 37..44: unsupported expression
+| error in file FileId(1) for 37..44: this expression is not supported yet
+

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_array_types_init_sized-5.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_array_types_init_sized-5.snap
@@ -16,10 +16,11 @@ Library@(dummy)
                   Literal@(FileId(1), 20..21): Integer(1)
               Primitive@(FileId(1), 30..33): Int
             ExprBody@(FileId(1), 37..44)
+              InitExpr@(FileId(1), 37..44)
+                ExprBody@(FileId(1), 42..43)
+                  Literal@(FileId(1), 42..43): Integer(1)
 error in file FileId(1) at 20..26: extra ranges specified
 | error in file FileId(1) for 14..18: extra ranges before
 | note in file FileId(1) for 20..26: this must be the only range present
 | info: `init`-sized arrays must have this range be the only range present
-error in file FileId(1) at 37..44: unsupported expression
-| error in file FileId(1) for 37..44: this expression is not supported yet
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_array_types_init_sized-6.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_array_types_init_sized-6.snap
@@ -1,0 +1,27 @@
+---
+source: compiler/toc_hir_lowering/tests/lowering.rs
+assertion_line: 61
+expression: "var _ : array char,,char, 1 .. * of int := init(1)"
+
+---
+Library@(dummy)
+  Root@(dummy): FileId(1) -> ItemId(1)
+    Module@(FileId(1), 0..50): "<root>"@(dummy)
+      StmtBody@(FileId(1), 0..50): []
+        StmtItem@(FileId(1), 0..50): ItemId(0)
+          ConstVar@(FileId(1), 0..50): var "_"@(FileId(1), 4..5)
+            Array@(FileId(1), 8..39): MaybeDyn
+              Constrained@(FileId(1), 26..32): end => Unsized(Some(1))
+                ExprBody@(FileId(1), 26..27)
+                  Literal@(FileId(1), 26..27): Integer(1)
+              Primitive@(FileId(1), 36..39): Int
+            ExprBody@(FileId(1), 43..50)
+error in file FileId(1) at 19..20: unexpected token
+| error in file FileId(1) for 19..20: expected type specifier, but found `,`
+error in file FileId(1) at 26..32: extra ranges specified
+| error in file FileId(1) for 14..24: extra ranges before
+| note in file FileId(1) for 26..32: this must be the only range present
+| info: `init`-sized arrays must have this range be the only range present
+error in file FileId(1) at 43..50: unsupported expression
+| error in file FileId(1) for 43..50: this expression is not supported yet
+

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_array_types_init_sized-6.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_array_types_init_sized-6.snap
@@ -16,12 +16,13 @@ Library@(dummy)
                   Literal@(FileId(1), 26..27): Integer(1)
               Primitive@(FileId(1), 36..39): Int
             ExprBody@(FileId(1), 43..50)
+              InitExpr@(FileId(1), 43..50)
+                ExprBody@(FileId(1), 48..49)
+                  Literal@(FileId(1), 48..49): Integer(1)
 error in file FileId(1) at 19..20: unexpected token
 | error in file FileId(1) for 19..20: expected type specifier, but found `,`
 error in file FileId(1) at 26..32: extra ranges specified
 | error in file FileId(1) for 14..24: extra ranges before
 | note in file FileId(1) for 26..32: this must be the only range present
 | info: `init`-sized arrays must have this range be the only range present
-error in file FileId(1) at 43..50: unsupported expression
-| error in file FileId(1) for 43..50: this expression is not supported yet
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_array_types_init_sized-7.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_array_types_init_sized-7.snap
@@ -16,11 +16,12 @@ Library@(dummy)
                   Literal@(FileId(1), 20..21): Integer(1)
               Primitive@(FileId(1), 36..39): Int
             ExprBody@(FileId(1), 43..50)
+              InitExpr@(FileId(1), 43..50)
+                ExprBody@(FileId(1), 48..49)
+                  Literal@(FileId(1), 48..49): Integer(1)
 error in file FileId(1) at 20..26: extra ranges specified
 | error in file FileId(1) for 14..18: extra ranges before
 | error in file FileId(1) for 28..32: extra ranges after
 | note in file FileId(1) for 20..26: this must be the only range present
 | info: `init`-sized arrays must have this range be the only range present
-error in file FileId(1) at 43..50: unsupported expression
-| error in file FileId(1) for 43..50: this expression is not supported yet
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_array_types_init_sized-7.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_array_types_init_sized-7.snap
@@ -1,0 +1,26 @@
+---
+source: compiler/toc_hir_lowering/tests/lowering.rs
+assertion_line: 61
+expression: "var _ : array char, 1 .. *, char of int := init(1)"
+
+---
+Library@(dummy)
+  Root@(dummy): FileId(1) -> ItemId(1)
+    Module@(FileId(1), 0..50): "<root>"@(dummy)
+      StmtBody@(FileId(1), 0..50): []
+        StmtItem@(FileId(1), 0..50): ItemId(0)
+          ConstVar@(FileId(1), 0..50): var "_"@(FileId(1), 4..5)
+            Array@(FileId(1), 8..39): MaybeDyn
+              Constrained@(FileId(1), 20..26): end => Unsized(Some(1))
+                ExprBody@(FileId(1), 20..21)
+                  Literal@(FileId(1), 20..21): Integer(1)
+              Primitive@(FileId(1), 36..39): Int
+            ExprBody@(FileId(1), 43..50)
+error in file FileId(1) at 20..26: extra ranges specified
+| error in file FileId(1) for 14..18: extra ranges before
+| error in file FileId(1) for 28..32: extra ranges after
+| note in file FileId(1) for 20..26: this must be the only range present
+| info: `init`-sized arrays must have this range be the only range present
+error in file FileId(1) at 43..50: unsupported expression
+| error in file FileId(1) for 43..50: this expression is not supported yet
+

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_array_types_init_sized.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_array_types_init_sized.snap
@@ -16,6 +16,7 @@ Library@(dummy)
                   Literal@(FileId(1), 14..15): Integer(1)
               Primitive@(FileId(1), 24..27): Int
             ExprBody@(FileId(1), 31..38)
-error in file FileId(1) at 31..38: unsupported expression
-| error in file FileId(1) for 31..38: this expression is not supported yet
+              InitExpr@(FileId(1), 31..38)
+                ExprBody@(FileId(1), 36..37)
+                  Literal@(FileId(1), 36..37): Integer(1)
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_array_types_init_sized.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_array_types_init_sized.snap
@@ -1,0 +1,21 @@
+---
+source: compiler/toc_hir_lowering/tests/lowering.rs
+assertion_line: 61
+expression: "var _ : array 1 .. * of int := init(1)"
+
+---
+Library@(dummy)
+  Root@(dummy): FileId(1) -> ItemId(1)
+    Module@(FileId(1), 0..38): "<root>"@(dummy)
+      StmtBody@(FileId(1), 0..38): []
+        StmtItem@(FileId(1), 0..38): ItemId(0)
+          ConstVar@(FileId(1), 0..38): var "_"@(FileId(1), 4..5)
+            Array@(FileId(1), 8..27): MaybeDyn
+              Constrained@(FileId(1), 14..20): end => Unsized(Some(1))
+                ExprBody@(FileId(1), 14..15)
+                  Literal@(FileId(1), 14..15): Integer(1)
+              Primitive@(FileId(1), 24..27): Int
+            ExprBody@(FileId(1), 31..38)
+error in file FileId(1) at 31..38: unsupported expression
+| error in file FileId(1) for 31..38: this expression is not supported yet
+

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_constrained_type_unsized-2.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_constrained_type_unsized-2.snap
@@ -1,0 +1,22 @@
+---
+source: compiler/toc_hir_lowering/tests/lowering.rs
+assertion_line: 61
+expression: "var _ : array 1 .. * of int := 2"
+
+---
+Library@(dummy)
+  Root@(dummy): FileId(1) -> ItemId(1)
+    Module@(FileId(1), 0..32): "<root>"@(dummy)
+      StmtBody@(FileId(1), 0..32): []
+        StmtItem@(FileId(1), 0..32): ItemId(0)
+          ConstVar@(FileId(1), 0..32): var "_"@(FileId(1), 4..5)
+            Array@(FileId(1), 8..27): MaybeDyn
+              Constrained@(FileId(1), 14..20): end => Unsized(None)
+                ExprBody@(FileId(1), 14..15)
+                  Literal@(FileId(1), 14..15): Integer(1)
+              Primitive@(FileId(1), 24..27): Int
+            ExprBody@(FileId(1), 31..32)
+              Literal@(FileId(1), 31..32): Integer(2)
+error in file FileId(1) at 14..20: unsized range types require an `init` initializer
+| error in file FileId(1) for 31..32: not an `init` expression
+

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_constrained_type_unsized-3.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_constrained_type_unsized-3.snap
@@ -1,0 +1,20 @@
+---
+source: compiler/toc_hir_lowering/tests/lowering.rs
+assertion_line: 61
+expression: "var _ : array 1 .. * of int"
+
+---
+Library@(dummy)
+  Root@(dummy): FileId(1) -> ItemId(1)
+    Module@(FileId(1), 0..27): "<root>"@(dummy)
+      StmtBody@(FileId(1), 0..27): []
+        StmtItem@(FileId(1), 0..27): ItemId(0)
+          ConstVar@(FileId(1), 0..27): var "_"@(FileId(1), 4..5)
+            Array@(FileId(1), 8..27): MaybeDyn
+              Constrained@(FileId(1), 14..20): end => Unsized(None)
+                ExprBody@(FileId(1), 14..15)
+                  Literal@(FileId(1), 14..15): Integer(1)
+              Primitive@(FileId(1), 24..27): Int
+error in file FileId(1) at 14..20: unsized range types require an `init` initializer
+| error in file FileId(1) for 0..27: missing an initializer expression
+

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_constrained_type_unsized-4.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_constrained_type_unsized-4.snap
@@ -1,0 +1,18 @@
+---
+source: compiler/toc_hir_lowering/tests/lowering.rs
+assertion_line: 61
+expression: "var _ : 1 .. *"
+
+---
+Library@(dummy)
+  Root@(dummy): FileId(1) -> ItemId(1)
+    Module@(FileId(1), 0..14): "<root>"@(dummy)
+      StmtBody@(FileId(1), 0..14): []
+        StmtItem@(FileId(1), 0..14): ItemId(0)
+          ConstVar@(FileId(1), 0..14): var "_"@(FileId(1), 4..5)
+            Constrained@(FileId(1), 8..14): end => Unsized(None)
+              ExprBody@(FileId(1), 8..9)
+                Literal@(FileId(1), 8..9): Integer(1)
+error in file FileId(1) at 8..14: cannot use unsized range type here
+| error in file FileId(1) for 8..14: unsized range types can only be used in array ranges
+

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_constrained_type_unsized-5.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_constrained_type_unsized-5.snap
@@ -1,0 +1,18 @@
+---
+source: compiler/toc_hir_lowering/tests/lowering.rs
+assertion_line: 61
+expression: "type _ : 1 .. *"
+
+---
+Library@(dummy)
+  Root@(dummy): FileId(1) -> ItemId(1)
+    Module@(FileId(1), 0..15): "<root>"@(dummy)
+      StmtBody@(FileId(1), 0..15): []
+        StmtItem@(FileId(1), 0..15): ItemId(0)
+          Type@(FileId(1), 0..15): "_"@(FileId(1), 5..6)
+            Constrained@(FileId(1), 9..15): end => Unsized(None)
+              ExprBody@(FileId(1), 9..10)
+                Literal@(FileId(1), 9..10): Integer(1)
+error in file FileId(1) at 9..15: cannot use unsized range type here
+| error in file FileId(1) for 9..15: unsized range types can only be used in array ranges
+

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_constrained_type_unsized.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_constrained_type_unsized.snap
@@ -1,0 +1,21 @@
+---
+source: compiler/toc_hir_lowering/tests/lowering.rs
+assertion_line: 61
+expression: "var _ : array 1 .. * of int := init(1, 2, 3)"
+
+---
+Library@(dummy)
+  Root@(dummy): FileId(1) -> ItemId(1)
+    Module@(FileId(1), 0..44): "<root>"@(dummy)
+      StmtBody@(FileId(1), 0..44): []
+        StmtItem@(FileId(1), 0..44): ItemId(0)
+          ConstVar@(FileId(1), 0..44): var "_"@(FileId(1), 4..5)
+            Array@(FileId(1), 8..27): MaybeDyn
+              Constrained@(FileId(1), 14..20): end => Unsized(Some(3))
+                ExprBody@(FileId(1), 14..15)
+                  Literal@(FileId(1), 14..15): Integer(1)
+              Primitive@(FileId(1), 24..27): Int
+            ExprBody@(FileId(1), 31..44)
+error in file FileId(1) at 31..44: unsupported expression
+| error in file FileId(1) for 31..44: this expression is not supported yet
+

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_constrained_type_unsized.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_constrained_type_unsized.snap
@@ -16,6 +16,11 @@ Library@(dummy)
                   Literal@(FileId(1), 14..15): Integer(1)
               Primitive@(FileId(1), 24..27): Int
             ExprBody@(FileId(1), 31..44)
-error in file FileId(1) at 31..44: unsupported expression
-| error in file FileId(1) for 31..44: this expression is not supported yet
+              InitExpr@(FileId(1), 31..44)
+                ExprBody@(FileId(1), 36..37)
+                  Literal@(FileId(1), 36..37): Integer(1)
+                ExprBody@(FileId(1), 39..40)
+                  Literal@(FileId(1), 39..40): Integer(2)
+                ExprBody@(FileId(1), 42..43)
+                  Literal@(FileId(1), 42..43): Integer(3)
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_init_expr-2.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_init_expr-2.snap
@@ -1,0 +1,26 @@
+---
+source: compiler/toc_hir_lowering/tests/lowering.rs
+assertion_line: 61
+expression: "var _ := init(1, 2, 3, 4)"
+
+---
+Library@(dummy)
+  Root@(dummy): FileId(1) -> ItemId(1)
+    Module@(FileId(1), 0..25): "<root>"@(dummy)
+      StmtBody@(FileId(1), 0..25): []
+        StmtItem@(FileId(1), 0..25): ItemId(0)
+          ConstVar@(FileId(1), 0..25): var "_"@(FileId(1), 4..5)
+            ExprBody@(FileId(1), 9..25)
+              InitExpr@(FileId(1), 9..25)
+                ExprBody@(FileId(1), 14..15)
+                  Literal@(FileId(1), 14..15): Integer(1)
+                ExprBody@(FileId(1), 17..18)
+                  Literal@(FileId(1), 17..18): Integer(2)
+                ExprBody@(FileId(1), 20..21)
+                  Literal@(FileId(1), 20..21): Integer(3)
+                ExprBody@(FileId(1), 23..24)
+                  Literal@(FileId(1), 23..24): Integer(4)
+error in file FileId(1) at 9..25: mismatched initializer
+| error in file FileId(1) for 9..25: `init` initializer is not allowed here
+| info: `init` initializer requires a type to be specified
+

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_init_expr-3.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_init_expr-3.snap
@@ -1,0 +1,27 @@
+---
+source: compiler/toc_hir_lowering/tests/lowering.rs
+assertion_line: 61
+expression: "var a : int a := init(1, 2, 3, 4)"
+
+---
+Library@(dummy)
+  Root@(dummy): FileId(1) -> ItemId(1)
+    Module@(FileId(1), 0..33): "<root>"@(dummy)
+      StmtBody@(FileId(1), 0..33): []
+        StmtItem@(FileId(1), 0..11): ItemId(0)
+          ConstVar@(FileId(1), 0..11): var "a"@(FileId(1), 4..5)
+            Primitive@(FileId(1), 8..11): Int
+        Assign@(FileId(1), 12..33)
+          Name@(FileId(1), 12..13): "a"@(FileId(1), 4..5)
+          InitExpr@(FileId(1), 17..33)
+            ExprBody@(FileId(1), 22..23)
+              Literal@(FileId(1), 22..23): Integer(1)
+            ExprBody@(FileId(1), 25..26)
+              Literal@(FileId(1), 25..26): Integer(2)
+            ExprBody@(FileId(1), 28..29)
+              Literal@(FileId(1), 28..29): Integer(3)
+            ExprBody@(FileId(1), 31..32)
+              Literal@(FileId(1), 31..32): Integer(4)
+error in file FileId(1) at 17..33: cannot use `init` expression here
+| error in file FileId(1) for 17..33: `init` expression can only be used as a `const` or `var` initializer
+

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_init_expr.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_init_expr.snap
@@ -1,0 +1,24 @@
+---
+source: compiler/toc_hir_lowering/tests/lowering.rs
+assertion_line: 61
+expression: "var _ : int := init(1, 2, 3, 4)"
+
+---
+Library@(dummy)
+  Root@(dummy): FileId(1) -> ItemId(1)
+    Module@(FileId(1), 0..31): "<root>"@(dummy)
+      StmtBody@(FileId(1), 0..31): []
+        StmtItem@(FileId(1), 0..31): ItemId(0)
+          ConstVar@(FileId(1), 0..31): var "_"@(FileId(1), 4..5)
+            Primitive@(FileId(1), 8..11): Int
+            ExprBody@(FileId(1), 15..31)
+              InitExpr@(FileId(1), 15..31)
+                ExprBody@(FileId(1), 20..21)
+                  Literal@(FileId(1), 20..21): Integer(1)
+                ExprBody@(FileId(1), 23..24)
+                  Literal@(FileId(1), 23..24): Integer(2)
+                ExprBody@(FileId(1), 26..27)
+                  Literal@(FileId(1), 26..27): Integer(3)
+                ExprBody@(FileId(1), 29..30)
+                  Literal@(FileId(1), 29..30): Integer(4)
+

--- a/compiler/toc_hir_pretty/src/graph.rs
+++ b/compiler/toc_hir_pretty/src/graph.rs
@@ -1236,6 +1236,24 @@ impl<'out, 'hir> HirVisitor for PrettyVisitor<'out, 'hir> {
         self.emit_type(id, "Enum", Layout::Vbox(v_layout))
     }
 
+    fn visit_array(&self, id: ty::TypeId, ty: &ty::Array) {
+        let mut v_layout = vec![Layout::Node(format!("{:?}", ty.sizing))];
+        v_layout.extend(
+            ty.ranges
+                .iter()
+                .enumerate()
+                .map(|(idx, _range)| Layout::Port(format!("dim{idx}"))),
+        );
+        v_layout.push(Layout::Port("element".into()));
+
+        self.emit_type(id, "Array", Layout::Vbox(v_layout));
+
+        let type_id = self.type_id(id);
+        for (idx, range_ty) in ty.ranges.iter().enumerate() {
+            self.emit_edge(format!("{type_id}:dim{idx}"), self.type_id(*range_ty));
+        }
+    }
+
     fn visit_set(&self, id: ty::TypeId, ty: &ty::Set) {
         self.emit_type(
             id,

--- a/compiler/toc_hir_pretty/src/graph.rs
+++ b/compiler/toc_hir_pretty/src/graph.rs
@@ -1235,6 +1235,7 @@ impl<'out, 'hir> HirVisitor for PrettyVisitor<'out, 'hir> {
             ty::ConstrainedEnd::Unsized(sz) => {
                 v_layout.push(Layout::Node(format!("Unsized({sz:?})", sz = sz.item())))
             }
+            ty::ConstrainedEnd::Any(_) => v_layout.push(Layout::Node("Any".into())),
         }
 
         self.emit_type(id, "Constrained", Layout::Vbox(v_layout));

--- a/compiler/toc_hir_pretty/src/graph.rs
+++ b/compiler/toc_hir_pretty/src/graph.rs
@@ -1015,6 +1015,21 @@ impl<'out, 'hir> HirVisitor for PrettyVisitor<'out, 'hir> {
         );
     }
 
+    fn visit_init_expr(&self, id: BodyExpr, expr: &expr::Init) {
+        let expr_id = self.expr_id(id);
+        let mut v_layout = vec![];
+
+        for (idx, &body_id) in expr.exprs.iter().enumerate() {
+            v_layout.push(Layout::Hbox(vec![
+                Layout::Node(format!("{idx}")),
+                Layout::NamedPort(format!("{expr_id}:body_{idx}"), "".into()),
+            ]));
+            self.emit_edge(format!("{expr_id}:body_{idx}"), self.body_id(body_id))
+        }
+
+        self.emit_expr(id, "InitExpr", Layout::Vbox(v_layout));
+    }
+
     fn visit_binary(&self, id: BodyExpr, expr: &expr::Binary) {
         self.emit_expr(
             id,

--- a/compiler/toc_hir_pretty/src/tree.rs
+++ b/compiler/toc_hir_pretty/src/tree.rs
@@ -531,6 +531,10 @@ impl<'out, 'hir> HirVisitor for PrettyVisitor<'out, 'hir> {
             Some(format_args!("{def_name} [ {variants} ]")),
         )
     }
+    fn visit_array(&self, id: ty::TypeId, ty: &ty::Array) {
+        let span = self.type_span(id);
+        self.emit_node("Array", span, Some(format_args!("{:?}", ty.sizing)))
+    }
     fn visit_set(&self, id: ty::TypeId, ty: &ty::Set) {
         let span = self.type_span(id);
         let extra = self.display_extra_def(ty.def_id);

--- a/compiler/toc_hir_pretty/src/tree.rs
+++ b/compiler/toc_hir_pretty/src/tree.rs
@@ -516,6 +516,7 @@ impl<'out, 'hir> HirVisitor for PrettyVisitor<'out, 'hir> {
         let extra = match ty.end {
             ty::ConstrainedEnd::Expr(_) => "end => Expr".into(),
             ty::ConstrainedEnd::Unsized(sz) => format!("end => Unsized({sz:?})", sz = sz.item()),
+            ty::ConstrainedEnd::Any(_) => "end => Any".into(),
         };
         self.emit_node("Constrained", span, Some(format_args!("{extra}")))
     }

--- a/compiler/toc_hir_pretty/src/tree.rs
+++ b/compiler/toc_hir_pretty/src/tree.rs
@@ -441,6 +441,10 @@ impl<'out, 'hir> HirVisitor for PrettyVisitor<'out, 'hir> {
         let span = self.expr_span(id);
         self.emit_node("Literal", span, Some(format_args!("{expr:?}")))
     }
+    fn visit_init_expr(&self, id: BodyExpr, _expr: &expr::Init) {
+        let span = self.expr_span(id);
+        self.emit_node("InitExpr", span, None);
+    }
     fn visit_binary(&self, id: BodyExpr, expr: &expr::Binary) {
         let span = self.expr_span(id);
         self.emit_node("Binary", span, Some(format_args!("{:?}", expr.op.item())))

--- a/compiler/toc_validate/src/stmt.rs
+++ b/compiler/toc_validate/src/stmt.rs
@@ -41,6 +41,8 @@ pub(super) fn validate_constvar_decl(decl: ast::ConstVarDecl, ctx: &mut Validate
     //     if decl.type_spec() is Some(Type::ArrayType(array_ty))
     //        and array_ty.ranges() contains unbounded range
 
+    // Note: array case + `init` initializer is handled during lowering to HIR
+
     if let Some(ast::Expr::InitExpr(init_expr)) = decl.init() {
         // Has init expr initializer, allowed here?
         if let Some(ty) = decl.type_spec() {
@@ -68,56 +70,6 @@ pub(super) fn validate_constvar_decl(decl: ast::ConstVarDecl, ctx: &mut Validate
                 .with_error("`init` initializer is not allowed here", span)
                 .with_info("`init` initializer requires a type to be specified")
                 .finish();
-        }
-    } else if let Some(ast::Type::ArrayType(array_ty)) = decl.type_spec() {
-        // Has array type spec, is unbounded?
-        // An array is unbounded if at least one of its ranges is unbounded
-        if let Some(ranges) = array_ty.range_list() {
-            let mut ranges = ranges.ranges();
-
-            // Check if the array is unbounded
-            let is_unbounded = loop {
-                let range = if let Some(range) = ranges.next() {
-                    range
-                } else {
-                    break false;
-                };
-
-                if let ast::Type::RangeType(range_ty) = range {
-                    let is_unbounded = range_ty
-                        .end()
-                        .map(|end_bound| matches!(end_bound, ast::EndBound::UnsizedBound(_)))
-                        .unwrap_or_default();
-
-                    if is_unbounded {
-                        break true;
-                    }
-                }
-            };
-
-            if is_unbounded {
-                // init expr is required
-                if !matches!(decl.init(), Some(ast::Expr::InitExpr(_))) {
-                    // Report at either the initializer expr, or the array type spec
-                    let ty_span = ctx.mk_span(array_ty.syntax().text_range());
-
-                    let (message, report_at) = if let Some(init) = decl.init() {
-                        let report_here = init.syntax().text_range();
-                        let span = ctx.mk_span(report_here);
-                        ("`init` initializer required here", span)
-                    } else {
-                        let report_after = array_ty.syntax().text_range();
-                        let span = ctx.mk_span(report_after);
-                        ("`init` initializer required after here", span)
-                    };
-
-                    ctx.push_detailed_error("mismatched initializer", report_at)
-                        .with_error(message, report_at)
-                        .with_note("this is an unbounded array type", ty_span)
-                        .with_info("unbounded arrays have their upper bounds specified by `init` initializers")
-                        .finish();
-                }
-            }
         }
     }
 }

--- a/compiler/toc_validate/src/stmt/test.rs
+++ b/compiler/toc_validate/src/stmt/test.rs
@@ -361,18 +361,6 @@ fn bind_decl_in_inner_blocks() {
 }
 
 #[test]
-fn report_init_expr_with_int_ty() {
-    check(
-        "var a : int := init(1)",
-        expect![[r#"
-            error in file FileId(1) at 15..22: mismatched initializer
-            | error in file FileId(1) for 15..22: `init` initializer is not allowed here
-            | error in file FileId(1) for 8..11: cannot use `init` initializer with this type
-            | info: `init` initializer can only be used with array, record, or union types"#]],
-    );
-}
-
-#[test]
 fn report_init_expr_with_no_ty() {
     check(
         "var a := init(1)",

--- a/compiler/toc_validate/src/stmt/test.rs
+++ b/compiler/toc_validate/src/stmt/test.rs
@@ -402,30 +402,6 @@ fn init_expr_with_union_ty() {
 }
 
 #[test]
-fn report_not_init_expr_with_unbounded_array() {
-    check(
-        "var a : array 1 .. * of int := 2",
-        expect![[r#"
-            error in file FileId(1) at 31..32: mismatched initializer
-            | error in file FileId(1) for 31..32: `init` initializer required here
-            | note in file FileId(1) for 8..27: this is an unbounded array type
-            | info: unbounded arrays have their upper bounds specified by `init` initializers"#]],
-    );
-}
-
-#[test]
-fn report_no_initializer_with_unbounded_array() {
-    check(
-        "var a : array 1 .. * of int",
-        expect![[r#"
-            error in file FileId(1) at 8..27: mismatched initializer
-            | error in file FileId(1) for 8..27: `init` initializer required after here
-            | note in file FileId(1) for 8..27: this is an unbounded array type
-            | info: unbounded arrays have their upper bounds specified by `init` initializers"#]],
-    );
-}
-
-#[test]
 fn proc_decl_in_main() {
     check("proc a end a", expect![[]]);
 }


### PR DESCRIPTION
- [x] AST Lowering
  - [x] ty::Array & ty::TypeKind::Array
  - [x] expr::Init
  - [x] Handling init-sized arrays
  - [x] Handling any-sized arrays (params only)
- [x] HIR db
  - [x] Type owners
  - [x] Body owners
- [x] Typed HIR
  - [x] ty::Array
  - [x] ty::rules::is_equivalent
  - [x] ty::rules::is_coercible_into
  - [x] ty::infer::call_expr Indexing
  - [x] ty::infer::array_ty
  - [x] expr::Init infer (just as an error, only allowed in `ConstVar` decls right now)
  - [x] Indexing produces values with the correct mutability
- [x] Typeck
  - [x] Indexing input assignable into index tys
  - [x] (Static-only) non-zero positive size
  - [x] (Flexible-only) positive size, including zero
  - [x] Unsized ranges only allowed for static arrays
  - [x] Only allow index types for indices
  - [x] Arrays that aren't too big
  - [x] Specialized message for iterable for-each