### PR TITLE
Add work-around for how `\0` is printed in tests

### DIFF
--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_char_seq_escapes-17.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_char_seq_escapes-17.snap
@@ -1,5 +1,6 @@
 ---
 source: compiler/toc_hir_lowering/tests/lowering.rs
+assertion_line: 61
 expression: "var _ : int _ := \"\\0o\""
 
 ---
@@ -12,5 +13,5 @@ Library@(dummy)
             Primitive@(FileId(1), 8..11): Int
         Assign@(FileId(1), 12..22)
           Name@(FileId(1), 12..13): "_"@(FileId(1), 4..5)
-          Literal@(FileId(1), 17..22): String("\u{0}o")
+          Literal@(FileId(1), 17..22): String("\0o")
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_char_seq_escapes-2.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_char_seq_escapes-2.snap
@@ -1,5 +1,6 @@
 ---
 source: compiler/toc_hir_lowering/tests/lowering.rs
+assertion_line: 61
 expression: "var _ : int _ := \"\\'\""
 
 ---
@@ -12,5 +13,5 @@ Library@(dummy)
             Primitive@(FileId(1), 8..11): Int
         Assign@(FileId(1), 12..21)
           Name@(FileId(1), 12..13): "_"@(FileId(1), 4..5)
-          Literal@(FileId(1), 17..21): String("'")
+          Literal@(FileId(1), 17..21): String("\'")
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_char_seq_escapes-22.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_char_seq_escapes-22.snap
@@ -1,5 +1,6 @@
 ---
 source: compiler/toc_hir_lowering/tests/lowering.rs
+assertion_line: 61
 expression: "var _ : int _ := \"\\x0o\""
 
 ---
@@ -12,5 +13,5 @@ Library@(dummy)
             Primitive@(FileId(1), 8..11): Int
         Assign@(FileId(1), 12..23)
           Name@(FileId(1), 12..13): "_"@(FileId(1), 4..5)
-          Literal@(FileId(1), 17..23): String("\u{0}o")
+          Literal@(FileId(1), 17..23): String("\0o")
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_char_seq_escapes-23.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_char_seq_escapes-23.snap
@@ -1,5 +1,6 @@
 ---
 source: compiler/toc_hir_lowering/tests/lowering.rs
+assertion_line: 61
 expression: "var _ : int _ := \"\\x00\""
 
 ---
@@ -12,5 +13,5 @@ Library@(dummy)
             Primitive@(FileId(1), 8..11): Int
         Assign@(FileId(1), 12..23)
           Name@(FileId(1), 12..13): "_"@(FileId(1), 4..5)
-          Literal@(FileId(1), 17..23): String("\u{0}")
+          Literal@(FileId(1), 17..23): String("\0")
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_char_seq_escapes-24.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_char_seq_escapes-24.snap
@@ -1,5 +1,6 @@
 ---
 source: compiler/toc_hir_lowering/tests/lowering.rs
+assertion_line: 61
 expression: "var _ : int _ := \"\\x00Ak\""
 
 ---
@@ -12,5 +13,5 @@ Library@(dummy)
             Primitive@(FileId(1), 8..11): Int
         Assign@(FileId(1), 12..25)
           Name@(FileId(1), 12..13): "_"@(FileId(1), 4..5)
-          Literal@(FileId(1), 17..25): String("\u{0}Ak")
+          Literal@(FileId(1), 17..25): String("\0Ak")
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_string_literal-3.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_string_literal-3.snap
@@ -1,5 +1,6 @@
 ---
 source: compiler/toc_hir_lowering/tests/lowering.rs
+assertion_line: 61
 expression: "const a := \"abcd'"
 
 ---
@@ -10,7 +11,7 @@ Library@(dummy)
         StmtItem@(FileId(1), 0..17): ItemId(0)
           ConstVar@(FileId(1), 0..17): const "a"@(FileId(1), 6..7)
             ExprBody@(FileId(1), 11..17)
-              Literal@(FileId(1), 11..17): String("abcd'")
+              Literal@(FileId(1), 11..17): String("abcd\'")
 error in file FileId(1) at 11..17: invalid string literal
 | error in file FileId(1) for 11..17: missing terminator character
 

--- a/compiler/toc_hir_pretty/src/tree.rs
+++ b/compiler/toc_hir_pretty/src/tree.rs
@@ -439,7 +439,16 @@ impl<'out, 'hir> HirVisitor for PrettyVisitor<'out, 'hir> {
     // Exprs //
     fn visit_literal(&self, id: BodyExpr, expr: &expr::Literal) {
         let span = self.expr_span(id);
-        self.emit_node("Literal", span, Some(format_args!("{expr:?}")))
+        // FIXME(rust-1.61.0): Debug escapes for \0 are different than previous version
+        let extra = if let expr::Literal::String(str) = expr {
+            format!(
+                "String(\"{}\")",
+                str.escape_debug().to_string().replace(r"\u{0}", r"\0")
+            )
+        } else {
+            format!("{expr:?}")
+        };
+        self.emit_node("Literal", span, Some(format_args!("{extra}")))
     }
     fn visit_init_expr(&self, id: BodyExpr, _expr: &expr::Init) {
         let span = self.expr_span(id);


### PR DESCRIPTION
Different between beta & stable, but back to the behaviour in previous stable