### PR TITLE
Symbol refactoring

### DIFF
--- a/compiler/toc_analysis/src/const_eval/errors.rs
+++ b/compiler/toc_analysis/src/const_eval/errors.rs
@@ -1,5 +1,5 @@
 //! Errors during constant evaluation
-use toc_hir::symbol::{DefId, NotBinding, Symbol};
+use toc_hir::symbol::{DefId, Symbol};
 use toc_span::Span;
 
 use crate::const_eval::db;
@@ -86,10 +86,9 @@ impl ConstError {
         let mut builder = match &self.kind {
             ErrorKind::NotConstExpr(Some(def_id)) => {
                 // Report at the reference's definition spot
-                let bind_to = match db.binding_to((*def_id).into()) {
-                    Ok(kind) => kind,
-                    Err(NotBinding::Missing) => return, // taken from an undeclared ident or missing expr
-                    Err(NotBinding::NotBinding) => unreachable!("taken from a def"),
+                let bind_to = match db.symbol_kind(*def_id) {
+                    Some(kind) => kind,
+                    None => return, // taken from an undeclared ident or missing expr
                 };
                 let library = db.library(def_id.0);
                 let def_info = library.local_def(def_id.1);

--- a/compiler/toc_analysis/src/const_eval/test.rs
+++ b/compiler/toc_analysis/src/const_eval/test.rs
@@ -109,7 +109,7 @@ fn stringify_const_eval_results(results: &str, messages: MessageBundle) -> Strin
 
     // Pretty print the messages
     for err in messages.iter() {
-        write!(&mut s, "\n{err}").unwrap();
+        writeln!(&mut s, "{err}").unwrap();
     }
 
     s

--- a/compiler/toc_analysis/src/const_eval/test.rs
+++ b/compiler/toc_analysis/src/const_eval/test.rs
@@ -100,6 +100,8 @@ fn do_const_eval(source: &str) -> String {
 }
 
 fn stringify_const_eval_results(results: &str, messages: MessageBundle) -> String {
+    use std::fmt::Write;
+
     // Pretty print const eval ctx
     // Want:
     // - Evaluation state of all accessible DefIds
@@ -107,7 +109,7 @@ fn stringify_const_eval_results(results: &str, messages: MessageBundle) -> Strin
 
     // Pretty print the messages
     for err in messages.iter() {
-        s.push_str(&format!("{err}\n"));
+        write!(&mut s, "\n{err}").unwrap();
     }
 
     s

--- a/compiler/toc_analysis/src/lints/test.rs
+++ b/compiler/toc_analysis/src/lints/test.rs
@@ -19,11 +19,13 @@ fn do_lint(source: &str) -> String {
 }
 
 fn stringify_lint_results(messages: &MessageBundle) -> String {
+    use std::fmt::Write;
+
     let mut s = String::new();
 
     // Pretty print the messages
     for err in messages.iter() {
-        s.push_str(&format!("\n{err}"));
+        write!(&mut s, "\n{err}").unwrap();
     }
 
     s

--- a/compiler/toc_analysis/src/ty.rs
+++ b/compiler/toc_analysis/src/ty.rs
@@ -528,7 +528,7 @@ where
             TypeKind::Integer => unreachable!("integer should be concrete"),
             TypeKind::Enum(_, variants) => {
                 // Always the ordinal of the last variant
-                if variants.len() == 0 {
+                if variants.is_empty() {
                     return Err(ConstError::without_span(ErrorKind::NotConstExpr(None)));
                 }
 

--- a/compiler/toc_analysis/src/ty/db.rs
+++ b/compiler/toc_analysis/src/ty/db.rs
@@ -36,11 +36,6 @@ pub trait TypeDatabase: TypeIntern + TypeInternExt {
     #[salsa::invoke(ty::query::value_produced)]
     fn value_produced(&self, source: ValueSource) -> Result<ValueKind, NotValue>;
 
-    /// Gets what a [`BindingSource`] binds to, or a [`NotBinding`](symbol::NotBinding) if it isn't one.
-    #[salsa::invoke(ty::query::binding_to)]
-    fn binding_to(&self, bind_src: BindingSource)
-        -> Result<symbol::SymbolKind, symbol::NotBinding>;
-
     /// Gets the corresponding definition from the given [`BindingSource`], or `None` if there isn't one.
     /// This also performs definition resolution, so resolving the resultant [`DefId`] is unnecessary.
     #[salsa::invoke(ty::query::binding_def)]

--- a/compiler/toc_analysis/src/ty/db.rs
+++ b/compiler/toc_analysis/src/ty/db.rs
@@ -41,9 +41,15 @@ pub trait TypeDatabase: TypeIntern + TypeInternExt {
     fn binding_to(&self, bind_src: BindingSource) -> Result<symbol::BindingTo, symbol::NotBinding>;
 
     /// Gets the corresponding definition from the given [`BindingSource`], or `None` if there isn't one.
-    /// No definition resolution is performed.
+    /// This also performs definition resolution, so resolving the resultant [`DefId`] is unnecessary.
     #[salsa::invoke(ty::query::binding_def)]
     fn binding_def(&self, bind_src: BindingSource) -> Option<DefId>;
+
+    /// Like [`Self::binding_def`], but does not perform definition resolution.
+    /// Unless looking at the immediate def is necessary (e.g. determining if it's an import),
+    /// then [`Self::binding_def`] should always be prefered.
+    #[salsa::invoke(ty::query::unresolved_binding_def)]
+    fn unresolved_binding_def(&self, bind_src: BindingSource) -> Option<DefId>;
 
     /// Gets the fields from the given [`FieldSource`]
     #[salsa::invoke(ty::query::fields_of)]

--- a/compiler/toc_analysis/src/ty/db.rs
+++ b/compiler/toc_analysis/src/ty/db.rs
@@ -323,7 +323,7 @@ impl NotValueErrExt for Result<ValueKind, NotValue> {
     }
 
     fn is_any_value(&self) -> bool {
-        matches!(self, Err(NotValue::NotValue))
+        !matches!(self, Err(NotValue::NotValue))
     }
 }
 

--- a/compiler/toc_analysis/src/ty/db.rs
+++ b/compiler/toc_analysis/src/ty/db.rs
@@ -38,7 +38,8 @@ pub trait TypeDatabase: TypeIntern + TypeInternExt {
 
     /// Gets what a [`BindingSource`] binds to, or a [`NotBinding`](symbol::NotBinding) if it isn't one.
     #[salsa::invoke(ty::query::binding_to)]
-    fn binding_to(&self, bind_src: BindingSource) -> Result<symbol::BindingTo, symbol::NotBinding>;
+    fn binding_to(&self, bind_src: BindingSource)
+        -> Result<symbol::SymbolKind, symbol::NotBinding>;
 
     /// Gets the corresponding definition from the given [`BindingSource`], or `None` if there isn't one.
     /// This also performs definition resolution, so resolving the resultant [`DefId`] is unnecessary.

--- a/compiler/toc_analysis/src/ty/lower.rs
+++ b/compiler/toc_analysis/src/ty/lower.rs
@@ -6,7 +6,7 @@ use toc_hir::{
     body, expr, item,
     library::{InLibrary, LibraryId, WrapInLibrary},
     stmt,
-    symbol::{self, BindingResultExt, BindingTo, DefId, LocalDefId},
+    symbol::{self, BindingResultExt, DefId, LocalDefId, SymbolKind},
     ty as hir_ty,
 };
 
@@ -101,7 +101,7 @@ fn alias_ty(
 
     if db
         .binding_to(def_id.into())
-        .map(BindingTo::is_type)
+        .map(SymbolKind::is_type)
         .or_missing()
     {
         // Defer to the type's definition
@@ -512,7 +512,7 @@ fn for_counter_ty(
                 // Must be a type alias
                 if !db
                     .binding_to(binding_def.into())
-                    .map(BindingTo::is_type)
+                    .map(SymbolKind::is_type)
                     .or_missing()
                 {
                     return db.mk_error();

--- a/compiler/toc_analysis/src/ty/lower.rs
+++ b/compiler/toc_analysis/src/ty/lower.rs
@@ -13,11 +13,7 @@ use toc_hir::{
 use crate::{
     const_eval::{Const, ConstInt},
     db::TypeDatabase,
-    ty::{
-        self,
-        db::{NotValueErrExt, ValueKind},
-        Checked, Param, TypeId, TypeKind,
-    },
+    ty::{self, db::NotValueErrExt, Checked, Param, TypeId, TypeKind},
 };
 
 use super::{AllowDyn, IntSize, NatSize, RealSize, SeqSize};
@@ -489,11 +485,7 @@ fn for_counter_ty(
             // - expr with an iterable ty (notably, arrays)
             let bounds_expr = (library_id, stmt_id.0, expr);
 
-            if db
-                .value_produced(bounds_expr.into())
-                .map(ValueKind::is_value)
-                .or_missing()
-            {
+            if db.value_produced(bounds_expr.into()).is_any_value() {
                 // - expr that may or may not be iterable
                 // We don't support for-each loops yet
                 // FIXME(new-features): Support for-each loop
@@ -509,7 +501,7 @@ fn for_counter_ty(
                 // Must be a type alias
                 if !db
                     .symbol_kind(binding_def)
-                    .or_is_missing(SymbolKind::is_type)
+                    .is_missing_or(SymbolKind::is_type)
                 {
                     return db.mk_error();
                 }

--- a/compiler/toc_analysis/src/ty/rules.rs
+++ b/compiler/toc_analysis/src/ty/rules.rs
@@ -1,6 +1,5 @@
 //! Rules for type interactions
 use toc_hir::library::LibraryId;
-use toc_hir::symbol::NotBinding;
 use toc_hir::{body, expr};
 use toc_reporting::MessageSink;
 use toc_span::Span;
@@ -1755,10 +1754,9 @@ fn report_not_value<'db, DB>(
     };
 
     let (binding_def, binding_to) = if let Some(def_id) = db.binding_def(binding_src) {
-        let binding_to = match db.binding_to(def_id.into()) {
-            Ok(binding_to) => binding_to,
-            Err(NotBinding::Missing) => return, // all values are accepted
-            Err(NotBinding::NotBinding) => unreachable!("from DefId"),
+        let binding_to = match db.symbol_kind(def_id) {
+            Some(binding_to) => binding_to,
+            None => return, // all values are accepted
         };
 
         (def_id, binding_to)

--- a/compiler/toc_analysis/src/typeck.rs
+++ b/compiler/toc_analysis/src/typeck.rs
@@ -510,7 +510,10 @@ impl TypeCheck<'_> {
         };
 
         let canon_def = self.db.resolve_def(DefId(self.library_id, item.def_id));
-        let real_mut = self.db.value_produced(canon_def.into()).expect("from def");
+        let real_mut = self
+            .db
+            .value_produced(canon_def.into())
+            .expect("from import def");
 
         match real_mut {
             ValueKind::Scalar => {
@@ -530,7 +533,7 @@ impl TypeCheck<'_> {
 
                     self.state()
                         .reporter
-                        .error_detailed(format!("cannot use `var` here"), attr_span)
+                        .error_detailed("cannot use `var` here", attr_span)
                         .with_error("`var` can only be applied to variables", attr_span)
                         .with_note(format!("`{name}` declared here"), def_at)
                         .finish()
@@ -827,11 +830,7 @@ impl TypeCheck<'_> {
                     .lookup_in(&self.library);
                 let in_module = db.inside_module(bounds_expr.into());
 
-                if db
-                    .value_produced(bounds_expr.into())
-                    .map(ValueKind::is_value)
-                    .or_missing()
-                {
+                if db.value_produced(bounds_expr.into()).is_any_value() {
                     // for-each loop
                     // These are not supported yet, until after 0.1 tagging
                     let bounds_ty = db.type_of(bounds_expr.into());
@@ -1366,7 +1365,7 @@ impl TypeCheck<'_> {
             // From an item
             (
                 db.type_of(def_id.into()),
-                db.symbol_kind(def_id).or_is_missing(SymbolKind::is_type),
+                db.symbol_kind(def_id).is_missing_or(SymbolKind::is_type),
             )
         } else {
             // From an actual expression
@@ -1722,10 +1721,7 @@ impl TypeCheck<'_> {
             let (matches_pass_by, mutability) = match param.pass_by {
                 ty::PassBy::Value => {
                     // Accept any expressions
-                    (
-                        arg_value.map(ValueKind::is_value).or_missing(),
-                        Mutability::Var,
-                    )
+                    (arg_value.is_any_value(), Mutability::Var)
                 }
                 ty::PassBy::Reference(mutability) => {
                     // Only accept storage locations
@@ -1733,7 +1729,8 @@ impl TypeCheck<'_> {
                         Mutability::Const => ValueKind::is_storage_backed,
                         Mutability::Var => ValueKind::is_storage_backed_mut,
                     };
-                    (arg_value.map(predicate).or_missing(), mutability)
+
+                    (arg_value.is_missing_or(predicate), mutability)
                 }
             };
 
@@ -1840,7 +1837,6 @@ impl TypeCheck<'_> {
             let actual_expr = library.body(body_id).expr(expr_id.2);
 
             let actual_ty = db.type_of(expr_id.into());
-            let actual_value = db.value_produced(expr_id.into());
             let actual_span = actual_expr.span.lookup_in(library);
 
             // Check that it isn't `all` or a range expr
@@ -1864,7 +1860,7 @@ impl TypeCheck<'_> {
                 _ => {}
             }
 
-            if !actual_value.map(ValueKind::is_value).or_missing() {
+            if !db.value_produced(expr_id.into()).is_any_value() {
                 self.report_mismatched_binding(
                     SymbolKind::ConstVar(Mutability::Var, IsRegister::No),
                     expr_id.into(),
@@ -2010,7 +2006,7 @@ impl TypeCheck<'_> {
             db.resolve_def(def_id)
         };
 
-        if !db.symbol_kind(def_id).or_is_missing(SymbolKind::is_type) {
+        if !db.symbol_kind(def_id).is_missing_or(SymbolKind::is_type) {
             let span = span.lookup_in(library);
 
             self.report_mismatched_binding(
@@ -2620,7 +2616,7 @@ impl TypeCheck<'_> {
         // "`{name}` is a reference to {binding_to}, not a variable" or "not a reference to a variable"
         // "`{name}` declared here"
 
-        let value_kind = self.db.value_produced(value_src);
+        let db = self.db;
         let predicate = match expected_kind {
             ExpectedValue::Value => ValueKind::is_value,
             ExpectedValue::Ref(Mutability::Const) => ValueKind::is_ref,
@@ -2628,121 +2624,118 @@ impl TypeCheck<'_> {
             ExpectedValue::NonRegisterRef(Mutability::Const) => ValueKind::is_storage_backed,
             ExpectedValue::NonRegisterRef(Mutability::Var) => ValueKind::is_storage_backed_mut,
         };
-        let is_valid = value_kind.map(predicate).or_missing();
-        let checking_for_value = matches!(expected_kind, ExpectedValue::Value);
 
-        if !is_valid {
-            let (thing, def_info) = match self.db.binding_def(value_src.into()) {
-                Some(unresolved_def) => {
-                    // From some def
-                    let def_id = self.db.resolve_def(unresolved_def);
-                    let binding_to = match self.db.symbol_kind(def_id.into()) {
-                        Some(binding_to) => binding_to,
-                        None => return true,
-                    };
-                    let def_library = self.db.library(def_id.0);
-                    let def_info = def_library.local_def(def_id.1);
-                    let name = def_info.name;
-                    let def_at = def_info.def_at.lookup_in(&def_library);
-
-                    (format!("`{name}`"), Some((def_id, def_at, binding_to)))
-                }
-                None => {
-                    // From expr
-                    ("expression".to_string(), None)
-                }
-            };
-
-            let mut state = self.state();
-            let mut builder = state.reporter.error_detailed(from_thing(&thing), report_at);
-
-            builder = if let Some((def_id, def_at, binding_to)) = def_info {
-                builder = if binding_to.is_ref_mut() {
-                    // Originally was mutable
-                    // Likely from an export or import
-
-                    // We want the unresolved version, since that's used for looking up the associated import
-                    // (already know that this produces a def, so it's fine to unwrap)
-                    let unresolved_def = self.db.unresolved_binding_def(value_src.into()).unwrap();
-
-                    // FIXME: Fold into `else` branch once we make export a real item
-                    if let Some(exporting_def) = self.db.exporting_def(value_src.into()) {
-                        let exported_library = self.db.library(exporting_def.0);
-                        let exported_span = exported_library
-                            .local_def(exporting_def.1)
-                            .def_at
-                            .lookup_in(&*exported_library);
-
-                        builder
-                            .with_error(format!("{thing} is not exported as `var`"), value_span)
-                            .with_note(format!("{thing} exported from here"), exported_span)
-                    } else {
-                        // Use unresolved def
-                        match self.db.def_owner(unresolved_def) {
-                            Some(DefOwner::Item(item_id)) => {
-                                let def_lib = self.db.library(def_id.0);
-
-                                match &def_lib.item(item_id).kind {
-                                    item::ItemKind::Import(import) => {
-                                        let imported_span = def_lib
-                                            .local_def(import.def_id)
-                                            .def_at
-                                            .lookup_in(&def_lib);
-
-                                        builder
-                                            .with_error(
-                                                format!("{thing} is not imported as `var`"),
-                                                value_span,
-                                            )
-                                            .with_note(
-                                                format!("{thing} imported from here"),
-                                                imported_span,
-                                            )
-                                    }
-                                    kind => unreachable!("not on an import or export: {kind:?}"),
-                                }
-                            }
-                            Some(owner) => unreachable!("not at item owner: {owner:?}"),
-                            None => unreachable!("def was undeclared but also mutable"),
-                        }
-                    }
-                } else {
-                    builder
-                        .with_error(
-                            format!("{thing} is a reference to {binding_to}, not a variable"),
-                            value_span,
-                        )
-                        .with_note(format!("{thing} declared here"), def_at)
-                };
-
-                if binding_to.is_type() && matches!(expected_kind, ExpectedValue::Value) {
-                    // Check if this is a set type
-                    let ty_ref = self.db.type_of(def_id.into()).in_db(self.db).to_base_type();
-
-                    if ty_ref.kind().is_set() {
-                        // Possibly trying to construct an empty set
-                        builder = builder.with_note(
-                            "to construct an empty set, add `()` after here",
-                            value_span,
-                        );
-                    }
-                }
-
-                builder
-            } else {
-                // Only in here when checking for references
-                debug_assert!(!checking_for_value);
-                builder.with_error("not a reference to a variable", value_span)
-            };
-
-            if let Some(extra) = additional_info {
-                builder = builder.with_info(extra);
-            }
-
-            builder.finish();
+        // Nothing extra needs to be done if the predicate is satisfied
+        if db.value_produced(value_src).is_missing_or(predicate) {
+            return true;
         }
 
-        is_valid
+        let (thing, def_info) = match db.binding_def(value_src.into()) {
+            Some(unresolved_def) => {
+                // From some def
+                let def_id = db.resolve_def(unresolved_def);
+                let binding_to = match db.symbol_kind(def_id) {
+                    Some(binding_to) => binding_to,
+                    None => return true,
+                };
+                let def_library = db.library(def_id.0);
+                let def_info = def_library.local_def(def_id.1);
+                let name = def_info.name;
+                let def_at = def_info.def_at.lookup_in(&def_library);
+
+                (format!("`{name}`"), Some((def_id, def_at, binding_to)))
+            }
+            None => {
+                // From expr
+                ("expression".to_string(), None)
+            }
+        };
+
+        let mut state = self.state();
+        let mut builder = state.reporter.error_detailed(from_thing(&thing), report_at);
+
+        builder = if let Some((def_id, def_at, binding_to)) = def_info {
+            builder = if binding_to.is_ref_mut() {
+                // Originally was mutable
+                // Likely from an export or import
+
+                // We want the unresolved version, since that's used for looking up the associated import
+                // (already know that this produces a def, so it's fine to unwrap)
+                let unresolved_def = db.unresolved_binding_def(value_src.into()).unwrap();
+
+                // FIXME: Fold into `else` branch once we make export a real item
+                if let Some(exporting_def) = db.exporting_def(value_src.into()) {
+                    let exported_library = db.library(exporting_def.0);
+                    let exported_span = exported_library
+                        .local_def(exporting_def.1)
+                        .def_at
+                        .lookup_in(&*exported_library);
+
+                    builder
+                        .with_error(format!("{thing} is not exported as `var`"), value_span)
+                        .with_note(format!("{thing} exported from here"), exported_span)
+                } else {
+                    // Use unresolved def
+                    match self.db.def_owner(unresolved_def) {
+                        Some(DefOwner::Item(item_id)) => {
+                            let def_lib = db.library(def_id.0);
+
+                            match &def_lib.item(item_id).kind {
+                                item::ItemKind::Import(import) => {
+                                    let imported_span =
+                                        def_lib.local_def(import.def_id).def_at.lookup_in(&def_lib);
+
+                                    builder
+                                        .with_error(
+                                            format!("{thing} is not imported as `var`"),
+                                            value_span,
+                                        )
+                                        .with_note(
+                                            format!("{thing} imported from here"),
+                                            imported_span,
+                                        )
+                                }
+                                kind => unreachable!("not on an import or export: {kind:?}"),
+                            }
+                        }
+                        Some(owner) => unreachable!("not at item owner: {owner:?}"),
+                        None => unreachable!("def was undeclared but also mutable"),
+                    }
+                }
+            } else {
+                builder
+                    .with_error(
+                        format!("{thing} is a reference to {binding_to}, not a variable"),
+                        value_span,
+                    )
+                    .with_note(format!("{thing} declared here"), def_at)
+            };
+
+            if binding_to.is_type() && matches!(expected_kind, ExpectedValue::Value) {
+                // Check if this is a set type
+                let ty_ref = db.type_of(def_id.into()).in_db(db).to_base_type();
+
+                if ty_ref.kind().is_set() {
+                    // Possibly trying to construct an empty set
+                    builder = builder
+                        .with_note("to construct an empty set, add `()` after here", value_span);
+                }
+            }
+
+            builder
+        } else {
+            // Only in here when checking for references
+            debug_assert!(!matches!(expected_kind, ExpectedValue::Value));
+            builder.with_error("not a reference to a variable", value_span)
+        };
+
+        if let Some(extra) = additional_info {
+            builder = builder.with_info(extra);
+        }
+
+        builder.finish();
+
+        false
     }
 
     fn expect_integer_value(&self, value_src: crate::db::ValueSource) -> bool {

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_array_param.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_array_param.snap
@@ -1,10 +1,8 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-assertion_line: 42
 expression: "type tp: proc(_ : array 1..2 of char(*))\nvar a : array 1..2 of char\nvar b : array 1..2 of char(42)\nvar p : tp\n\n% element type is also coercible\np(a)\np(b)\n"
-
 ---
-"<unnamed>"@(dummy) [Declared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "_"@(FileId(1), 14..15) [Declared]: <error>
 "tp"@(FileId(1), 5..7) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(2))] of procedure ( pass(value) array ( range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No)), ) of char_n Any, ) -> void
 "a"@(FileId(1), 45..46) [Declared]: array ( range of `int` (Unevaluated(LibraryId(0), BodyId(2)) .. Expr(Unevaluated(LibraryId(0), BodyId(3)), Yes)), ) of char

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_char_any_lhs.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_char_any_lhs.snap
@@ -1,11 +1,9 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-assertion_line: 42
 expression: "proc __(var c_any : char(*), var s_any : string(*), var _v00, _v01, _v02, _v03, _v04, _v05, _v06, _v07, _v08 : char(*))\n% all runtime checked\nvar c : char\nvar c1 : char(1)\nvar c5 : char(5)\nvar c255 : char(255)\nvar s : string\nvar s1 : string(1)\nvar s5 : string(5)\n\n_v00 := c\n_v01 := c1\n_v02 := c5\n_v03 := c255\n_v04 := c_any\n_v05 := s\n_v06 := s1\n_v07 := s5\n_v08 := s_any\nend __\n"
-
 ---
 "__"@(FileId(1), 5..7) [Declared]: procedure ( pass(var ref) char_n Any, pass(var ref) string_n Any, pass(var ref) char_n Any, pass(var ref) char_n Any, pass(var ref) char_n Any, pass(var ref) char_n Any, pass(var ref) char_n Any, pass(var ref) char_n Any, pass(var ref) char_n Any, pass(var ref) char_n Any, pass(var ref) char_n Any, ) -> void
-"<unnamed>"@(dummy) [Declared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "c_any"@(FileId(1), 12..17) [Declared]: char_n Any
 "s_any"@(FileId(1), 33..38) [Declared]: string_n Any
 "_v00"@(FileId(1), 56..60) [Declared]: char_n Any

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_char_any_rhs.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_char_any_rhs.snap
@@ -1,11 +1,9 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-assertion_line: 42
 expression: "% all runtime checked\nproc __(var s_any, _v09 : string(*), var c_any, _v05 : char(*))\n\nvar _v00 : char := c_any\nvar _v01 : char(1) := c_any\nvar _v02 : char(5) := c_any\nvar _v03 : char(255) := c_any\nvar _v04 : char(256) := c_any\n_v05 := c_any\nvar _v06 : string := c_any\nvar _v07 : string(1) := c_any\nvar _v08 : string(5) := c_any\n_v09 := c_any\nend __\n"
-
 ---
 "__"@(FileId(1), 27..29) [Declared]: procedure ( pass(var ref) string_n Any, pass(var ref) string_n Any, pass(var ref) char_n Any, pass(var ref) char_n Any, ) -> void
-"<unnamed>"@(dummy) [Declared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "s_any"@(FileId(1), 34..39) [Declared]: string_n Any
 "_v09"@(FileId(1), 41..45) [Declared]: string_n Any
 "c_any"@(FileId(1), 63..68) [Declared]: char_n Any

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_constrained_array_range.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_constrained_array_range.snap
@@ -1,10 +1,8 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-assertion_line: 42
 expression: "type tp : proc(var _ : array 1 .. * of int)\nvar a : array 1 .. 3 of int\nvar b : array 2 .. 3 of int\nvar p : tp\n\n% only coercible if start bound is the same\np(a) % success\np(b) % fail\n"
-
 ---
-"<unnamed>"@(dummy) [Declared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "_"@(FileId(1), 19..20) [Declared]: <error>
 "tp"@(FileId(1), 5..7) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(2))] of procedure ( pass(var ref) array ( range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Any), ) of int, ) -> void
 "a"@(FileId(1), 48..49) [Declared]: array ( range of `int` (Unevaluated(LibraryId(0), BodyId(1)) .. Expr(Unevaluated(LibraryId(0), BodyId(2)), Yes)), ) of int

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_dyn_array_param_err.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_dyn_array_param_err.snap
@@ -1,13 +1,11 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-assertion_line: 42
 expression: "% dyn arrays aren't allowed, since the range is expected to be known at compile-time\nvar c : int\nvar a : array 1..c of char\nproc p(_ : array 1..2 of char(*)) end p\n\np(a)\n"
-
 ---
 "c"@(FileId(1), 89..90) [Declared]: int
 "a"@(FileId(1), 101..102) [Declared]: array ( range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), Yes)), ) of char
 "p"@(FileId(1), 129..130) [Declared]: procedure ( pass(value) array ( range of `int` (Unevaluated(LibraryId(0), BodyId(2)) .. Expr(Unevaluated(LibraryId(0), BodyId(3)), No)), ) of char_n Any, ) -> void
-"<unnamed>"@(dummy) [Declared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "_"@(FileId(1), 131..132) [Declared]: array ( range of `int` (Unevaluated(LibraryId(0), BodyId(2)) .. Expr(Unevaluated(LibraryId(0), BodyId(3)), No)), ) of char_n Any
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_string_any_lhs.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_string_any_lhs.snap
@@ -1,11 +1,9 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-assertion_line: 42
 expression: "proc __(var c_any : char(*), var s_any : string(*), var _v00, _v01, _v02, _v03, _v04, _v05, _v06, _v07, _v08 : string(*))\n% all runtime checked\nvar c : char\nvar c1 : char(1)\nvar c5 : char(5)\nvar c255 : char(255)\nvar s : string\nvar s1 : string(1)\nvar s5 : string(5)\n\n_v00 := c\n_v01 := c1\n_v02 := c5\n_v03 := c255\n_v04 := c_any\n_v05 := s\n_v06 := s1\n_v07 := s5\n_v08 := s_any\nend __\n"
-
 ---
 "__"@(FileId(1), 5..7) [Declared]: procedure ( pass(var ref) char_n Any, pass(var ref) string_n Any, pass(var ref) string_n Any, pass(var ref) string_n Any, pass(var ref) string_n Any, pass(var ref) string_n Any, pass(var ref) string_n Any, pass(var ref) string_n Any, pass(var ref) string_n Any, pass(var ref) string_n Any, pass(var ref) string_n Any, ) -> void
-"<unnamed>"@(dummy) [Declared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "c_any"@(FileId(1), 12..17) [Declared]: char_n Any
 "s_any"@(FileId(1), 33..38) [Declared]: string_n Any
 "_v00"@(FileId(1), 56..60) [Declared]: string_n Any

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_string_any_rhs.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_string_any_rhs.snap
@@ -1,11 +1,9 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-assertion_line: 42
 expression: "% all runtime checked\nproc __(var s_any, _v09 : string(*), var c_any, _v05 : char(*))\n\nvar _v00 : char := s_any\nvar _v01 : char(1) := s_any\nvar _v02 : char(5) := s_any\nvar _v03 : char(255) := s_any\nvar _v04 : char(256) := s_any\n_v05 := s_any\nvar _v06 : string := s_any\nvar _v07 : string(1) := s_any\nvar _v08 : string(5) := s_any\n_v09 := s_any\nend __\n"
-
 ---
 "__"@(FileId(1), 27..29) [Declared]: procedure ( pass(var ref) string_n Any, pass(var ref) string_n Any, pass(var ref) char_n Any, pass(var ref) char_n Any, ) -> void
-"<unnamed>"@(dummy) [Declared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "s_any"@(FileId(1), 34..39) [Declared]: string_n Any
 "_v09"@(FileId(1), 41..45) [Declared]: string_n Any
 "c_any"@(FileId(1), 63..68) [Declared]: char_n Any

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_string_err_lhs.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_string_err_lhs.snap
@@ -1,12 +1,10 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-assertion_line: 42
 expression: "var cmx : char(256)\n\nproc __(var _e00 : string(*))\n_e00 := cmx % [not captured by ctc]\nend __\n"
-
 ---
 "cmx"@(FileId(1), 4..7) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
 "__"@(FileId(1), 26..28) [Declared]: procedure ( pass(var ref) string_n Any, ) -> void
-"<unnamed>"@(dummy) [Declared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "_e00"@(FileId(1), 33..37) [Declared]: string_n Any
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__equivalence_of_opaques.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__equivalence_of_opaques.snap
@@ -1,16 +1,14 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-assertion_line: 42
 expression: "module z\n    export unqualified opaque ty, unwrap, make\n\n    type ty : int\n\n    fcn unwrap(t : ty) : int\n        result t\n    end unwrap\n\n    fcn make(i : int) : ty\n        result i\n    end make\nend z\n\n% can't use path syntax since it isn't lowered yet\nvar a, b : ty\nvar c := z.make(1)\n\n% is equivalent to self\na := b\na := c\n\n% to the original alias def\nvar i : int := z.unwrap(a)\n\n% but not the alias type\ni := a\n"
-
 ---
 "z"@(FileId(1), 7..8) [Declared]: <error>
 "ty"@(FileId(1), 66..68) [Resolved(Type)]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
 "unwrap"@(FileId(1), 84..90) [Declared]: function ( pass(value) opaque[DefId(LibraryId(0), LocalDefId(1))] type to int, ) -> int
-"<unnamed>"@(dummy) [Declared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "t"@(FileId(1), 91..92) [Declared]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
 "make"@(FileId(1), 146..150) [Declared]: function ( pass(value) int, ) -> opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
-"<unnamed>"@(dummy) [Declared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "i"@(FileId(1), 151..152) [Declared]: int
 "ty"@(FileId(1), 39..41) [ItemExport(LocalDefId(1))]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
 "unwrap"@(FileId(1), 43..49) [ItemExport(LocalDefId(2))]: function ( pass(value) opaque[DefId(LibraryId(0), LocalDefId(1))] type to int, ) -> int

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__equivalence_of_subprogram_formals.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__equivalence_of_subprogram_formals.snap
@@ -1,16 +1,14 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-assertion_line: 41
 expression: "type t_p : procedure(a, b : int, var c : string)\nprocedure p(a, b : int, var c : string) end p\n\nvar _ : t_p := p\n"
-
 ---
-"<unnamed>"@(dummy) [Declared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "a"@(FileId(1), 21..22) [Declared]: <error>
 "b"@(FileId(1), 24..25) [Declared]: <error>
 "c"@(FileId(1), 37..38) [Declared]: <error>
 "t_p"@(FileId(1), 5..8) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(4))] of procedure ( pass(value) int, pass(value) int, pass(var ref) string, ) -> void
 "p"@(FileId(1), 59..60) [Declared]: procedure ( pass(value) int, pass(value) int, pass(var ref) string, ) -> void
-"<unnamed>"@(dummy) [Declared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "a"@(FileId(1), 61..62) [Declared]: int
 "b"@(FileId(1), 64..65) [Declared]: int
 "c"@(FileId(1), 77..78) [Declared]: string

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__equivalence_of_subprogram_formals_bare.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__equivalence_of_subprogram_formals_bare.snap
@@ -1,14 +1,12 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-assertion_line: 41
 expression: "type t_f : function : int\ntype t_p : procedure\ntype t_fp : function() : int\ntype t_pp : procedure()\n\nvar f : t_f\nvar p : t_p\nvar fp : t_fp\nvar pp : t_pp\n\n% transitive\nf := fp\nfp := f\n\np := pp\npp := p\n"
-
 ---
 "t_f"@(FileId(1), 5..8) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of function -> int
 "t_p"@(FileId(1), 31..34) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(1))] of procedure -> void
-"<unnamed>"@(dummy) [Declared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "t_fp"@(FileId(1), 52..56) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(3))] of function ( ) -> int
-"<unnamed>"@(dummy) [Declared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "t_pp"@(FileId(1), 81..85) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(5))] of procedure ( ) -> void
 "f"@(FileId(1), 105..106) [Declared]: alias[DefId(LibraryId(0), LocalDefId(0))] of function -> int
 "p"@(FileId(1), 117..118) [Declared]: alias[DefId(LibraryId(0), LocalDefId(1))] of procedure -> void

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__equivalence_of_subprogram_formals_cheat.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__equivalence_of_subprogram_formals_cheat.snap
@@ -1,15 +1,13 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-assertion_line: 41
 expression: "type t_f : function(a, b : int, var c : string) : int\ntype t_fc : function(a, b : cheat int, var c : cheat string) : int\nvar f : t_f\nvar fc : t_fc\n\n% transitive\nf := fc\nfc := f\n"
-
 ---
-"<unnamed>"@(dummy) [Declared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "a"@(FileId(1), 20..21) [Declared]: <error>
 "b"@(FileId(1), 23..24) [Declared]: <error>
 "c"@(FileId(1), 36..37) [Declared]: <error>
 "t_f"@(FileId(1), 5..8) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(4))] of function ( pass(value) int, pass(value) int, pass(var ref) string, ) -> int
-"<unnamed>"@(dummy) [Declared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "a"@(FileId(1), 75..76) [Declared]: <error>
 "b"@(FileId(1), 78..79) [Declared]: <error>
 "c"@(FileId(1), 97..98) [Declared]: <error>

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__equivalence_of_subprogram_formals_err_not_var.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__equivalence_of_subprogram_formals_err_not_var.snap
@@ -1,16 +1,14 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-assertion_line: 41
 expression: "type t_p : procedure(a, b : int, var c : string)\nprocedure p(a, b : int, c : string) end p\n\nvar _ : t_p := p\n"
-
 ---
-"<unnamed>"@(dummy) [Declared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "a"@(FileId(1), 21..22) [Declared]: <error>
 "b"@(FileId(1), 24..25) [Declared]: <error>
 "c"@(FileId(1), 37..38) [Declared]: <error>
 "t_p"@(FileId(1), 5..8) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(4))] of procedure ( pass(value) int, pass(value) int, pass(var ref) string, ) -> void
 "p"@(FileId(1), 59..60) [Declared]: procedure ( pass(value) int, pass(value) int, pass(value) string, ) -> void
-"<unnamed>"@(dummy) [Declared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "a"@(FileId(1), 61..62) [Declared]: int
 "b"@(FileId(1), 64..65) [Declared]: int
 "c"@(FileId(1), 73..74) [Declared]: string

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__equivalence_of_subprogram_formals_err_too_few.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__equivalence_of_subprogram_formals_err_too_few.snap
@@ -1,16 +1,14 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-assertion_line: 41
 expression: "type t_p : procedure(a, b : int, var c : string)\nprocedure p(a : int, var c : string) end p\n\nvar _ : t_p := p\n"
-
 ---
-"<unnamed>"@(dummy) [Declared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "a"@(FileId(1), 21..22) [Declared]: <error>
 "b"@(FileId(1), 24..25) [Declared]: <error>
 "c"@(FileId(1), 37..38) [Declared]: <error>
 "t_p"@(FileId(1), 5..8) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(4))] of procedure ( pass(value) int, pass(value) int, pass(var ref) string, ) -> void
 "p"@(FileId(1), 59..60) [Declared]: procedure ( pass(value) int, pass(var ref) string, ) -> void
-"<unnamed>"@(dummy) [Declared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "a"@(FileId(1), 61..62) [Declared]: int
 "c"@(FileId(1), 74..75) [Declared]: string
 "_"@(FileId(1), 97..98) [Declared]: alias[DefId(LibraryId(0), LocalDefId(4))] of procedure ( pass(value) int, pass(value) int, pass(var ref) string, ) -> void

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__equivalence_of_subprogram_formals_err_too_many.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__equivalence_of_subprogram_formals_err_too_many.snap
@@ -1,16 +1,14 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-assertion_line: 41
 expression: "type t_p : procedure(a, b : int, var c : string)\nprocedure p(a, b, k : int, var c : string) end p\n\nvar _ : t_p := p\n"
-
 ---
-"<unnamed>"@(dummy) [Declared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "a"@(FileId(1), 21..22) [Declared]: <error>
 "b"@(FileId(1), 24..25) [Declared]: <error>
 "c"@(FileId(1), 37..38) [Declared]: <error>
 "t_p"@(FileId(1), 5..8) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(4))] of procedure ( pass(value) int, pass(value) int, pass(var ref) string, ) -> void
 "p"@(FileId(1), 59..60) [Declared]: procedure ( pass(value) int, pass(value) int, pass(value) int, pass(var ref) string, ) -> void
-"<unnamed>"@(dummy) [Declared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "a"@(FileId(1), 61..62) [Declared]: int
 "b"@(FileId(1), 64..65) [Declared]: int
 "k"@(FileId(1), 67..68) [Declared]: int

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__equivalence_of_subprogram_formals_register.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__equivalence_of_subprogram_formals_register.snap
@@ -1,15 +1,13 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-assertion_line: 41
 expression: "type t_f : function(a, b : int, var c : string) : int\ntype t_fr : function(register a, b : int, var register c : string) : int\nvar f : t_f\nvar fc : t_fr\n\n% transitive\nf := fc\nfc := f\n"
-
 ---
-"<unnamed>"@(dummy) [Declared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "a"@(FileId(1), 20..21) [Declared]: <error>
 "b"@(FileId(1), 23..24) [Declared]: <error>
 "c"@(FileId(1), 36..37) [Declared]: <error>
 "t_f"@(FileId(1), 5..8) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(4))] of function ( pass(value) int, pass(value) int, pass(var ref) string, ) -> int
-"<unnamed>"@(dummy) [Declared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "a"@(FileId(1), 84..85) [Declared]: <error>
 "b"@(FileId(1), 87..88) [Declared]: <error>
 "c"@(FileId(1), 109..110) [Declared]: <error>

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__equivalence_of_subprogram_result.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__equivalence_of_subprogram_result.snap
@@ -1,13 +1,11 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-assertion_line: 41
 expression: "type fa : function () : int\nfunction fb () : int end fb\n\nvar _ : fa := fb\n"
-
 ---
-"<unnamed>"@(dummy) [Declared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "fa"@(FileId(1), 5..7) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(1))] of function ( ) -> int
 "fb"@(FileId(1), 37..39) [Declared]: function ( ) -> int
-"<unnamed>"@(dummy) [Declared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "_"@(FileId(1), 61..62) [Declared]: alias[DefId(LibraryId(0), LocalDefId(1))] of function ( ) -> int
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__equivalence_of_subprogram_result_err.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__equivalence_of_subprogram_result_err.snap
@@ -1,13 +1,11 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-assertion_line: 41
 expression: "type fa : function () : int1\nfunction fb () : int end fb\n\nvar _ : fa := fb\n"
-
 ---
-"<unnamed>"@(dummy) [Declared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "fa"@(FileId(1), 5..7) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(1))] of function ( ) -> int1
 "fb"@(FileId(1), 38..40) [Declared]: function ( ) -> int
-"<unnamed>"@(dummy) [Declared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "_"@(FileId(1), 62..63) [Declared]: alias[DefId(LibraryId(0), LocalDefId(1))] of function ( ) -> int1
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__report_aliased_type_in_subprog_ty.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__report_aliased_type_in_subprog_ty.snap
@@ -1,14 +1,12 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-assertion_line: 42
 expression: "type i : int\ntype am_in : real\ntype misery : char(*)\ntype eat_em_up : string\ntype f : function(c : i, p : am_in, r : misery) : eat_em_up\n\nvar y : f\nvar _ : int := y\n"
-
 ---
 "i"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of int
 "am_in"@(FileId(1), 18..23) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(1))] of real
 "misery"@(FileId(1), 36..42) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(2))] of char_n Any
 "eat_em_up"@(FileId(1), 58..67) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(3))] of string
-"<unnamed>"@(dummy) [Declared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "c"@(FileId(1), 95..96) [Declared]: <error>
 "p"@(FileId(1), 102..103) [Declared]: <error>
 "r"@(FileId(1), 113..114) [Declared]: <error>

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__require_positive_size_in_subprogram_param.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__require_positive_size_in_subprogram_param.snap
@@ -1,11 +1,9 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-assertion_line: 42
 expression: "proc p(_:1..0) end p"
-
 ---
 "p"@(FileId(1), 5..6) [Declared]: procedure ( pass(value) range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No)), ) -> void
-"<unnamed>"@(dummy) [Declared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "_"@(FileId(1), 7..8) [Declared]: range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No))
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__require_positive_size_in_subprogram_result.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__require_positive_size_in_subprogram_result.snap
@@ -1,11 +1,9 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-assertion_line: 42
 expression: "fcn _() : 1..0 end _"
-
 ---
 "_"@(FileId(1), 4..5) [Declared]: function ( ) -> range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No))
-"<unnamed>"@(dummy) [Declared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 10..14: element range is too small

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__require_positive_size_in_subprogram_ty_param.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__require_positive_size_in_subprogram_ty_param.snap
@@ -1,10 +1,8 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-assertion_line: 42
 expression: "type _ : proc p(_:1..0)"
-
 ---
-"<unnamed>"@(dummy) [Declared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "_"@(FileId(1), 16..17) [Declared]: <error>
 "_"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(2))] of procedure ( pass(value) range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No)), ) -> void
 "<root>"@(dummy) [Declared]: <error>

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__require_positive_size_in_subprogram_ty_result.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__require_positive_size_in_subprogram_ty_result.snap
@@ -1,10 +1,8 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-assertion_line: 42
 expression: "type _ : fcn _() : 1..0"
-
 ---
-"<unnamed>"@(dummy) [Declared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "_"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(1))] of function ( ) -> range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No))
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__string_manip_op_concat.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__string_manip_op_concat.snap
@@ -1,11 +1,9 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-assertion_line: 42
 expression: "\n    proc __ (var c_any : char(*), var s_any : string(*))\n    var c : char\n    var c_sz : char(6)\n    var s : string\n    var s_sz : string(6)\n\n    % special cases first\n    var _t00 := c + c\n    var _t02 := c + c_sz\n    var _t20 := c_sz + c\n    var _t22 := c_sz + c_sz\n\n    % the rest of them down here (should produce string)\n    var _t01 := c + c_any\n    var _t03 := c + s\n    var _t04 := c + s_any\n    var _t05 := c + s_sz\n\n    var _t10 := c_any + c\n    var _t30 := s + c\n    var _t40 := s_any + c\n    var _t50 := s_sz + c\n\n    var _t11 := c_any + c_any\n    var _t12 := c_any + c_sz\n    var _t13 := c_any + s\n    var _t14 := c_any + s_any\n    var _t15 := c_any + s_sz\n\n    var _t21 := c_sz + c_any\n    var _t31 := s + c_any\n    var _t41 := s_any + c_any\n    var _t51 := s_sz + c_any\n\n    var _t23 := c_sz + s\n    var _t24 := c_sz + s_any\n    var _t25 := c_sz + s_sz\n\n    var _t32 := s + c_sz\n    var _t42 := s_any + c_sz\n    var _t52 := s_sz + c_sz\n\n    var _t33 := s + s\n    var _t34 := s + s_any\n    var _t35 := s + s_sz\n\n    var _t43 := s_any + s\n    var _t53 := s_sz + s\n\n    var _t44 := s_any + s_any\n    var _t45 := s_any + s_sz\n\n    var _t54 := s_sz + s_any\n\n    var _t55 := s_sz + s_sz\n    end __\n    "
-
 ---
 "__"@(FileId(1), 10..12) [Declared]: procedure ( pass(var ref) char_n Any, pass(var ref) string_n Any, ) -> void
-"<unnamed>"@(dummy) [Declared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "c_any"@(FileId(1), 18..23) [Declared]: char_n Any
 "s_any"@(FileId(1), 39..44) [Declared]: string_n Any
 "c"@(FileId(1), 66..67) [Declared]: char

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__string_manip_op_wrong_type_concat.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__string_manip_op_wrong_type_concat.snap
@@ -1,11 +1,9 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-assertion_line: 42
 expression: "\n    proc __ (var c_any : char(*), var s_any : string(*))\n    var c : char\n    var c_sz : char(6)\n    var s : string\n    var s_sz : string(6)\n    var i : int\n\n    var _e00 := c + i\n    var _e01 := c_any + i\n    var _e02 := c_sz + i\n    var _e03 := s + i\n    var _e04 := s_any + i\n    var _e05 := s_sz + i\n\n    var _e10 := i + c\n    var _e11 := i + c_any\n    var _e12 := i + c_sz\n    var _e13 := i + s\n    var _e14 := i + s_any\n    var _e15 := i + s_sz\n\n    % TODO: Uncomment to verify incompatible types\n    /*\n    var _e20 : char(13) := c_sz + c_sz\n    var _e21 : char(8) := c_sz + c\n    var _e22 : char(8) := c + c_sz\n    var _e23 : char(3) := c + c\n    var _e24 : char := c + c\n    */\n    end __\n    "
-
 ---
 "__"@(FileId(1), 10..12) [Declared]: procedure ( pass(var ref) char_n Any, pass(var ref) string_n Any, ) -> void
-"<unnamed>"@(dummy) [Declared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "c_any"@(FileId(1), 18..23) [Declared]: char_n Any
 "s_any"@(FileId(1), 39..44) [Declared]: string_n Any
 "c"@(FileId(1), 66..67) [Declared]: char

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_import_decl_const_on_never_applicable.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_import_decl_const_on_never_applicable.snap
@@ -1,0 +1,13 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+expression: "type ty : int\nmodule _\n    import const ty\n    type tou : ty\nend _\n"
+---
+"ty"@(FileId(1), 5..7) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of int
+"_"@(FileId(1), 21..22) [Declared]: <error>
+"ty"@(FileId(1), 40..42) [ItemImport(LocalDefId(0))]: alias[DefId(LibraryId(0), LocalDefId(0))] of int
+"tou"@(FileId(1), 52..55) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(3))] of int
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 34..39: cannot use `const` here
+| error in file FileId(1) for 34..39: `const` can only be applied to variables
+| note in file FileId(1) for 5..7: `ty` declared here

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_import_decl_implied_on_never_applicable.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_import_decl_implied_on_never_applicable.snap
@@ -1,0 +1,10 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+expression: "type ty : int\nmodule _\n    import ty\n    type tou : ty\nend _\n"
+---
+"ty"@(FileId(1), 5..7) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of int
+"_"@(FileId(1), 21..22) [Declared]: <error>
+"ty"@(FileId(1), 34..36) [ItemImport(LocalDefId(0))]: alias[DefId(LibraryId(0), LocalDefId(0))] of int
+"tou"@(FileId(1), 46..49) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(3))] of int
+"<root>"@(dummy) [Declared]: <error>
+

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_import_decl_mutable_on_never_applicable.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_import_decl_mutable_on_never_applicable.snap
@@ -1,0 +1,13 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+expression: "type ty : int\nmodule _\n    import var ty\n    type tou : ty\nend _\n"
+---
+"ty"@(FileId(1), 5..7) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of int
+"_"@(FileId(1), 21..22) [Declared]: <error>
+"ty"@(FileId(1), 38..40) [ItemImport(LocalDefId(0))]: alias[DefId(LibraryId(0), LocalDefId(0))] of int
+"tou"@(FileId(1), 50..53) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(3))] of int
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 34..37: cannot use `var` here
+| error in file FileId(1) for 34..37: `var` can only be applied to variables
+| note in file FileId(1) for 5..7: `ty` declared here

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_module_field_unqualified_export_lhs_not_mut.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_module_field_unqualified_export_lhs_not_mut.snap
@@ -1,0 +1,14 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+expression: "% crashed because we we weren't poking through resolution\nmodule indirection\n    export ~. lhs\n    module lhs\n        export field\n        var field : int\n    end lhs\nend indirection\n\n% triggers `exporting_def` with an indirect lhs def\nlhs.field := 6\n"
+---
+"indirection"@(FileId(1), 65..76) [Declared]: <error>
+"lhs"@(FileId(1), 106..109) [Declared]: <error>
+"field"@(FileId(1), 143..148) [Declared]: int
+"field"@(FileId(1), 125..130) [ItemExport(LocalDefId(2))]: int
+"lhs"@(FileId(1), 91..94) [ItemExport(LocalDefId(1))]: <error>
+"<root>"@(dummy) [Declared]: <error>
+
+error in file FileId(1) at 246..248: cannot assign into `field`
+| error in file FileId(1) for 236..245: `field` is not exported as `var`
+| note in file FileId(1) for 125..130: `field` exported from here

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_opaque_ty_outside_module.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_opaque_ty_outside_module.snap
@@ -1,13 +1,11 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-assertion_line: 42
 expression: "module k\n    export opaque ~.* t, f\n\n    type t : int\n\n    fcn f() : t loop end loop end f\nend k\n\nvar a : t\nvar b := k.f()\nvar c : k.t\n"
-
 ---
 "k"@(FileId(1), 7..8) [Declared]: <error>
 "t"@(FileId(1), 46..47) [Resolved(Type)]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
 "f"@(FileId(1), 63..64) [Declared]: function ( ) -> opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
-"<unnamed>"@(dummy) [Declared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "t"@(FileId(1), 31..32) [ItemExport(LocalDefId(1))]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
 "f"@(FileId(1), 34..35) [ItemExport(LocalDefId(2))]: function ( ) -> opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
 "a"@(FileId(1), 102..103) [Declared]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_opaque_ty_poke_opaque_call_param.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_opaque_ty_poke_opaque_call_param.snap
@@ -1,13 +1,11 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-assertion_line: 42
 expression: "module m\n    export opaque t, a, p\n    type t : int\n    proc p(a : t) end p\n    var a : t\n\n    % should be coercible\n    m.p(a)\n    m.p(69)\nend m\n\n% should be fine\nvar a := m.a\nm.p(a)\n% shouldn't be fine\nm.p(2)\n"
-
 ---
 "m"@(FileId(1), 7..8) [Declared]: <error>
 "t"@(FileId(1), 44..45) [Resolved(Type)]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
 "p"@(FileId(1), 61..62) [Declared]: procedure ( pass(value) opaque[DefId(LibraryId(0), LocalDefId(1))] type to int, ) -> void
-"<unnamed>"@(dummy) [Declared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "a"@(FileId(1), 63..64) [Declared]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
 "a"@(FileId(1), 84..85) [Declared]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
 "t"@(FileId(1), 27..28) [ItemExport(LocalDefId(1))]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_opaque_ty_poke_opaque_call_parens.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_opaque_ty_poke_opaque_call_parens.snap
@@ -1,13 +1,11 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-assertion_line: 42
 expression: "module m\n    export opaque t, f\n    type t : int\n    fcn f() : t loop end loop end f\n\n    var a : int := f()\nend m\n\n% should fail\nvar b : int := m.f()\n"
-
 ---
 "m"@(FileId(1), 7..8) [Declared]: <error>
 "t"@(FileId(1), 41..42) [Resolved(Type)]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
 "f"@(FileId(1), 57..58) [Declared]: function ( ) -> opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
-"<unnamed>"@(dummy) [Declared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "a"@(FileId(1), 94..95) [Declared]: int
 "t"@(FileId(1), 27..28) [ItemExport(LocalDefId(1))]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
 "f"@(FileId(1), 30..31) [ItemExport(LocalDefId(2))]: function ( ) -> opaque[DefId(LibraryId(0), LocalDefId(1))] type to int

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_opaque_ty_poke_opaque_result.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_opaque_ty_poke_opaque_result.snap
@@ -1,16 +1,14 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-assertion_line: 42
 expression: "module m\n    export opaque ~.* t\n    type t : int\n\n    % should be equivalent\n    fcn f() : t result 2 end f\nend m\n\n% should fail\nfcn k() : t result 2 end k\n"
-
 ---
 "m"@(FileId(1), 7..8) [Declared]: <error>
 "t"@(FileId(1), 42..43) [Resolved(Type)]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
 "f"@(FileId(1), 86..87) [Declared]: function ( ) -> opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
-"<unnamed>"@(dummy) [Declared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "t"@(FileId(1), 31..32) [ItemExport(LocalDefId(1))]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
 "k"@(FileId(1), 134..135) [Declared]: function ( ) -> opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
-"<unnamed>"@(dummy) [Declared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 149..150: mismatched types

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_opaque_ty_poke_opaque_set_cons_param.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_opaque_ty_poke_opaque_set_cons_param.snap
@@ -1,15 +1,13 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-assertion_line: 42
 expression: "module m\n    export opaque t, ~.* s, make\n    type t : char\n    type s : set of t\n\n    fcn make(c : char) : t\n        result c\n    end mk\n\n    % both should succeed\n    var a : s := s('6', '9')\n    a := s(make('i'))\nend m\n\n% should fail\nvar vs : s := s('i')\n% should succeed\nvs := s(m.make('i'))\n"
-
 ---
 "m"@(FileId(1), 7..8) [Declared]: <error>
 "t"@(FileId(1), 51..52) [Resolved(Type)]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
 "s"@(FileId(1), 73..81) [Declared]: <error>
 "s"@(FileId(1), 69..70) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(2))] of opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
 "make"@(FileId(1), 91..95) [Declared]: function ( pass(value) char, ) -> opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
-"<unnamed>"@(dummy) [Declared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "c"@(FileId(1), 96..97) [Declared]: char
 "a"@(FileId(1), 173..174) [Declared]: set[DefId(LibraryId(0), LocalDefId(2))] of opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
 "t"@(FileId(1), 27..28) [ItemExport(LocalDefId(1))]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to char

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_opaque_ty_poke_opaque_set_elem_ty.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_opaque_ty_poke_opaque_set_elem_ty.snap
@@ -1,15 +1,13 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-assertion_line: 42
 expression: "module m\n    export opaque ~.* t, ~.* s, make\n    type t : char\n    type s : set of t\n    fcn make(c : char) : t result c end make\nend m\n\n% both should fail, is strictly opaque\ntype xs : set of t\nvar vs : s := s('i')\n\n% should succeed\nvar _ : boolean := m.make('i') in vs\n"
-
 ---
 "m"@(FileId(1), 7..8) [Declared]: <error>
 "t"@(FileId(1), 55..56) [Resolved(Type)]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
 "s"@(FileId(1), 77..85) [Declared]: <error>
 "s"@(FileId(1), 73..74) [Resolved(Type)]: set[DefId(LibraryId(0), LocalDefId(2))] of opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
 "make"@(FileId(1), 94..98) [Declared]: function ( pass(value) char, ) -> opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
-"<unnamed>"@(dummy) [Declared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "c"@(FileId(1), 99..100) [Declared]: char
 "t"@(FileId(1), 31..32) [ItemExport(LocalDefId(1))]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
 "s"@(FileId(1), 38..39) [ItemExport(LocalDefId(3))]: set[DefId(LibraryId(0), LocalDefId(2))] of opaque[DefId(LibraryId(0), LocalDefId(1))] type to char

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_args_err_cheat_ty.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_args_err_cheat_ty.snap
@@ -1,12 +1,10 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-assertion_line: 41
 expression: "var tree : string\nprocedure boop(a, b : cheat int, var c : cheat int) end boop\nboop(\"tree\", tree, tree)\n"
-
 ---
 "tree"@(FileId(1), 4..8) [Declared]: string
 "boop"@(FileId(1), 28..32) [Declared]: procedure ( pass(value) cheat int, pass(value) cheat int, pass(var ref) cheat int, ) -> void
-"<unnamed>"@(dummy) [Declared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "a"@(FileId(1), 33..34) [Declared]: int
 "b"@(FileId(1), 36..37) [Declared]: int
 "c"@(FileId(1), 55..56) [Declared]: int

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_args_err_few.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_args_err_few.snap
@@ -1,11 +1,9 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-assertion_line: 41
 expression: "procedure boop(a, b, c : int) end boop\nboop(1, 2)\nboop(1)\n"
-
 ---
 "boop"@(FileId(1), 10..14) [Declared]: procedure ( pass(value) int, pass(value) int, pass(value) int, ) -> void
-"<unnamed>"@(dummy) [Declared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "a"@(FileId(1), 15..16) [Declared]: int
 "b"@(FileId(1), 18..19) [Declared]: int
 "c"@(FileId(1), 21..22) [Declared]: int

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_args_err_many.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_args_err_many.snap
@@ -1,11 +1,9 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-assertion_line: 41
 expression: "procedure boop(a, b, c : int) end boop\nboop(1, 2, 3, 4)\nboop(1, 2, 3, 4, 5)\n"
-
 ---
 "boop"@(FileId(1), 10..14) [Declared]: procedure ( pass(value) int, pass(value) int, pass(value) int, ) -> void
-"<unnamed>"@(dummy) [Declared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "a"@(FileId(1), 15..16) [Declared]: int
 "b"@(FileId(1), 18..19) [Declared]: int
 "c"@(FileId(1), 21..22) [Declared]: int

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_args_err_missing.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_args_err_missing.snap
@@ -1,11 +1,9 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-assertion_line: 42
-expression: "procedure boop(a : int) end boop\nboop(())\n"
-
+expression: "procedure boop(a : int) end boop\n% shouldn't die, not reporting an error is fine\nboop(())\n"
 ---
 "boop"@(FileId(1), 10..14) [Declared]: procedure ( pass(value) int, ) -> void
-"<unnamed>"@(dummy) [Declared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "a"@(FileId(1), 15..16) [Declared]: int
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_args_err_not_expr.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_args_err_not_expr.snap
@@ -1,12 +1,10 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-assertion_line: 42
 expression: "type a : int\nprocedure boop(a, b : int, var c : int) end boop\nboop(1, a, a)\n"
-
 ---
 "a"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of int
 "boop"@(FileId(1), 23..27) [Declared]: procedure ( pass(value) int, pass(value) int, pass(var ref) int, ) -> void
-"<unnamed>"@(dummy) [Declared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "a"@(FileId(1), 28..29) [Declared]: int
 "b"@(FileId(1), 31..32) [Declared]: int
 "c"@(FileId(1), 44..45) [Declared]: int

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_args_err_wrong_binding.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_args_err_wrong_binding.snap
@@ -1,11 +1,9 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-assertion_line: 41
 expression: "procedure boop(a, b : int, var c : int) end boop\nboop(1, 2, 3)\n"
-
 ---
 "boop"@(FileId(1), 10..14) [Declared]: procedure ( pass(value) int, pass(value) int, pass(var ref) int, ) -> void
-"<unnamed>"@(dummy) [Declared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "a"@(FileId(1), 15..16) [Declared]: int
 "b"@(FileId(1), 18..19) [Declared]: int
 "c"@(FileId(1), 31..32) [Declared]: int

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_args_err_wrong_ty.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_args_err_wrong_ty.snap
@@ -1,12 +1,10 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-assertion_line: 41
 expression: "var tree : string\nprocedure boop(a, b : int, var c : int) end boop\nboop(1, 2, tree)\n"
-
 ---
 "tree"@(FileId(1), 4..8) [Declared]: string
 "boop"@(FileId(1), 28..32) [Declared]: procedure ( pass(value) int, pass(value) int, pass(var ref) int, ) -> void
-"<unnamed>"@(dummy) [Declared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "a"@(FileId(1), 33..34) [Declared]: int
 "b"@(FileId(1), 36..37) [Declared]: int
 "c"@(FileId(1), 49..50) [Declared]: int

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_args_exact.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_args_exact.snap
@@ -1,12 +1,10 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-assertion_line: 41
 expression: "var tree : int\nprocedure boop(a, b : int, var c : int) end boop\nboop(1, 2, tree)\n"
-
 ---
 "tree"@(FileId(1), 4..8) [Declared]: int
 "boop"@(FileId(1), 25..29) [Declared]: procedure ( pass(value) int, pass(value) int, pass(var ref) int, ) -> void
-"<unnamed>"@(dummy) [Declared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "a"@(FileId(1), 30..31) [Declared]: int
 "b"@(FileId(1), 33..34) [Declared]: int
 "c"@(FileId(1), 46..47) [Declared]: int

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_as_expr.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_as_expr.snap
@@ -1,11 +1,9 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-assertion_line: 41
 expression: "function key() : int end key\nvar res := key()\n"
-
 ---
 "key"@(FileId(1), 9..12) [Declared]: function ( ) -> int
-"<unnamed>"@(dummy) [Declared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "res"@(FileId(1), 33..36) [Declared]: int
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_as_expr_err.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_as_expr_err.snap
@@ -1,11 +1,9 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-assertion_line: 41
 expression: "procedure lime() end lime\nvar res := lime()\n"
-
 ---
 "lime"@(FileId(1), 10..14) [Declared]: procedure ( ) -> void
-"<unnamed>"@(dummy) [Declared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "res"@(FileId(1), 30..33) [Declared]: <error>
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_as_stmt.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_as_stmt.snap
@@ -1,12 +1,10 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-assertion_line: 41
 expression: "function key() : int end key\nprocedure lime() end lime\nkey() lime()\n"
-
 ---
 "key"@(FileId(1), 9..12) [Declared]: function ( ) -> int
-"<unnamed>"@(dummy) [Declared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "lime"@(FileId(1), 39..43) [Declared]: procedure ( ) -> void
-"<unnamed>"@(dummy) [Declared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_as_stmt_err.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_as_stmt_err.snap
@@ -1,13 +1,11 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-assertion_line: 41
 expression: "function key() : int end key\nprocedure lime() end lime\n% can't be used like this, need paren\nkey lime\n"
-
 ---
 "key"@(FileId(1), 9..12) [Declared]: function ( ) -> int
-"<unnamed>"@(dummy) [Declared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "lime"@(FileId(1), 39..43) [Declared]: procedure ( ) -> void
-"<unnamed>"@(dummy) [Declared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "<root>"@(dummy) [Declared]: <error>
 
 error in file FileId(1) at 93..96: cannot use `key` as a statement

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_coerce_ref_arg_char_any.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_coerce_ref_arg_char_any.snap
@@ -1,11 +1,9 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-assertion_line: 42
 expression: "procedure p(var a : char(*)) end p\nvar c : char\nvar cs : char(6)\np(c) p(cs)\n"
-
 ---
 "p"@(FileId(1), 10..11) [Declared]: procedure ( pass(var ref) char_n Any, ) -> void
-"<unnamed>"@(dummy) [Declared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "a"@(FileId(1), 16..17) [Declared]: char_n Any
 "c"@(FileId(1), 39..40) [Declared]: char
 "cs"@(FileId(1), 52..54) [Declared]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_coerce_ref_arg_char_any_err.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_coerce_ref_arg_char_any_err.snap
@@ -1,11 +1,9 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-assertion_line: 42
 expression: "procedure p(var a : char(*)) end p\nvar c : string\np(c)\n"
-
 ---
 "p"@(FileId(1), 10..11) [Declared]: procedure ( pass(var ref) char_n Any, ) -> void
-"<unnamed>"@(dummy) [Declared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "a"@(FileId(1), 16..17) [Declared]: char_n Any
 "c"@(FileId(1), 39..40) [Declared]: string
 "<root>"@(dummy) [Declared]: <error>

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_coerce_ref_arg_cheated.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_coerce_ref_arg_cheated.snap
@@ -1,11 +1,9 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-assertion_line: 41
 expression: "procedure p(var a : cheat real) end p\nvar i : int\np(i)\n"
-
 ---
 "p"@(FileId(1), 10..11) [Declared]: procedure ( pass(var ref) cheat real, ) -> void
-"<unnamed>"@(dummy) [Declared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "a"@(FileId(1), 16..17) [Declared]: real
 "i"@(FileId(1), 42..43) [Declared]: int
 "<root>"@(dummy) [Declared]: <error>

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_coerce_ref_arg_err.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_coerce_ref_arg_err.snap
@@ -1,11 +1,9 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-assertion_line: 41
 expression: "procedure p(var a : real) end p\nvar i : int\np(i)\n"
-
 ---
 "p"@(FileId(1), 10..11) [Declared]: procedure ( pass(var ref) real, ) -> void
-"<unnamed>"@(dummy) [Declared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "a"@(FileId(1), 16..17) [Declared]: real
 "i"@(FileId(1), 36..37) [Declared]: int
 "<root>"@(dummy) [Declared]: <error>

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_coerce_ref_arg_string_any.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_coerce_ref_arg_string_any.snap
@@ -1,11 +1,9 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-assertion_line: 42
 expression: "procedure p(var a : string(*)) end p\nvar c : string\np(c)\n"
-
 ---
 "p"@(FileId(1), 10..11) [Declared]: procedure ( pass(var ref) string_n Any, ) -> void
-"<unnamed>"@(dummy) [Declared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "a"@(FileId(1), 16..17) [Declared]: string_n Any
 "c"@(FileId(1), 41..42) [Declared]: string
 "<root>"@(dummy) [Declared]: <error>

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_coerce_ref_arg_string_any_err.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_coerce_ref_arg_string_any_err.snap
@@ -1,11 +1,9 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-assertion_line: 42
 expression: "procedure p(var a : string(*)) end p\nvar c : char\np(c)\n"
-
 ---
 "p"@(FileId(1), 10..11) [Declared]: procedure ( pass(var ref) string_n Any, ) -> void
-"<unnamed>"@(dummy) [Declared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "a"@(FileId(1), 16..17) [Declared]: string_n Any
 "c"@(FileId(1), 41..42) [Declared]: char
 "<root>"@(dummy) [Declared]: <error>

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_coerce_value_arg.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_coerce_value_arg.snap
@@ -1,11 +1,9 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-assertion_line: 41
 expression: "procedure p(a : real) end p\nvar i : int\np(i)\n"
-
 ---
 "p"@(FileId(1), 10..11) [Declared]: procedure ( pass(value) real, ) -> void
-"<unnamed>"@(dummy) [Declared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "a"@(FileId(1), 12..13) [Declared]: real
 "i"@(FileId(1), 32..33) [Declared]: int
 "<root>"@(dummy) [Declared]: <error>

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_on_type_err.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_on_type_err.snap
@@ -1,10 +1,8 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-assertion_line: 42
 expression: "type kall : procedure() kall"
-
 ---
-"<unnamed>"@(dummy) [Declared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "kall"@(FileId(1), 5..9) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(1))] of procedure ( ) -> void
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_wrong_arg_all_err.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_wrong_arg_all_err.snap
@@ -1,11 +1,9 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-assertion_line: 42
 expression: "procedure k(var j : int) end p\nk(all)\n"
-
 ---
 "k"@(FileId(1), 10..11) [Declared]: procedure ( pass(var ref) int, ) -> void
-"<unnamed>"@(dummy) [Declared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "j"@(FileId(1), 16..17) [Declared]: int
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_wrong_arg_range_err.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_wrong_arg_range_err.snap
@@ -1,11 +1,9 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-assertion_line: 42
 expression: "procedure k(var j : int) end p\nk(1 .. * - 2)\n"
-
 ---
 "k"@(FileId(1), 10..11) [Declared]: procedure ( pass(var ref) int, ) -> void
-"<unnamed>"@(dummy) [Declared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "j"@(FileId(1), 16..17) [Declared]: int
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_param_infer_binding.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_param_infer_binding.snap
@@ -1,11 +1,9 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-assertion_line: 41
 expression: "function ka(register a : int, b : int, var c : int) r : int\n    bind\n        ra to a, % should fail\n        rb to b,\n        rc to c\n    r := 0 % should fail\nend ka"
-
 ---
 "ka"@(FileId(1), 9..11) [Declared]: function ( pass(value) register int, pass(value) int, pass(var ref) int, ) -> int
-"<unnamed>"@(dummy) [Declared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "a"@(FileId(1), 21..22) [Declared]: int
 "b"@(FileId(1), 30..31) [Declared]: int
 "c"@(FileId(1), 43..44) [Declared]: int

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_param_infer_ty.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_param_infer_ty.snap
@@ -1,12 +1,10 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-assertion_line: 41
 expression: "type tyres : string\nfunction own(me : nat, pie : real) sammy : tyres\nend own"
-
 ---
 "tyres"@(FileId(1), 5..10) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(0))] of string
 "own"@(FileId(1), 29..32) [Declared]: function ( pass(value) nat, pass(value) real, ) -> alias[DefId(LibraryId(0), LocalDefId(0))] of string
-"<unnamed>"@(dummy) [Declared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "me"@(FileId(1), 33..35) [Declared]: nat
 "pie"@(FileId(1), 43..46) [Declared]: real
 "sammy"@(FileId(1), 55..60) [LimitedDeclared(PostCondition)]: alias[DefId(LibraryId(0), LocalDefId(0))] of string

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_ty_char_any_err.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_ty_char_any_err.snap
@@ -1,10 +1,8 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-assertion_line: 42
 expression: "type _ : function () : char(*)"
-
 ---
-"<unnamed>"@(dummy) [Declared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "_"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(1))] of function ( ) -> char_n Any
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_ty_from_alias_function.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_ty_from_alias_function.snap
@@ -1,10 +1,8 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-assertion_line: 41
 expression: "type sha : function (a : int, b : char) : int"
-
 ---
-"<unnamed>"@(dummy) [Declared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "a"@(FileId(1), 21..22) [Declared]: <error>
 "b"@(FileId(1), 30..31) [Declared]: <error>
 "sha"@(FileId(1), 5..8) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(3))] of function ( pass(value) int, pass(value) char, ) -> int

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_ty_from_alias_procedure.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_ty_from_alias_procedure.snap
@@ -1,10 +1,8 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-assertion_line: 41
 expression: "type sha : procedure (a : int, b : char)"
-
 ---
-"<unnamed>"@(dummy) [Declared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "a"@(FileId(1), 22..23) [Declared]: <error>
 "b"@(FileId(1), 31..32) [Declared]: <error>
 "sha"@(FileId(1), 5..8) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(3))] of procedure ( pass(value) int, pass(value) char, ) -> void

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_ty_from_function.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_ty_from_function.snap
@@ -1,11 +1,9 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-assertion_line: 41
 expression: "function sha(a : int, b : char) : int end sha"
-
 ---
 "sha"@(FileId(1), 9..12) [Declared]: function ( pass(value) int, pass(value) char, ) -> int
-"<unnamed>"@(dummy) [Declared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "a"@(FileId(1), 13..14) [Declared]: int
 "b"@(FileId(1), 22..23) [Declared]: char
 "<root>"@(dummy) [Declared]: <error>

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_ty_from_procedure.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_ty_from_procedure.snap
@@ -1,11 +1,9 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-assertion_line: 41
 expression: "procedure sha(a : int, b : char) end sha"
-
 ---
 "sha"@(FileId(1), 10..13) [Declared]: procedure ( pass(value) int, pass(value) char, ) -> void
-"<unnamed>"@(dummy) [Declared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "a"@(FileId(1), 14..15) [Declared]: int
 "b"@(FileId(1), 23..24) [Declared]: char
 "<root>"@(dummy) [Declared]: <error>

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_ty_from_process.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_ty_from_process.snap
@@ -1,11 +1,9 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-assertion_line: 41
 expression: "process sha(a : int, b : char) end sha"
-
 ---
 "sha"@(FileId(1), 8..11) [Declared]: process ( pass(value) int, pass(value) char, ) -> void
-"<unnamed>"@(dummy) [Declared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "a"@(FileId(1), 12..13) [Declared]: int
 "b"@(FileId(1), 21..22) [Declared]: char
 "<root>"@(dummy) [Declared]: <error>

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_ty_param_attrs.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_ty_param_attrs.snap
@@ -1,10 +1,8 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-assertion_line: 41
 expression: "type _ : procedure (\n    ki : int,\n    var v : int,\n    register r : int,\n    var register vr : int,\n    ci : cheat int,\n    var vci : cheat int,\n    register rci : cheat int,\n    var register vrci : cheat int\n)"
-
 ---
-"<unnamed>"@(dummy) [Declared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "ki"@(FileId(1), 25..27) [Declared]: <error>
 "v"@(FileId(1), 43..44) [Declared]: <error>
 "r"@(FileId(1), 65..66) [Declared]: <error>

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_ty_string_any_err.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_ty_string_any_err.snap
@@ -1,10 +1,8 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-assertion_line: 42
 expression: "type _ : function () : string(*)"
-
 ---
-"<unnamed>"@(dummy) [Declared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "_"@(FileId(1), 5..6) [Resolved(Type)]: alias[DefId(LibraryId(0), LocalDefId(1))] of function ( ) -> string_n Any
 "<root>"@(dummy) [Declared]: <error>
 

--- a/compiler/toc_analysis/src/typeck/test.rs
+++ b/compiler/toc_analysis/src/typeck/test.rs
@@ -55,6 +55,8 @@ fn stringify_typeck_results(
     lib: toc_hir::library::LibraryId,
     messages: &MessageBundle,
 ) -> String {
+    use std::fmt::Write;
+
     let mut s = String::new();
     // Pretty print typectx
     // Want: `type_of` all reachable DefIds
@@ -65,17 +67,14 @@ fn stringify_typeck_results(
         let name = def_info.name;
         let name_span = def_info.def_at.lookup_in(&library);
         let def_kind = def_info.declare_kind;
-        let ty = db.type_of(DefId(lib, did).into());
-        let name_fmt = format!("{name:?}@{name_span:?} [{def_kind:?}]: ");
+        let ty = db.type_of(DefId(lib, did).into()).in_db(db);
 
-        s.push_str(&name_fmt);
-        s.push_str(&format!("{:?}", ty.in_db(db)));
-        s.push('\n');
+        writeln!(&mut s, "{name:?}@{name_span:?} [{def_kind:?}]: {ty:?}").unwrap();
     }
 
     // Pretty print the messages
     for err in messages.iter() {
-        s.push_str(&format!("\n{err}"));
+        write!(&mut s, "\n{err}").unwrap();
     }
 
     s

--- a/compiler/toc_analysis/src/typeck/test.rs
+++ b/compiler/toc_analysis/src/typeck/test.rs
@@ -2479,6 +2479,28 @@ test_named_group! { typeck_import_decl,
             outer := 6 % this should still be fine, since we take the specified mut for its word
         end _
         ",
+
+        mutable_on_never_applicable => "
+        type ty : int
+        module _
+            import var ty
+            type tou : ty
+        end _
+        ",
+        const_on_never_applicable => "
+        type ty : int
+        module _
+            import const ty
+            type tou : ty
+        end _
+        ",
+        implied_on_never_applicable => "
+        type ty : int
+        module _
+            import ty
+            type tou : ty
+        end _
+        ",
     ]
 }
 

--- a/compiler/toc_analysis/src/typeck/test.rs
+++ b/compiler/toc_analysis/src/typeck/test.rs
@@ -64,7 +64,7 @@ fn stringify_typeck_results(
         let def_info = library.local_def(did);
         let name = def_info.name;
         let name_span = def_info.def_at.lookup_in(&library);
-        let def_kind = def_info.kind;
+        let def_kind = def_info.declare_kind;
         let ty = db.type_of(DefId(lib, did).into());
         let name_fmt = format!("{name:?}@{name_span:?} [{def_kind:?}]: ");
 

--- a/compiler/toc_analysis/src/typeck/test.rs
+++ b/compiler/toc_analysis/src/typeck/test.rs
@@ -1009,6 +1009,19 @@ test_named_group! { typeck_module_field,
         end a
         b := 1
         ",
+        unqualified_export_lhs_not_mut => "
+        % crashed because we we weren't poking through resolution
+        module indirection
+            export ~. lhs
+            module lhs
+                export field
+                var field : int
+            end lhs
+        end indirection
+
+        % triggers `exporting_def` with an indirect lhs def
+        lhs.field := 6
+        "
     ]
 }
 

--- a/compiler/toc_hir/src/builder.rs
+++ b/compiler/toc_hir/src/builder.rs
@@ -41,12 +41,14 @@ impl LibraryBuilder {
         &mut self,
         name: Symbol,
         span: SpanId,
-        kind: symbol::SymbolKind,
+        kind: Option<symbol::SymbolKind>,
+        declare_kind: symbol::DeclareKind,
     ) -> symbol::LocalDefId {
         let def = symbol::DefInfo {
             name,
             def_at: span,
             kind,
+            declare_kind,
         };
         let index = self.defs.alloc(def);
         symbol::LocalDefId(index)

--- a/compiler/toc_hir/src/lib.rs
+++ b/compiler/toc_hir/src/lib.rs
@@ -114,3 +114,14 @@ pub mod stmt;
 pub mod symbol;
 pub mod ty;
 pub mod visitor;
+
+/// Helper trait equivalent to `Option::map_or(predicate)`
+pub trait OrMissingExt<T> {
+    fn or_is_missing(self, is_predicate: impl FnOnce(T) -> bool) -> bool;
+}
+
+impl<T> OrMissingExt<T> for Option<T> {
+    fn or_is_missing(self, is_predicate: impl FnOnce(T) -> bool) -> bool {
+        self.map_or(true, is_predicate)
+    }
+}

--- a/compiler/toc_hir/src/lib.rs
+++ b/compiler/toc_hir/src/lib.rs
@@ -69,6 +69,37 @@ pub(crate) mod internals {
             }
         };
     }
+
+    /// Simple named boolean
+    #[macro_export]
+    macro_rules! make_named_bool {
+        (
+            $(#[$attrs:meta])*
+            $vis:vis enum $ident:ident $(;)?
+        ) => {
+            $(#[$attrs])*
+            #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+            $vis enum $ident {
+                No,
+                Yes
+            }
+
+            impl ::std::convert::From<bool> for $ident {
+                fn from(v: bool) -> Self {
+                    match v {
+                        false => Self::No,
+                        true => Self::Yes,
+                    }
+                }
+            }
+
+            impl ::std::convert::From<$ident> for bool {
+                fn from(v: $ident) -> bool {
+                    matches!(v, $ident::Yes)
+                }
+            }
+        };
+    }
 }
 
 pub(crate) mod ids;

--- a/compiler/toc_hir/src/lib.rs
+++ b/compiler/toc_hir/src/lib.rs
@@ -117,11 +117,14 @@ pub mod visitor;
 
 /// Helper trait equivalent to `Option::map_or(predicate)`
 pub trait OrMissingExt<T> {
-    fn or_is_missing(self, is_predicate: impl FnOnce(T) -> bool) -> bool;
+    fn is_missing_or(&self, is_predicate: impl FnOnce(T) -> bool) -> bool;
 }
 
-impl<T> OrMissingExt<T> for Option<T> {
-    fn or_is_missing(self, is_predicate: impl FnOnce(T) -> bool) -> bool {
+impl<T> OrMissingExt<T> for Option<T>
+where
+    T: Copy,
+{
+    fn is_missing_or(&self, is_predicate: impl FnOnce(T) -> bool) -> bool {
         self.map_or(true, is_predicate)
     }
 }

--- a/compiler/toc_hir/src/symbol.rs
+++ b/compiler/toc_hir/src/symbol.rs
@@ -298,20 +298,6 @@ impl Mutability {
     }
 }
 
-/// From a failed binding lookup
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum NotBinding {
-    /// From an undeclared definition or an error expression
-    Missing,
-    /// Not a binding at all (e.g. a plain value)
-    NotBinding,
-}
-
-mod seal_me {
-    pub trait Sealed {}
-    impl Sealed for Result<bool, super::NotBinding> {}
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum SubprogramKind {
     Procedure,

--- a/compiler/toc_hir/src/symbol.rs
+++ b/compiler/toc_hir/src/symbol.rs
@@ -307,24 +307,6 @@ pub enum NotBinding {
     NotBinding,
 }
 
-/// Helper trait to deal with [`NotBinding`] kind narrowing
-pub trait BindingResultExt: seal_me::Sealed {
-    /// Allows a missing definition to match the previous predicate
-    fn or_missing(self) -> bool;
-}
-
-impl BindingResultExt for Result<bool, NotBinding> {
-    // Treat error exprs as the same as error
-    // It can be any kind of expression
-
-    fn or_missing(self) -> bool {
-        self.unwrap_or_else(|err| match err {
-            NotBinding::Missing => true,
-            NotBinding::NotBinding => false,
-        })
-    }
-}
-
 mod seal_me {
     pub trait Sealed {}
     impl Sealed for Result<bool, super::NotBinding> {}

--- a/compiler/toc_hir/src/symbol.rs
+++ b/compiler/toc_hir/src/symbol.rs
@@ -10,7 +10,7 @@ pub use crate::ids::{DefId, LocalDefId};
 use crate::{
     ids::{ExportId, ItemId, LocalDefIndex, ModuleId},
     stmt::BodyStmt,
-    ty::{FieldId, TypeId},
+    ty::{FieldId, PassBy, TypeId},
 };
 
 pub mod syms;
@@ -55,6 +55,8 @@ impl From<&str> for Symbol {
     }
 }
 
+// TODO(was doing): Migrating over to the new SymbolKind, replacing BindingTo
+
 /// Information associated with a `LocalDefId` or `DefId`.
 #[derive(Debug, PartialEq, Eq)]
 pub struct DefInfo {
@@ -62,18 +64,170 @@ pub struct DefInfo {
     pub name: Symbol,
     /// Where the def was defined at
     pub def_at: SpanId,
-    /// The kind of symbol.
-    pub kind: SymbolKind,
-    // ...
-    // probably include additional definition information such as
-    // - bound to a register (unsure?)
-    // - pervasive (maybe left over from construction)
-    // - mutability/access (const, var, type/none)?
-    // - is part of a forward resolution chain?
+    /// What kind of declaration this definition refers to,
+    /// or `None` if it's from an undeclared definition.
+    pub kind: Option<SymbolKind>,
+    /// How this definition was declared
+    // ???: Can we punt this to only be during construction?
+    pub declare_kind: DeclareKind,
 }
 
+/// What kind of item this symbol references.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(dead_code)] // Exhaustive listing of variants
 pub enum SymbolKind {
+    /// From `const`, `var`, or the `for`-loop counter var, which might be bound to a register
+    ConstVar(Mutability, IsRegister),
+    /// From a `bind`, which might be bound to a register
+    Binding(Mutability, IsRegister),
+    /// From a `type`, or `collection of forward {name}`
+    Type,
+    /// From a `function`, `procedure`, or `process`
+    Subprogram(SubprogramKind),
+    /// Parameter on a subprogram (either in or out/result params)
+    Param(PassBy, IsRegister),
+    // ???: Could probably make this a prop of the sym
+    /// From `external const` or `external var`
+    ExternalConstVar(Mutability),
+    // ???: Could probably make this a prop of the sym
+    /// From an `external function` or `external procedure`
+    ExternalSubprog(SubprogramKind),
+    // ???: Could probably make this a prop of the sym
+    /// Deferred subprogram, which has no body
+    Deferred(SubprogramKind),
+    /// From a `body`, which may know what it's a body of.
+    /// Not resolved to what it's a body of, since that requires name resolution.
+    Body(Option<SubprogramKind>),
+    /// From a `module`, which may or may not be a monitor
+    Module(IsMonitor),
+    /// From a `class`, which may or may not be a monitor
+    Class(IsMonitor),
+
+    /// From an `import` item
+    Import,
+    /// From an `export` item
+    Export,
+
+    /// From an `enum`
+    Enum,
+    /// From a `set`
+    Set,
+    /// From a `record`
+    Record,
+    /// From a `union`
+    Union,
+    /// From a variant on an `enum`
+    EnumVariant,
+    /// From a field on a `record` or `union`
+    RecordField,
+}
+
+impl SymbolKind {
+    /// If this is can be used as a value reference
+    pub fn is_ref(self) -> bool {
+        matches!(
+            self,
+            Self::ConstVar(..)
+                | Self::Binding(..)
+                | Self::Subprogram(_)
+                | Self::Param(..)
+                | Self::RecordField
+                | Self::EnumVariant
+        )
+    }
+
+    /// If this is a binding to a mutable value reference (storage or register)
+    pub fn is_ref_mut(self) -> bool {
+        matches!(
+            self,
+            Self::ConstVar(muta, _)
+            | Self::Binding(muta, _)
+            | Self::Param(PassBy::Reference(muta), _) if muta == Mutability::Var
+        )
+    }
+
+    /// If this is a binding to a storage location (mut or immutable)
+    pub fn is_storage(self) -> bool {
+        matches!(self, Self::ConstVar(..) | Self::Binding(..))
+    }
+
+    /// If this is a binding to a mutable storage location
+    pub fn is_storage_mut(self) -> bool {
+        matches!(
+            self,
+            Self::ConstVar(muta, reg)
+            | Self::Binding(muta, reg)
+            | Self::Param(PassBy::Reference(muta), reg) if muta == Mutability::Var && reg == IsRegister::No
+        )
+    }
+
+    /// If this is a binding to a type
+    pub fn is_type(self) -> bool {
+        matches!(self, Self::Type)
+    }
+}
+
+impl std::fmt::Display for SymbolKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let name = match self {
+            Self::ConstVar(muta, reg) | Self::Binding(muta, reg) => match (reg, muta) {
+                (IsRegister::No, Mutability::Const) => "a constant",
+                (IsRegister::No, Mutability::Var) => "a variable",
+                (IsRegister::Yes, Mutability::Const) => "a constant register",
+                (IsRegister::Yes, Mutability::Var) => "a register",
+            },
+            Self::Type => "a type",
+            Self::Subprogram(SubprogramKind::Procedure) => "a procedure",
+            Self::Subprogram(SubprogramKind::Function) => "a function",
+            Self::Subprogram(SubprogramKind::Process) => "a process",
+            Self::Param(pass_by, reg) => match (reg, pass_by) {
+                (IsRegister::No, PassBy::Value | PassBy::Reference(Mutability::Const)) => {
+                    "a constant"
+                }
+                (IsRegister::Yes, PassBy::Value | PassBy::Reference(Mutability::Const)) => {
+                    "a constant register"
+                }
+                (IsRegister::No, PassBy::Reference(Mutability::Var)) => "a variable",
+                (IsRegister::Yes, PassBy::Reference(Mutability::Var)) => "a register",
+            },
+            Self::ExternalConstVar(Mutability::Const) => "an external constant",
+            Self::ExternalConstVar(Mutability::Var) => "an external variable",
+            Self::ExternalSubprog(SubprogramKind::Procedure) => "an external procedure",
+            Self::ExternalSubprog(SubprogramKind::Function) => "an external function",
+            Self::ExternalSubprog(SubprogramKind::Process) => "an external process",
+            Self::Deferred(SubprogramKind::Procedure) => "a deferred procedure",
+            Self::Deferred(SubprogramKind::Function) => "a deferred function",
+            Self::Deferred(SubprogramKind::Process) => "a deferred process",
+            Self::Body(_) => "a subprogram body",
+            Self::Module(IsMonitor::No) => "a module",
+            Self::Module(IsMonitor::Yes) => "a monitor",
+            Self::Class(IsMonitor::No) => "a class",
+            Self::Class(IsMonitor::Yes) => "a monitor class",
+            Self::Import => "an import",
+            Self::Export => "an export",
+            Self::Enum => "an enum",
+            Self::Set => "a set",
+            Self::Record => "a record",
+            Self::Union => "a union",
+            Self::EnumVariant => "an enum variant",
+            Self::RecordField => "a record field",
+        };
+
+        f.write_str(name)
+    }
+}
+
+crate::make_named_bool! {
+    pub enum IsRegister;
+}
+
+crate::make_named_bool! {
+    pub enum IsMonitor;
+}
+
+/// How a symbol is brought into scope
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DeclareKind {
     /// The symbol is undeclared at the point of definition.
     Undeclared,
     /// The symbol is a normal declaration at the point of definition.
@@ -85,9 +239,13 @@ pub enum SymbolKind {
     Forward(ForwardKind, Option<LocalDefId>),
     /// The symbol is a resolution of a forward declaration.
     Resolved(ForwardKind),
+
+    // TODO: We only care about where it's exported from, attrs can come later (library local export table?)
     /// The symbol is from an export of an item, with a [`LocalDefId`]
     /// pointing to the original item.
     ItemExport(LocalDefId),
+
+    // TODO: Shunt this info into a libray local import table/resolution map?
     /// The symbol is of an imported item, optionally with a [`LocalDefId`]
     /// pointing to the original item (or an undeclared definition).
     ItemImport(LocalDefId),
@@ -137,81 +295,6 @@ impl Mutability {
             true => Mutability::Var,
             false => Mutability::Const,
         }
-    }
-}
-
-/// What a definition binds to
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum BindingTo {
-    /// A binding to a storage location (e.g. from [`ConstVar`](crate::item::ConstVar))
-    Storage(Mutability),
-    /// A binding to a register
-    Register(Mutability),
-    /// Binding to a type
-    Type,
-    /// Binding to a module
-    Module,
-    /// Binding to a subprogram
-    Subprogram(SubprogramKind),
-    /// Binding to an enum field
-    EnumField,
-}
-
-impl BindingTo {
-    // Undeclared bindings are treated as equivalent to all of the
-    // other binding types, for error reporting purposes.
-    //
-    // While it's still an invalid state, it can theoretically be
-    // any valid binding kind.
-
-    /// If this is a binding to a value reference (mut or immutable, storage, register, subprogram)
-    pub fn is_ref(self) -> bool {
-        matches!(
-            self,
-            Self::Storage(_) | Self::Register(_) | Self::Subprogram(_) | Self::EnumField
-        )
-    }
-
-    /// If this is a binding to a mutable value reference (storage or register)
-    pub fn is_ref_mut(self) -> bool {
-        matches!(
-            self,
-            Self::Storage(Mutability::Var) | Self::Register(Mutability::Var)
-        )
-    }
-
-    /// If this is a binding to a storage location (mut or immutable)
-    pub fn is_storage(self) -> bool {
-        matches!(self, Self::Storage(_))
-    }
-
-    /// If this is a binding to a mutable storage location
-    pub fn is_storage_mut(self) -> bool {
-        matches!(self, Self::Storage(Mutability::Var))
-    }
-
-    /// If this is a binding to a type
-    pub fn is_type(self) -> bool {
-        matches!(self, Self::Type)
-    }
-}
-
-impl std::fmt::Display for BindingTo {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let name = match self {
-            BindingTo::Storage(Mutability::Var) => "a variable",
-            BindingTo::Storage(Mutability::Const) => "a constant",
-            BindingTo::Register(Mutability::Var) => "a register",
-            BindingTo::Register(Mutability::Const) => "a constant register",
-            BindingTo::Type => "a type",
-            BindingTo::Module => "a module",
-            BindingTo::Subprogram(SubprogramKind::Procedure) => "a procedure",
-            BindingTo::Subprogram(SubprogramKind::Function) => "a function",
-            BindingTo::Subprogram(SubprogramKind::Process) => "a process",
-            BindingTo::EnumField => "an enum variant",
-        };
-
-        f.write_str(name)
     }
 }
 

--- a/compiler/toc_hir_db/src/db.rs
+++ b/compiler/toc_hir_db/src/db.rs
@@ -7,7 +7,7 @@ use toc_hir::{
     library::{InLibrary, LibraryId, LoweredLibrary},
     library_graph::LibraryGraph,
     stmt,
-    symbol::{DefId, DefOwner, DefTable},
+    symbol::{DefId, DefOwner, DefTable, SymbolKind},
     ty::{self, TypeOwners},
 };
 use toc_salsa::salsa;
@@ -92,6 +92,12 @@ pub trait HirDatabase: toc_hir_lowering::LoweringDb {
     /// or itself if it is one.
     #[salsa::invoke(query::resolve_def)]
     fn resolve_def(&self, def_id: DefId) -> DefId;
+
+    /// Gets the [`SymbolKind`] of the given `def_id`, or [`None`] if it's an undeclared definition.
+    ///
+    /// This does not perform any form of definition resolution.
+    #[salsa::invoke(query::symbol_kind)]
+    fn symbol_kind(&self, def_id: DefId) -> Option<SymbolKind>;
 }
 
 /// Any HIR node that can uniquely be inside of a module

--- a/compiler/toc_hir_db/src/query.rs
+++ b/compiler/toc_hir_db/src/query.rs
@@ -271,11 +271,16 @@ pub(crate) fn symbol_kind(db: &dyn HirDatabase, def_id: DefId) -> Option<SymbolK
     // Take the binding kind from the def owner
     let library = db.library(def_id.0);
     let def_info = library.local_def(def_id.1);
-
     let kind = def_info.kind?;
+
+    // Note: This was left here during the migration of `binding_to`
+    // If, at some point, we want to know that we're looking at an export/import via symbol kind,
+    // then this can be removed. However, this will come at the cost of knowing when to resolve a def
+    // through import indirection.
     if matches!(kind, SymbolKind::Import | SymbolKind::Export) {
         unreachable!("already resolved defs to their canon form")
     }
+
     Some(kind)
 }
 

--- a/compiler/toc_hir_lowering/src/lower/expr.rs
+++ b/compiler/toc_hir_lowering/src/lower/expr.rs
@@ -1,7 +1,7 @@
 //! Lowering into `Expr` HIR nodes
 use toc_hir::{
     body, expr,
-    symbol::{LimitedKind, SymbolKind},
+    symbol::{DeclareKind, LimitedKind},
 };
 use toc_span::{HasSpanTable, Span, SpanId, Spanned, TextRange};
 use toc_syntax::{
@@ -170,7 +170,7 @@ impl super::BodyLowering<'_, '_> {
         let def_id = self.ctx.use_sym(name.text().into(), span);
 
         let def_info = self.ctx.library.local_def(def_id);
-        if let SymbolKind::LimitedDeclared(kind) = def_info.kind {
+        if let DeclareKind::LimitedDeclared(kind) = def_info.declare_kind {
             let name = name.text();
 
             match kind {

--- a/compiler/toc_hir_lowering/src/lower/stmt.rs
+++ b/compiler/toc_hir_lowering/src/lower/stmt.rs
@@ -383,7 +383,7 @@ impl super::BodyLowering<'_, '_> {
                 *syms::Unnamed,
                 self.ctx.library.span_table().dummy_span(),
                 None,
-                DeclareKind::Declared, // TODO: Change to undeclared once verified that this is the only change
+                DeclareKind::Undeclared,
             );
 
             for param_def in formals.param_decl() {

--- a/compiler/toc_hir_lowering/src/lower/stmt.rs
+++ b/compiler/toc_hir_lowering/src/lower/stmt.rs
@@ -2,11 +2,12 @@
 use std::collections::HashMap;
 
 use indexmap::IndexMap;
-use toc_hir::symbol::{syms, LocalDefId};
+use toc_hir::symbol::{syms, IsMonitor, IsRegister, LocalDefId, SubprogramKind, SymbolKind};
+use toc_hir::ty::PassBy;
 use toc_hir::{
     expr, item,
     stmt::{self, Assign},
-    symbol::{self, ForwardKind, LimitedKind, Mutability, Symbol, SymbolKind},
+    symbol::{self, DeclareKind, ForwardKind, LimitedKind, Mutability, Symbol},
     ty,
 };
 use toc_span::{HasSpanTable, Span, SpanId, Spanned};
@@ -120,18 +121,18 @@ impl super::BodyLowering<'_, '_> {
 
         let is_pervasive = decl.pervasive_attr().is_some();
         let is_register = decl.register_attr().is_some();
-        let is_const = decl.const_token().is_some();
+        let is_var = decl.var_token().is_some();
+        let mutability = Mutability::from_is_mutable(is_var);
 
         let type_spec = decl.type_spec().and_then(|ty| self.lower_type(ty));
         let init_expr = decl.init().map(|expr| self.ctx.lower_expr_body(expr));
 
         // Declare names after uses to prevent def-use cycles
-        let names = self.lower_name_list(decl.decl_list(), is_pervasive)?;
-        let mutability = if is_const {
-            Mutability::Const
-        } else {
-            Mutability::Var
-        };
+        let names = self.lower_name_list(
+            decl.decl_list(),
+            SymbolKind::ConstVar(mutability, is_register.into()),
+            is_pervasive,
+        )?;
 
         let stmts: Vec<_> = names
             .into_iter()
@@ -180,22 +181,23 @@ impl super::BodyLowering<'_, '_> {
 
         let is_pervasive = decl.pervasive_attr().is_some();
 
-        let (type_def, sym_kind) = if let Some(forward) = decl.forward_token() {
+        let (type_def, decl_kind) = if let Some(forward) = decl.forward_token() {
             let token_span = self.ctx.intern_range(forward.text_range());
             (
                 item::DefinedType::Forward(token_span),
-                SymbolKind::Forward(ForwardKind::Type, None),
+                DeclareKind::Forward(ForwardKind::Type, None),
             )
         } else {
             let ty = self.lower_required_type(decl.named_ty());
             (
                 item::DefinedType::Alias(ty),
-                SymbolKind::Resolved(ForwardKind::Type),
+                DeclareKind::Resolved(ForwardKind::Type),
             )
         };
 
         // Declare name after type to prevent def-use cycles
-        let def_id = self.lower_name_def(decl.decl_name()?, sym_kind, is_pervasive);
+        let def_id =
+            self.lower_name_def(decl.decl_name()?, SymbolKind::Type, decl_kind, is_pervasive);
 
         let span = self.ctx.intern_range(decl.syntax().text_range());
 
@@ -220,7 +222,12 @@ impl super::BodyLowering<'_, '_> {
                 let is_register = binding.to_register().is_some();
 
                 let bind_to = self.lower_required_expr_body(binding.expr());
-                let def_id = self.lower_name_def(binding.bind_as()?, SymbolKind::Declared, false);
+                let def_id = self.lower_name_def(
+                    binding.bind_as()?,
+                    SymbolKind::Binding(mutability, is_register.into()),
+                    DeclareKind::Declared,
+                    false,
+                );
                 let span = self.ctx.intern_range(binding.syntax().text_range());
 
                 let binding = item::Binding {
@@ -257,8 +264,12 @@ impl super::BodyLowering<'_, '_> {
         let subprog_header = decl.proc_header().unwrap();
 
         let is_pervasive = subprog_header.pervasive_attr().is_some();
-        let def_id =
-            self.lower_name_def(subprog_header.name()?, SymbolKind::Declared, is_pervasive);
+        let def_id = self.lower_name_def(
+            subprog_header.name()?,
+            SymbolKind::Subprogram(SubprogramKind::Procedure),
+            DeclareKind::Declared,
+            is_pervasive,
+        );
         let param_list = self.lower_formals_spec(subprog_header.params());
         let result = self.none_subprog_result(subprog_header.syntax().text_range());
         let extra = match subprog_header.device_spec().and_then(|spec| spec.expr()) {
@@ -289,8 +300,12 @@ impl super::BodyLowering<'_, '_> {
         let subprog_header = decl.fcn_header().unwrap();
 
         let is_pervasive = subprog_header.pervasive_attr().is_some();
-        let def_id =
-            self.lower_name_def(subprog_header.name()?, SymbolKind::Declared, is_pervasive);
+        let def_id = self.lower_name_def(
+            subprog_header.name()?,
+            SymbolKind::Subprogram(SubprogramKind::Function),
+            DeclareKind::Declared,
+            is_pervasive,
+        );
         let param_list = self.lower_formals_spec(subprog_header.params());
         let result = self.lower_subprog_result(subprog_header.fcn_result());
         let extra = item::SubprogramExtra::None;
@@ -318,8 +333,12 @@ impl super::BodyLowering<'_, '_> {
         let subprog_header = decl.process_header().unwrap();
 
         let is_pervasive = subprog_header.pervasive_attr().is_some();
-        let def_id =
-            self.lower_name_def(subprog_header.name()?, SymbolKind::Declared, is_pervasive);
+        let def_id = self.lower_name_def(
+            subprog_header.name()?,
+            SymbolKind::Subprogram(SubprogramKind::Process),
+            DeclareKind::Declared,
+            is_pervasive,
+        );
         let param_list = self.lower_formals_spec(subprog_header.params());
         let result = self.none_subprog_result(subprog_header.syntax().text_range());
         let extra = match subprog_header.stack_size() {
@@ -350,7 +369,7 @@ impl super::BodyLowering<'_, '_> {
         &mut self,
         formals: Option<ast::ParamSpec>,
     ) -> Option<item::ParamList> {
-        use ty::{Parameter, PassBy};
+        use ty::Parameter;
 
         let formals = formals?;
 
@@ -363,7 +382,8 @@ impl super::BodyLowering<'_, '_> {
             let missing_name = self.ctx.library.add_def(
                 *syms::Unnamed,
                 self.ctx.library.span_table().dummy_span(),
-                SymbolKind::Declared,
+                None,
+                DeclareKind::Declared, // TODO: Change to undeclared once verified that this is the only change
             );
 
             for param_def in formals.param_decl() {
@@ -379,6 +399,7 @@ impl super::BodyLowering<'_, '_> {
 
                         let names = self.lower_name_list_with_missing(
                             param.param_names(),
+                            SymbolKind::Param(pass_by, is_register.into()),
                             false,
                             missing_name,
                         );
@@ -413,7 +434,12 @@ impl super::BodyLowering<'_, '_> {
                         };
 
                         let name = name.map_or(missing_name, |name| {
-                            self.lower_name_def(name, SymbolKind::Declared, false)
+                            self.lower_name_def(
+                                name,
+                                SymbolKind::Param(PassBy::Value, IsRegister::No),
+                                DeclareKind::Declared,
+                                false,
+                            )
                         });
                         param_names.push(name);
 
@@ -453,7 +479,9 @@ impl super::BodyLowering<'_, '_> {
             let name = result.name().map(|name| {
                 self.name_to_def(
                     name,
-                    SymbolKind::LimitedDeclared(LimitedKind::PostCondition),
+                    // ???: Does this need to be pass by value? (can it be pass by const ref?)
+                    SymbolKind::Param(PassBy::Value, IsRegister::No),
+                    DeclareKind::LimitedDeclared(LimitedKind::PostCondition),
                 )
             });
             (name, result.ty())
@@ -502,7 +530,12 @@ impl super::BodyLowering<'_, '_> {
 
     fn lower_module_decl(&mut self, decl: ast::ModuleDecl) -> Option<stmt::StmtKind> {
         let is_pervasive = decl.pervasive_attr().is_some();
-        let def_id = self.lower_name_def(decl.name()?, SymbolKind::Declared, is_pervasive);
+        let def_id = self.lower_name_def(
+            decl.name()?,
+            SymbolKind::Module(IsMonitor::No),
+            DeclareKind::Declared,
+            is_pervasive,
+        );
 
         self.unsupported_node(decl.implement_stmt());
         self.unsupported_node(decl.implement_by_stmt());
@@ -708,11 +741,15 @@ impl super::BodyLowering<'_, '_> {
                 let def_at = self.ctx.library.intern_span(def_at);
                 self.ctx
                     .library
-                    .add_def(name.into(), def_at, symbol::SymbolKind::Undeclared)
+                    .add_def(name.into(), def_at, None, symbol::DeclareKind::Undeclared)
             };
 
             let span = self.ctx.intern_range(import.syntax().text_range());
-            let def_id = self.name_to_def(name, SymbolKind::ItemImport(imported_def));
+            let def_id = self.name_to_def(
+                name,
+                SymbolKind::Import,
+                DeclareKind::ItemImport(imported_def),
+            );
             import_defs.push(def_id);
 
             let item_id = self.ctx.library.add_item(item::Item {
@@ -864,7 +901,8 @@ impl super::BodyLowering<'_, '_> {
                     let def_id = self.ctx.library.add_def(
                         export_name,
                         export_span,
-                        SymbolKind::ItemExport(item_def),
+                        Some(SymbolKind::Export),
+                        DeclareKind::ItemExport(item_def),
                     );
 
                     item::ExportItem {
@@ -1003,7 +1041,8 @@ impl super::BodyLowering<'_, '_> {
                         let def_id = self.ctx.library.add_def(
                             name_text,
                             export_span,
-                            SymbolKind::ItemExport(item_def),
+                            Some(SymbolKind::Export),
+                            DeclareKind::ItemExport(item_def),
                         );
 
                         Some(item::ExportItem {
@@ -1188,8 +1227,14 @@ impl super::BodyLowering<'_, '_> {
         self.ctx.scopes.push_scope(ScopeKind::Loop);
         {
             // counter is only available inside of the loop body
-            counter_def =
-                name.map(|name| self.lower_name_def(name, symbol::SymbolKind::Declared, false));
+            counter_def = name.map(|name| {
+                self.lower_name_def(
+                    name,
+                    SymbolKind::ConstVar(Mutability::Const, IsRegister::No),
+                    symbol::DeclareKind::Declared,
+                    false,
+                )
+            });
             body_stmts = self.lower_stmt_list(stmt.stmt_list().unwrap());
         }
         self.ctx.scopes.pop_scope();
@@ -1366,11 +1411,14 @@ impl super::BodyLowering<'_, '_> {
     fn lower_name_list(
         &mut self,
         name_list: Option<ast::NameList>,
+        kind: SymbolKind,
         is_pervasive: bool,
     ) -> Option<Vec<symbol::LocalDefId>> {
         let names = name_list?
             .names()
-            .map(|name| self.lower_name_def(name, symbol::SymbolKind::Declared, is_pervasive))
+            .map(|name| {
+                self.lower_name_def(name, kind, symbol::DeclareKind::Declared, is_pervasive)
+            })
             .collect::<Vec<_>>();
 
         // Invariant: Names list must contain at least one name
@@ -1381,6 +1429,7 @@ impl super::BodyLowering<'_, '_> {
     fn lower_name_list_with_missing(
         &mut self,
         name_list: Option<ast::NameList>,
+        kind: SymbolKind,
         is_pervasive: bool,
         fill_with: symbol::LocalDefId,
     ) -> Vec<symbol::LocalDefId> {
@@ -1390,9 +1439,12 @@ impl super::BodyLowering<'_, '_> {
                 name_list
                     .names_with_missing()
                     .map(|name| match name {
-                        Some(name) => {
-                            self.lower_name_def(name, symbol::SymbolKind::Declared, is_pervasive)
-                        }
+                        Some(name) => self.lower_name_def(
+                            name,
+                            kind,
+                            symbol::DeclareKind::Declared,
+                            is_pervasive,
+                        ),
                         None => fill_with,
                     })
                     .collect::<Vec<_>>()
@@ -1408,12 +1460,13 @@ impl super::BodyLowering<'_, '_> {
         &mut self,
         name: ast::Name,
         kind: SymbolKind,
+        declare_kind: DeclareKind,
         is_pervasive: bool,
     ) -> symbol::LocalDefId {
         // Can't declare an undefined symbol from a name def
-        assert_ne!(kind, SymbolKind::Undeclared);
+        assert_ne!(declare_kind, DeclareKind::Undeclared);
 
-        let def_id = self.name_to_def(name, kind);
+        let def_id = self.name_to_def(name, kind, declare_kind);
 
         // Bring into scope
         self.ctx.introduce_def(def_id, is_pervasive);
@@ -1421,10 +1474,17 @@ impl super::BodyLowering<'_, '_> {
         def_id
     }
 
-    fn name_to_def(&mut self, name: ast::Name, kind: SymbolKind) -> symbol::LocalDefId {
+    fn name_to_def(
+        &mut self,
+        name: ast::Name,
+        kind: SymbolKind,
+        declare_kind: DeclareKind,
+    ) -> symbol::LocalDefId {
         let token = name.identifier_token().unwrap();
         let span = self.ctx.intern_range(token.text_range());
-        self.ctx.library.add_def(token.text().into(), span, kind)
+        self.ctx
+            .library
+            .add_def(token.text().into(), span, Some(kind), declare_kind)
     }
 }
 

--- a/compiler/toc_hir_lowering/src/lower/ty.rs
+++ b/compiler/toc_hir_lowering/src/lower/ty.rs
@@ -1,5 +1,5 @@
 //! Lowering into `Type` HIR nodes
-use toc_hir::symbol::syms;
+use toc_hir::symbol::{syms, DeclareKind, SymbolKind};
 use toc_hir::{symbol, ty};
 use toc_span::{HasSpanTable, Span, Spanned};
 use toc_syntax::ast::{self, AstNode};
@@ -279,18 +279,22 @@ impl super::BodyLowering<'_, '_> {
             .filter_map(|name| {
                 let span = self.ctx.intern_range(name.syntax().text_range());
                 let name = name.identifier_token()?.text().into();
-                let def_id = self
-                    .ctx
-                    .library
-                    .add_def(name, span, symbol::SymbolKind::Declared);
+                let def_id = self.ctx.library.add_def(
+                    name,
+                    span,
+                    Some(SymbolKind::EnumVariant),
+                    DeclareKind::Declared,
+                );
 
                 Some(def_id)
             })
             .collect();
-        let def_id =
-            self.ctx
-                .library
-                .add_def(type_decl_name(ty), span, symbol::SymbolKind::Declared);
+        let def_id = self.ctx.library.add_def(
+            type_decl_name(ty),
+            span,
+            Some(SymbolKind::Enum),
+            DeclareKind::Declared,
+        );
 
         Some(ty::TypeKind::Enum(ty::Enum { def_id, variants }))
     }
@@ -409,10 +413,12 @@ impl super::BodyLowering<'_, '_> {
     fn lower_set_type(&mut self, ty: ast::SetType) -> Option<ty::TypeKind> {
         let span = self.ctx.intern_range(ty.syntax().text_range());
         let elem = self.lower_required_type(ty.elem_ty());
-        let def_id =
-            self.ctx
-                .library
-                .add_def(type_decl_name(ty), span, symbol::SymbolKind::Declared);
+        let def_id = self.ctx.library.add_def(
+            type_decl_name(ty),
+            span,
+            Some(SymbolKind::Set),
+            DeclareKind::Declared,
+        );
 
         Some(ty::TypeKind::Set(ty::Set {
             def_id,

--- a/compiler/toc_hir_lowering/src/scopes.rs
+++ b/compiler/toc_hir_lowering/src/scopes.rs
@@ -8,7 +8,7 @@ mod test;
 
 use std::collections::{HashMap, HashSet};
 
-use toc_hir::symbol::{self, ForwardKind, LocalDefId, Symbol, SymbolKind};
+use toc_hir::symbol::{self, DeclareKind, ForwardKind, LocalDefId, Symbol};
 
 #[derive(Debug)]
 pub(crate) struct Scope {
@@ -152,7 +152,7 @@ impl ScopeTracker {
         &mut self,
         name: Symbol,
         def_id: symbol::LocalDefId,
-        kind: SymbolKind,
+        kind: DeclareKind,
         is_pervasive: bool,
     ) -> Option<symbol::LocalDefId> {
         use std::collections::hash_map::Entry;
@@ -163,7 +163,7 @@ impl ScopeTracker {
 
         // Update the forward decl list
         match kind {
-            SymbolKind::Forward(forward_kind, _) => {
+            DeclareKind::Forward(forward_kind, _) => {
                 // Add to this scope's forward declaration list
                 let forward_group = def_scope.forward_symbols.entry(name);
 
@@ -185,7 +185,7 @@ impl ScopeTracker {
                     }
                 }
             }
-            SymbolKind::Declared => {
+            DeclareKind::Declared => {
                 // Remove it completely, leaving any forward decls unresolved
                 def_scope.forward_symbols.remove(&name);
             }

--- a/compiler/toc_hir_lowering/tests/lowering.rs
+++ b/compiler/toc_hir_lowering/tests/lowering.rs
@@ -57,7 +57,7 @@ fn assert_lower(src: &str) -> LowerResult {
 
     let mut s = toc_hir_pretty::tree::pretty_print_tree(lowered.result());
     for err in lowered.messages().iter() {
-        write!(&mut s, "\n{err}").unwrap();
+        writeln!(&mut s, "{err}").unwrap();
     }
 
     insta::assert_snapshot!(insta::internals::AutoName, s, src);

--- a/compiler/toc_hir_lowering/tests/lowering.rs
+++ b/compiler/toc_hir_lowering/tests/lowering.rs
@@ -41,6 +41,8 @@ struct LowerResult {
 }
 
 fn assert_lower(src: &str) -> LowerResult {
+    use std::fmt::Write;
+
     let mut db = TestHirDb::default();
     let fixture = toc_vfs::generate_vfs(&mut db, src);
     db.insert_fixture(fixture);
@@ -55,7 +57,7 @@ fn assert_lower(src: &str) -> LowerResult {
 
     let mut s = toc_hir_pretty::tree::pretty_print_tree(lowered.result());
     for err in lowered.messages().iter() {
-        s.push_str(&format!("{err}\n"));
+        write!(&mut s, "\n{err}").unwrap();
     }
 
     insta::assert_snapshot!(insta::internals::AutoName, s, src);

--- a/compiler/toc_hir_pretty/src/graph.rs
+++ b/compiler/toc_hir_pretty/src/graph.rs
@@ -331,7 +331,7 @@ impl<'out, 'hir> PrettyVisitor<'out, 'hir> {
                     "at: '{span}'",
                     span = self.display_span(def_info.def_at)
                 )),
-                Layout::Node(format!("kind: {kind:?}", kind = def_info.kind)),
+                Layout::Node(format!("kind: {kind:?}", kind = def_info.declare_kind)),
             ]),
         )
     }

--- a/compiler/toc_hir_pretty/src/tree.rs
+++ b/compiler/toc_hir_pretty/src/tree.rs
@@ -108,14 +108,14 @@ impl<'out, 'hir> PrettyVisitor<'out, 'hir> {
     fn display_extra_def(&self, def_id: LocalDefId) -> String {
         let def_info = self.library.local_def(def_id);
         let def_display = self.display_def(def_id);
-        match def_info.kind {
-            toc_hir::symbol::SymbolKind::Undeclared => {
+        match def_info.declare_kind {
+            toc_hir::symbol::DeclareKind::Undeclared => {
                 format!("{def_display}, undeclared")
             }
-            toc_hir::symbol::SymbolKind::Forward(kind, None) => {
+            toc_hir::symbol::DeclareKind::Forward(kind, None) => {
                 format!("{def_display}, unresolved forward({kind:?})")
             }
-            toc_hir::symbol::SymbolKind::Forward(kind, Some(resolve_to)) => {
+            toc_hir::symbol::DeclareKind::Forward(kind, Some(resolve_to)) => {
                 format!(
                     "{}, forward({:?}) -> {}",
                     def_display,
@@ -123,7 +123,7 @@ impl<'out, 'hir> PrettyVisitor<'out, 'hir> {
                     self.display_def(resolve_to)
                 )
             }
-            toc_hir::symbol::SymbolKind::Resolved(kind) => {
+            toc_hir::symbol::DeclareKind::Resolved(kind) => {
                 format!("{def_display}, resolved({kind:?})")
             }
             _ => def_display,

--- a/compiler/toc_parser/src/lib.rs
+++ b/compiler/toc_parser/src/lib.rs
@@ -60,6 +60,8 @@ impl ParseTree {
 #[cfg(test)]
 #[track_caller]
 pub(crate) fn check(source: &str, expected: expect_test::Expect) {
+    use std::fmt::Write;
+
     let dummy_file = FileId::new_testing(1).unwrap();
     let res = parse(dummy_file, source);
 
@@ -69,7 +71,7 @@ pub(crate) fn check(source: &str, expected: expect_test::Expect) {
     debug_tree.pop();
 
     for err in res.messages().iter() {
-        debug_tree.push_str(&format!("\n{err}"));
+        write!(&mut debug_tree, "\n{err}").unwrap();
     }
 
     expected.assert_eq(&debug_tree);

--- a/compiler/toc_validate/src/lib.rs
+++ b/compiler/toc_validate/src/lib.rs
@@ -174,13 +174,15 @@ fn validate_source(src: ast::Source, ctx: &mut ValidateCtx) {
 #[cfg(test)]
 #[track_caller]
 pub(crate) fn check(source: &str, expected: expect_test::Expect) {
+    use std::fmt::Write;
+
     let dummy_id = FileId::new_testing(1).unwrap();
     let res = toc_parser::parse(dummy_id, source);
     let validate_res = validate_ast(dummy_id, res.result().syntax());
 
     let mut buf = String::new();
     for msg in res.messages().iter().chain(validate_res.messages().iter()) {
-        buf.push_str(&format!("{msg}\n"));
+        writeln!(&mut buf, "{msg}").unwrap();
     }
     let trimmed = buf.trim_end();
 


### PR DESCRIPTION
Hopefully much simpler to work with, and also paving the way for AST definition collection
(+ other clippy fixes to warnings introduced by bumping the rust version)