### PR TITLE
Implement delayed reports

### DIFF
--- a/compiler/toc_analysis/src/const_eval/snapshots/toc_analysis__const_eval__test__error_no_const_expr-2.snap
+++ b/compiler/toc_analysis/src/const_eval/snapshots/toc_analysis__const_eval__test__error_no_const_expr-2.snap
@@ -1,6 +1,6 @@
 ---
 source: compiler/toc_analysis/src/const_eval/test.rs
-assertion_line: 13
+assertion_line: 15
 expression: "var a := 1\nconst b := a\nconst c := b\n"
 
 ---
@@ -8,6 +8,9 @@ expression: "var a := 1\nconst b := a\nconst c := b\n"
 "b"@(FileId(1), 17..18) -> ConstError { kind: NotConstExpr(Some(DefId(LibraryId(0), LocalDefId(0)))), span: (FileId(1), 22..23) }
 "c"@(FileId(1), 30..31) -> ConstError { kind: NotConstExpr(Some(DefId(LibraryId(0), LocalDefId(0)))), span: (FileId(1), 22..23) }
 
+error in file FileId(1) at 22..23: cannot compute `a` at compile-time
+| error in file FileId(1) for 22..23: `a` is a reference to a variable, not a constant
+| note in file FileId(1) for 4..5: `a` declared here
 error in file FileId(1) at 22..23: cannot compute `a` at compile-time
 | error in file FileId(1) for 22..23: `a` is a reference to a variable, not a constant
 | note in file FileId(1) for 4..5: `a` declared here

--- a/compiler/toc_analysis/src/const_eval/snapshots/toc_analysis__const_eval__test__error_propagation.snap
+++ b/compiler/toc_analysis/src/const_eval/snapshots/toc_analysis__const_eval__test__error_propagation.snap
@@ -1,12 +1,14 @@
 ---
 source: compiler/toc_analysis/src/const_eval/test.rs
-assertion_line: 13
+assertion_line: 15
 expression: "const a := 1 div 0\nconst b := a\n"
 
 ---
 "a"@(FileId(1), 6..7) -> ConstError { kind: DivByZero, span: (FileId(1), 13..16) }
 "b"@(FileId(1), 25..26) -> ConstError { kind: DivByZero, span: (FileId(1), 13..16) }
 
+error in file FileId(1) at 13..16: cannot compute expression at compile-time
+| error in file FileId(1) for 13..16: division by zero in compile-time expression
 error in file FileId(1) at 13..16: cannot compute expression at compile-time
 | error in file FileId(1) for 13..16: division by zero in compile-time expression
 

--- a/compiler/toc_analysis/src/lints/test.rs
+++ b/compiler/toc_analysis/src/lints/test.rs
@@ -13,6 +13,7 @@ fn assert_lint(source: &str) {
 fn do_lint(source: &str) -> String {
     let (db, lib) = TestDb::from_source(source);
     let res = db.lint_library(lib);
+    res.messages().assert_no_delayed_reports();
 
     stringify_lint_results(res.messages())
 }

--- a/compiler/toc_analysis/src/typeck/test.rs
+++ b/compiler/toc_analysis/src/typeck/test.rs
@@ -45,6 +45,7 @@ fn assert_typecheck(source: &str) {
 fn do_typecheck(source: &str) -> String {
     let (db, lib) = TestDb::from_source(source);
     let typeck_res = db.typecheck_library(lib);
+    typeck_res.messages().assert_no_delayed_reports();
 
     stringify_typeck_results(&db, lib, typeck_res.messages())
 }

--- a/compiler/toc_driver/src/main.rs
+++ b/compiler/toc_driver/src/main.rs
@@ -92,6 +92,7 @@ fn main() {
     for msg in msgs.iter() {
         emit_message(&db, &mut cache, msg);
     }
+    msgs.assert_no_delayed_reports();
 
     if let Some(blob) = codegen_res.result() {
         let mut encoded = vec![];

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_put_stmt-7.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_put_stmt-7.snap
@@ -1,5 +1,6 @@
 ---
 source: compiler/toc_hir_lowering/tests/lowering.rs
+assertion_line: 61
 expression: "put : a"
 
 ---
@@ -9,6 +10,8 @@ Library@(dummy)
       StmtBody@(FileId(1), 0..7): []
         Put@(FileId(1), 0..7): newline
           Name@(FileId(1), 6..7): "a"@(FileId(1), 6..7), undeclared
+error in file FileId(1) at 6..7: unexpected end of file
+| error in file FileId(1) for 6..7: expected `,` after here
 error in file FileId(1) at 6..7: `a` is undeclared
 | error in file FileId(1) for 6..7: no definitions of `a` are in scope
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_self_expr.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_self_expr.snap
@@ -1,5 +1,6 @@
 ---
 source: compiler/toc_hir_lowering/tests/lowering.rs
+assertion_line: 61
 expression: "const a := self"
 
 ---
@@ -12,4 +13,6 @@ Library@(dummy)
             ExprBody@(FileId(1), 11..15)
 error in file FileId(1) at 11..15: unsupported expression
 | error in file FileId(1) for 11..15: this expression is not supported yet
+error in file FileId(1) at 11..15: cannot use `self` here
+| error in file FileId(1) for 11..15: `self` is only allowed inside of class subprograms
 

--- a/compiler/toc_parser/src/grammar/preproc/test.rs
+++ b/compiler/toc_parser/src/grammar/preproc/test.rs
@@ -616,10 +616,10 @@ mod cond {
                       PPElseif@0..7
                         PPKwElseif@0..7 "#elseif"
                         PPTokenBody@7..7
-                warn in file FileId(1) at 0..7: `#elseif` found
-                | warn in file FileId(1) for 0..7: assuming it to be `#elsif`
                 error in file FileId(1) at 0..7: unexpected end of file
-                | error in file FileId(1) for 0..7: expected preprocessor condition after here"##]],
+                | error in file FileId(1) for 0..7: expected preprocessor condition after here
+                warn in file FileId(1) at 0..7: `#elseif` found
+                | warn in file FileId(1) for 0..7: assuming it to be `#elsif`"##]],
         );
     }
 

--- a/compiler/toc_parser/src/parser.rs
+++ b/compiler/toc_parser/src/parser.rs
@@ -357,18 +357,22 @@ impl<'p, 't, 's> UnexpectedBuilder<'p, 't, 's> {
             "unexpected end of file"
         };
 
-        self.p.msg_sink.error(
-            header,
-            &format!(
-                "{}",
-                ParseMessage::UnexpectedToken {
-                    expected: mem::take(&mut self.p.expected_kinds),
-                    expected_category: self.category,
-                    found,
-                }
-            ),
-            span,
-        );
+        self.p
+            .msg_sink
+            .error_detailed(header, span)
+            .with_error(
+                &format!(
+                    "{}",
+                    ParseMessage::UnexpectedToken {
+                        expected: mem::take(&mut self.p.expected_kinds),
+                        expected_category: self.category,
+                        found,
+                    }
+                ),
+                span,
+            )
+            .report_first_always()
+            .finish();
 
         // If the cursor is part of the recovery set (and if we're set to respect recovery sets),
         // error node does not need to be built

--- a/compiler/toc_reporting/src/annotate.rs
+++ b/compiler/toc_reporting/src/annotate.rs
@@ -31,7 +31,6 @@ impl fmt::Display for AnnotateKind {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SourceAnnotation {
-    // FIXME: These don't need to be pub crate
     pub(crate) annotation: Annotation,
     pub(crate) span: Span,
 }

--- a/compiler/toc_reporting/src/lib.rs
+++ b/compiler/toc_reporting/src/lib.rs
@@ -6,7 +6,7 @@ mod message;
 mod reporter;
 
 pub use annotate::{AnnotateKind, Annotation, SourceAnnotation};
-pub use message::{MessageBundle, ReportMessage};
+pub use message::{MessageBundle, ReportMessage, ReportWhen};
 pub use reporter::{MessageBuilder, MessageSink};
 
 /// A compilation result, including a bundle of associated messages

--- a/compiler/toc_reporting/src/message.rs
+++ b/compiler/toc_reporting/src/message.rs
@@ -125,7 +125,7 @@ impl MessageBundle {
 
         if let Some(delayed) = any_delayed {
             panic!(
-                "detected delayed report message at {:?}, should have been reported over\n\nOriginal message:\n{}\n",
+                "detected delayed report message at {:?}, should have been reported over\n\nOriginal message:\n{:#?}\n",
                 delayed.span(),
                 delayed
             );

--- a/compiler/toc_reporting/src/message.rs
+++ b/compiler/toc_reporting/src/message.rs
@@ -68,7 +68,6 @@ impl MessageBundle {
 /// A reported message
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ReportMessage {
-    // FIXME: These don't need to be pub crate
     pub(crate) header: SourceAnnotation,
     pub(crate) annotations: Vec<SourceAnnotation>,
     pub(crate) footer: Vec<Annotation>,

--- a/compiler/toc_reporting/src/message.rs
+++ b/compiler/toc_reporting/src/message.rs
@@ -1,6 +1,7 @@
 //! Constructed messages
 
-use std::{collections::HashSet, fmt};
+use std::collections::HashSet;
+use std::fmt;
 
 use toc_span::Span;
 
@@ -40,21 +41,72 @@ impl MessageBundle {
     }
 
     pub fn iter(&self) -> impl Iterator<Item = &'_ ReportMessage> + '_ {
-        // Perform message deduplication
-        // Earlier messages get reported over later ones
-        // Annotate kinds are considered separately from each other
-        // Spans that cover each-other are considered different
-
-        let mut reported_at = HashSet::new();
-        self.messages.iter().filter(move |msg| {
-            // Only report the first one at a given span & kind
-            reported_at.insert((msg.span(), msg.kind()))
-        })
+        self.messages.iter()
     }
 
     /// Puts the message bundle into a consistent state (sorted + all other metadata is correct)
     fn make_uniform(&mut self) {
-        self.messages.sort_by_key(|item| item.span());
+        use std::cmp::Ordering;
+
+        // Deal with occluding `FirstAlways` spans
+        {
+            let mut reported_at = HashSet::new();
+            self.messages.retain(|msg| {
+                if msg.when == ReportWhen::FirstAlways {
+                    // Only accept the first kind at this span
+                    reported_at.insert((msg.span(), msg.kind()))
+                } else {
+                    // Dealt with later
+                    true
+                }
+            })
+        }
+
+        // Want to deal with all dupes, so needs to be sorted
+        self.messages
+            .sort_by(|a, b| Ord::cmp(&a.span(), &b.span()).then(Ord::cmp(&a.when, &b.when)));
+        // Reverse vec so that messages get occluded in the correct order
+        self.messages.reverse();
+
+        // Occlude messages by kind and span
+        self.messages.dedup_by(move |a, b| {
+            // Spans must be the same
+            if a.span() != b.span() {
+                return false;
+            }
+
+            // Main annotation kinds must be the same
+            if a.header.kind() != b.header.kind() {
+                return false;
+            }
+
+            // Don't touch always reported spans
+            if a.when.report_always() && b.when.report_always() {
+                return false;
+            }
+
+            // From/To | Always | Delayed | Hidden
+            // --------|--------|---------|--------
+            // Always  | Keep   | From    | From
+            // Delayed | To     | Keep    | From
+            // Hidden  | To     | To      | To
+            match a.when.cmp(&b.when) {
+                // Always occlude lesser whens
+                Ordering::Less => {
+                    debug_assert!(
+                        !(a.when == ReportWhen::FirstAlways && b.when == ReportWhen::Always)
+                    );
+
+                    true
+                }
+                // Only occlude when eq for `Hidden` whens
+                Ordering::Equal if a.when == ReportWhen::Hidden => true,
+                // Otherwise, keep both
+                _ => false,
+            }
+        });
+
+        self.messages.reverse();
     }
 
     /// Tests if this message bundle contains any error messages
@@ -71,6 +123,7 @@ pub struct ReportMessage {
     pub(crate) header: SourceAnnotation,
     pub(crate) annotations: Vec<SourceAnnotation>,
     pub(crate) footer: Vec<Annotation>,
+    pub(crate) when: ReportWhen,
 }
 
 impl ReportMessage {
@@ -115,5 +168,182 @@ impl fmt::Display for ReportMessage {
         }
 
         Ok(())
+    }
+}
+
+/// When a [`ReportMessage`] should be reported
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum ReportWhen {
+    /// Allow this message to be occluded by later messages.
+    /// Used when a later stage improves the message at this span
+    Hidden,
+    /// Require this message to be occluded by a later message.
+    /// Panic if one is encountered during the final reporting.
+    Delayed,
+    /// Always have this message reported, but only if it's the first at this span.
+    /// Used for parser error messages, where earlier messages are more useful than later ones.
+    FirstAlways,
+    /// Always have this message reported (not occluded by other spans).
+    /// This is the default option.
+    Always,
+}
+
+impl ReportWhen {
+    fn report_always(self) -> bool {
+        matches!(self, Self::FirstAlways | Self::Always)
+    }
+}
+
+impl Default for ReportWhen {
+    fn default() -> Self {
+        Self::Always
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use toc_span::Span;
+
+    use crate::*;
+
+    #[test]
+    fn collapse_hidden() {
+        let mut reporter = MessageSink::default();
+
+        reporter
+            .error_detailed("first", Span::default())
+            .report_hidden()
+            .finish();
+        reporter
+            .error_detailed("second", Span::default())
+            .report_hidden()
+            .finish();
+        reporter
+            .error_detailed("third", Span::default())
+            .report_hidden()
+            .finish();
+
+        let mut msgs = reporter.finish();
+        msgs.make_uniform();
+
+        assert_eq!(msgs.messages.len(), 1);
+        assert_eq!(msgs.messages[0].header.message(), "third");
+    }
+
+    #[test]
+    fn keep_delayed() {
+        let mut reporter = MessageSink::default();
+
+        reporter
+            .error_detailed("first", Span::default())
+            .report_delayed()
+            .finish();
+        reporter
+            .error_detailed("second", Span::default())
+            .report_delayed()
+            .finish();
+        reporter
+            .error_detailed("third", Span::default())
+            .report_delayed()
+            .finish();
+
+        let mut msgs = reporter.finish();
+        let before = msgs.messages.clone();
+        msgs.make_uniform();
+
+        // Should be unchanged
+        assert_eq!(msgs.messages.len(), 3);
+        assert_eq!(before, msgs.messages);
+    }
+
+    #[test]
+    fn delayed_occludes_hidden() {
+        let mut reporter = MessageSink::default();
+
+        reporter
+            .error_detailed("delayed", Default::default())
+            .report_delayed()
+            .finish();
+        reporter
+            .error_detailed("hidden", Default::default())
+            .report_hidden()
+            .finish();
+
+        let mut msgs = reporter.finish();
+        msgs.make_uniform();
+
+        assert_eq!(msgs.messages.len(), 1);
+        assert_eq!(msgs.messages[0].header.annotation.msg, "delayed");
+    }
+
+    #[test]
+    fn always_occludes_both() {
+        let mut reporter = MessageSink::default();
+
+        reporter
+            .error_detailed("delayed", Default::default())
+            .report_delayed()
+            .finish();
+        reporter
+            .error_detailed("hidden", Default::default())
+            .report_hidden()
+            .finish();
+        reporter
+            .error_detailed("always", Default::default())
+            .report_always()
+            .finish();
+
+        let mut msgs = reporter.finish();
+        msgs.make_uniform();
+
+        assert_eq!(msgs.messages.len(), 1);
+        assert_eq!(msgs.messages[0].header.annotation.msg, "always");
+    }
+
+    #[test]
+    fn keep_always_and_first_always() {
+        let mut reporter = MessageSink::default();
+
+        reporter
+            .error_detailed("always", Default::default())
+            .report_always()
+            .finish();
+        reporter
+            .error_detailed("first always", Default::default())
+            .report_first_always()
+            .finish();
+
+        let mut msgs = reporter.finish();
+        msgs.make_uniform();
+
+        // `FirstAlways` before `Always`
+        assert_eq!(msgs.messages.len(), 2);
+        assert_eq!(msgs.messages[0].header.annotation.msg, "first always");
+        assert_eq!(msgs.messages[1].header.annotation.msg, "always");
+    }
+
+    #[test]
+    fn dedup_first_always() {
+        let mut reporter = MessageSink::default();
+
+        reporter
+            .error_detailed("first", Span::default())
+            .report_first_always()
+            .finish();
+        reporter
+            .error_detailed("second", Span::default())
+            .report_first_always()
+            .finish();
+        reporter
+            .error_detailed("third", Span::default())
+            .report_first_always()
+            .finish();
+
+        let mut msgs = reporter.finish();
+        msgs.make_uniform();
+
+        // Collapses to first
+        assert_eq!(msgs.messages.len(), 1);
+        assert_eq!(msgs.messages[0].header.message(), "first");
     }
 }

--- a/compiler/toc_reporting/src/reporter.rs
+++ b/compiler/toc_reporting/src/reporter.rs
@@ -2,7 +2,7 @@
 
 use toc_span::Span;
 
-use crate::{AnnotateKind, Annotation, MessageBundle, ReportMessage, SourceAnnotation};
+use crate::{AnnotateKind, Annotation, MessageBundle, ReportMessage, ReportWhen, SourceAnnotation};
 
 /// Sink for message reports
 #[derive(Debug, Default)]
@@ -68,6 +68,7 @@ pub struct MessageBuilder<'a> {
     span: Span,
     annotations: Vec<SourceAnnotation>,
     footer: Vec<Annotation>,
+    when: ReportWhen,
 }
 
 impl<'a> MessageBuilder<'a> {
@@ -85,6 +86,7 @@ impl<'a> MessageBuilder<'a> {
             span,
             annotations: vec![],
             footer: vec![],
+            when: Default::default(),
         }
     }
 
@@ -119,6 +121,28 @@ impl<'a> MessageBuilder<'a> {
         self
     }
 
+    pub fn report_always(self) -> Self {
+        self.with_when(ReportWhen::Always)
+    }
+
+    pub fn report_first_always(self) -> Self {
+        self.with_when(ReportWhen::FirstAlways)
+    }
+
+    pub fn report_delayed(self) -> Self {
+        self.with_when(ReportWhen::Delayed)
+    }
+
+    pub fn report_hidden(self) -> Self {
+        self.with_when(ReportWhen::Hidden)
+    }
+
+    fn with_when(mut self, when: ReportWhen) -> Self {
+        self.when = when;
+
+        self
+    }
+
     pub fn finish(self) {
         let MessageBuilder {
             mut drop_bomb,
@@ -128,6 +152,7 @@ impl<'a> MessageBuilder<'a> {
             span,
             annotations,
             footer,
+            when,
         } = self;
 
         // Defuse bomb now
@@ -140,6 +165,7 @@ impl<'a> MessageBuilder<'a> {
             },
             annotations,
             footer,
+            when,
         });
     }
 }

--- a/compiler/toc_validate/src/stmt/test.rs
+++ b/compiler/toc_validate/src/stmt/test.rs
@@ -881,8 +881,10 @@ fn report_return_stmt_in_unit() {
     check(
         "unit return",
         expect![[r#"
-        error in file FileId(1) at 5..11: invalid unit file
-        | error in file FileId(1) for 5..11: expected a module, class, or monitor declaration"#]],
+            error in file FileId(1) at 5..11: invalid unit file
+            | error in file FileId(1) for 5..11: expected a module, class, or monitor declaration
+            error in file FileId(1) at 5..11: cannot use `return` here
+            | error in file FileId(1) for 5..11: `return` statement is only allowed in subprogram bodies and module-kind declarations"#]],
     );
 }
 
@@ -937,8 +939,10 @@ fn report_result_stmt_in_unit() {
     check(
         "unit result 'uwu'",
         expect![[r#"
-        error in file FileId(1) at 5..17: invalid unit file
-        | error in file FileId(1) for 5..17: expected a module, class, or monitor declaration"#]],
+            error in file FileId(1) at 5..17: invalid unit file
+            | error in file FileId(1) for 5..17: expected a module, class, or monitor declaration
+            error in file FileId(1) at 5..17: cannot use `result` here
+            | error in file FileId(1) for 5..17: `result` statement is only allowed in function bodies"#]],
     );
 }
 
@@ -1211,8 +1215,10 @@ fn report_import_stmt_in_unit() {
     check(
         "unit import ()",
         expect![[r#"
-        error in file FileId(1) at 5..14: invalid unit file
-        | error in file FileId(1) for 5..14: expected a module, class, or monitor declaration"#]],
+            error in file FileId(1) at 5..14: invalid unit file
+            | error in file FileId(1) for 5..14: expected a module, class, or monitor declaration
+            error in file FileId(1) at 5..14: cannot use `import` statement here
+            | error in file FileId(1) for 5..14: `import` statement is only allowed at the top level of subprograms, module-likes, or programs"#]],
     );
 }
 

--- a/lsp-server/src/state.rs
+++ b/lsp-server/src/state.rs
@@ -108,6 +108,9 @@ impl ServerState {
         let analyze_res = self.db.analyze_libraries();
         let msgs = analyze_res.messages();
 
+        // Note: this does noisily fail, but we don't gracefully handle panics yet
+        msgs.assert_no_delayed_reports();
+
         fn to_diag_level(kind: toc_reporting::AnnotateKind) -> DiagnosticSeverity {
             use toc_reporting::AnnotateKind;
 


### PR DESCRIPTION
Ensures that we are reporting errors at the given locations.

May want to change to just span-based in the future, but for now, this does the job