### PR TITLE
Update vscode engine version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,15 +245,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "experiment_driver"
-version = "0.0.0"
-dependencies = [
- "toc_parser",
- "toc_span",
- "toc_syntax",
-]
-
-[[package]]
 name = "fixedbitset"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/lsp-client/vscode/package.json
+++ b/lsp-client/vscode/package.json
@@ -13,7 +13,7 @@
     "description": "Syntax highlighting & LSP provider for HoltSoft's Turing language",
     "license": "SEE LICENSE IN LICENSE",
     "engines": {
-        "vscode": "^1.46.0"
+        "vscode": "^1.69.0"
     },
     "categories": [
         "Programming Languages"


### PR DESCRIPTION
Required to build the ext, since vscode types requires the newer engine version.