### PR TITLE
Syntax fixups

### DIFF
--- a/compiler/toc_hir_lowering/src/lower/stmt.rs
+++ b/compiler/toc_hir_lowering/src/lower/stmt.rs
@@ -622,18 +622,20 @@ impl super::BodyLowering<'_, '_> {
                 continue;
             };
 
-            let is_const = import.attrs().and_then(|attrs| match attrs {
+            let is_const = import.attrs().find_map(|attrs| match attrs {
                 ast::ImportAttr::ConstAttr(node) => Some(node),
                 _ => None,
             });
-            let is_var = import.attrs().and_then(|attrs| match attrs {
+            let is_var = import.attrs().find_map(|attrs| match attrs {
                 ast::ImportAttr::VarAttr(node) => Some(node),
                 _ => None,
             });
-            let is_forward = import.attrs().and_then(|attrs| match attrs {
+            let is_forward = import.attrs().find_map(|attrs| match attrs {
                 ast::ImportAttr::ForwardAttr(node) => Some(node),
                 _ => None,
             });
+
+            dbg!((&is_const, &is_var, &is_forward));
 
             // Mutabilty can only be one or the other, or not specified
             let import_mut = match (is_const, is_var) {

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_import_stmt-2.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_import_stmt-2.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler/toc_hir_lowering/tests/lowering.rs
-assertion_line: 61
 expression: "\n    var a : int\n    module _\n        import const var a\n    end _"
-
 ---
 Library@(dummy)
   Root@(dummy): FileId(1) -> ItemId(3)
@@ -13,11 +11,9 @@ Library@(dummy)
             Primitive@(FileId(1), 13..16): Int
         StmtItem@(FileId(1), 21..66): ItemId(2)
           Module@(FileId(1), 21..66): "_"@(FileId(1), 28..29)
-            StmtBody@(FileId(1), 51..56): []
-              StmtItem@(FileId(1), 51..56): ItemId(1)
-                ConstVar@(FileId(1), 51..56): var "a"@(FileId(1), 55..56)
-error in file FileId(1) at 51..54: unexpected token
-| error in file FileId(1) for 51..54: expected string literal or identifier, but found `var`
-error in file FileId(1) at 61..64: unexpected token
-| error in file FileId(1) for 61..64: expected `,`, `:` or `:=`, but found `end`
+            Import@(FileId(1), 45..56): SameAsItem "a"@(FileId(1), 55..56)
+            StmtBody@(FileId(1), 61..61): []
+error in file FileId(1) at 51..54: cannot use `const` and `var` on the same import
+| error in file FileId(1) for 45..50: first conflicting `const`
+| error in file FileId(1) for 51..54: first conflicting `var`
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_import_stmt-5.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_import_stmt-5.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler/toc_hir_lowering/tests/lowering.rs
-assertion_line: 61
 expression: "\n    var a : int\n    proc _\n        import const var a\n    end _"
-
 ---
 Library@(dummy)
   Root@(dummy): FileId(1) -> ItemId(3)
@@ -14,11 +12,9 @@ Library@(dummy)
         StmtItem@(FileId(1), 21..64): ItemId(2)
           Subprogram@(FileId(1), 21..64): "_"@(FileId(1), 26..27)
             Void@(FileId(1), 21..27)
-            StmtBody@(FileId(1), 49..54): []
-              StmtItem@(FileId(1), 49..54): ItemId(1)
-                ConstVar@(FileId(1), 49..54): var "a"@(FileId(1), 53..54)
-error in file FileId(1) at 49..52: unexpected token
-| error in file FileId(1) for 49..52: expected string literal or identifier, but found `var`
-error in file FileId(1) at 59..62: unexpected token
-| error in file FileId(1) for 59..62: expected `,`, `:` or `:=`, but found `end`
+            Import@(FileId(1), 43..54): SameAsItem "a"@(FileId(1), 53..54)
+            StmtBody@(FileId(1), 59..59): []
+error in file FileId(1) at 49..52: cannot use `const` and `var` on the same import
+| error in file FileId(1) for 43..48: first conflicting `const`
+| error in file FileId(1) for 49..52: first conflicting `var`
 

--- a/compiler/toc_parser/src/grammar/expr.rs
+++ b/compiler/toc_parser/src/grammar/expr.rs
@@ -384,15 +384,7 @@ fn cheat_expr(p: &mut Parser) -> Option<CompletedMarker> {
             self::expect_expr(p);
         });
 
-        if p.at(TokenKind::Colon) {
-            // Eat cheat size spec
-            let m = p.start();
-            p.bump();
-
-            self::expect_expr(p);
-
-            m.complete(p, SyntaxKind::SizeSpec);
-        }
+        ty::size_spec(p);
     });
     p.expect_punct(TokenKind::RightParen);
 

--- a/compiler/toc_parser/src/grammar/stmt.rs
+++ b/compiler/toc_parser/src/grammar/stmt.rs
@@ -1550,9 +1550,15 @@ fn import_list(p: &mut Parser) -> Option<CompletedMarker> {
 fn import_item(p: &mut Parser) -> Option<CompletedMarker> {
     let m = p.start();
 
-    attr_var(p)
-        .or_else(|| attr_const(p))
-        .or_else(|| attr_forward(p));
+    p.with_extra_recovery(&[TokenKind::Identifier, TokenKind::StringLiteral], |p| {
+        while attr_var(p)
+            .or_else(|| attr_const(p))
+            .or_else(|| attr_forward(p))
+            .is_some()
+        {
+            // continue parsing attrs
+        }
+    });
 
     external_item(p);
 

--- a/compiler/toc_parser/src/grammar/stmt/test.rs
+++ b/compiler/toc_parser/src/grammar/stmt/test.rs
@@ -9021,6 +9021,57 @@ fn parse_import_stmt_attrs() {
 }
 
 #[test]
+fn parse_import_stmt_attrs_multiple() {
+    check(
+        r#"import var const forward forward const var it, var var var "barbar""#,
+        expect![[r#"
+            Source@0..67
+              ImportStmt@0..67
+                KwImport@0..6 "import"
+                Whitespace@6..7 " "
+                ImportList@7..67
+                  ImportItem@7..45
+                    VarAttr@7..10
+                      KwVar@7..10 "var"
+                    Whitespace@10..11 " "
+                    ConstAttr@11..16
+                      KwConst@11..16 "const"
+                    Whitespace@16..17 " "
+                    ForwardAttr@17..24
+                      KwForward@17..24 "forward"
+                    Whitespace@24..25 " "
+                    ForwardAttr@25..32
+                      KwForward@25..32 "forward"
+                    Whitespace@32..33 " "
+                    ConstAttr@33..38
+                      KwConst@33..38 "const"
+                    Whitespace@38..39 " "
+                    VarAttr@39..42
+                      KwVar@39..42 "var"
+                    Whitespace@42..43 " "
+                    ExternalItem@43..45
+                      Name@43..45
+                        Identifier@43..45 "it"
+                  Comma@45..46 ","
+                  Whitespace@46..47 " "
+                  ImportItem@47..67
+                    VarAttr@47..50
+                      KwVar@47..50 "var"
+                    Whitespace@50..51 " "
+                    VarAttr@51..54
+                      KwVar@51..54 "var"
+                    Whitespace@54..55 " "
+                    VarAttr@55..58
+                      KwVar@55..58 "var"
+                    Whitespace@58..59 " "
+                    ExternalItem@59..67
+                      LiteralExpr@59..67
+                        StringLiteral@59..67 "\"barbar\""
+              StmtList@67..67"#]],
+    )
+}
+
+#[test]
 fn parse_import_stmt_empty() {
     check(
         "import ()",

--- a/compiler/toc_parser/src/parser/error.rs
+++ b/compiler/toc_parser/src/parser/error.rs
@@ -62,6 +62,7 @@ pub(crate) enum Expected {
     PreprocCondition,
     Statement,
     Type,
+    PackedType,
     InfixOp,
 }
 
@@ -72,6 +73,8 @@ impl fmt::Display for Expected {
             Self::PreprocCondition => "preprocessor condition",
             Self::Statement => "statement",
             Self::Type => "type specifier",
+            // HACK: Brute-forced way of getting a better error message
+            Self::PackedType => "`array`, `enum`, `set`, `record`, `union`, or a range type",
             Self::InfixOp => "infix operator",
         })
     }

--- a/compiler/toc_syntax/parsed_turing.ungram
+++ b/compiler/toc_syntax/parsed_turing.ungram
@@ -540,7 +540,7 @@ ImportList =
   ( ImportItem ( ',' ImportItem )* )
 
 ImportItem =
-  attrs:ImportAttr? ExternalItem
+  attrs:ImportAttr* ExternalItem
 
 ImportAttr =
   VarAttr

--- a/compiler/toc_syntax/parsed_turing.ungram
+++ b/compiler/toc_syntax/parsed_turing.ungram
@@ -685,9 +685,6 @@ DerefExpr =
 CheatExpr =
   'cheat' '(' Type ',' Expr SizeSpec? ')'
 
-SizeSpec =
-  ':' Expr
-
 NatCheatExpr =
   '#' Expr
 
@@ -776,7 +773,7 @@ NameType =
   Expr
 
 RangeType =
-  start:Expr '..' end:EndBound
+  'packed'? start:Expr '..' end:EndBound SizeSpec?
 
 EndBound =
   UnsizedBound
@@ -785,17 +782,22 @@ EndBound =
 UnsizedBound =
   '*'
 
+// Storage size overrides being in a 'packed' context
+SizeSpec =
+  ':' size:Expr
+  
+
 EnumType =
-  'enum' '(' fields:NameList ')'
+  'packed'? 'enum' '(' fields:NameList ')' SizeSpec?
 
 ArrayType =
-  'flexible'? 'array' RangeList 'of' elem_ty:Type
+  'packed'? 'flexible'? 'array' RangeList 'of' elem_ty:Type
 
 RangeList =
   ranges:( Type ( ',' Type )* )
 
 SetType =
-  'set' 'of' elem_ty:Type
+  'packed'? 'set' 'of' elem_ty:Type SizeSpec?
 
 RecordType =
   'packed'? 'record'

--- a/compiler/toc_syntax/src/ast/nodes.rs
+++ b/compiler/toc_syntax/src/ast/nodes.rs
@@ -2746,7 +2746,7 @@ impl AstNode for ImportItem {
     fn syntax(&self) -> &SyntaxNode { &self.0 }
 }
 impl ImportItem {
-    pub fn attrs(&self) -> Option<ImportAttr> { helper::node(&self.0) }
+    pub fn attrs(&self) -> impl Iterator<Item = ImportAttr> + '_ { helper::nodes(&self.0) }
     pub fn external_item(&self) -> Option<ExternalItem> { helper::node(&self.0) }
 }
 #[derive(Debug, PartialEq, Eq, Hash)]

--- a/compiler/toc_syntax/src/ast/nodes.rs
+++ b/compiler/toc_syntax/src/ast/nodes.rs
@@ -3247,7 +3247,7 @@ impl AstNode for SizeSpec {
 }
 impl SizeSpec {
     pub fn colon_token(&self) -> Option<SyntaxToken> { helper::token(&self.0, SyntaxKind::Colon) }
-    pub fn expr(&self) -> Option<Expr> { helper::node(&self.0) }
+    pub fn size(&self) -> Option<Expr> { helper::node(&self.0) }
 }
 #[derive(Debug, PartialEq, Eq, Hash)]
 #[repr(transparent)]
@@ -3395,7 +3395,9 @@ impl AstNode for RangeType {
     fn syntax(&self) -> &SyntaxNode { &self.0 }
 }
 impl RangeType {
+    pub fn packed_token(&self) -> Option<SyntaxToken> { helper::token(&self.0, SyntaxKind::KwPacked) }
     pub fn range_token(&self) -> Option<SyntaxToken> { helper::token(&self.0, SyntaxKind::Range) }
+    pub fn size_spec(&self) -> Option<SizeSpec> { helper::node(&self.0) }
 }
 #[derive(Debug, PartialEq, Eq, Hash)]
 #[repr(transparent)]
@@ -3416,10 +3418,12 @@ impl AstNode for EnumType {
     fn syntax(&self) -> &SyntaxNode { &self.0 }
 }
 impl EnumType {
+    pub fn packed_token(&self) -> Option<SyntaxToken> { helper::token(&self.0, SyntaxKind::KwPacked) }
     pub fn enum_token(&self) -> Option<SyntaxToken> { helper::token(&self.0, SyntaxKind::KwEnum) }
     pub fn l_paren_token(&self) -> Option<SyntaxToken> { helper::token(&self.0, SyntaxKind::LeftParen) }
     pub fn fields(&self) -> Option<NameList> { helper::node(&self.0) }
     pub fn r_paren_token(&self) -> Option<SyntaxToken> { helper::token(&self.0, SyntaxKind::RightParen) }
+    pub fn size_spec(&self) -> Option<SizeSpec> { helper::node(&self.0) }
 }
 #[derive(Debug, PartialEq, Eq, Hash)]
 #[repr(transparent)]
@@ -3440,6 +3444,7 @@ impl AstNode for ArrayType {
     fn syntax(&self) -> &SyntaxNode { &self.0 }
 }
 impl ArrayType {
+    pub fn packed_token(&self) -> Option<SyntaxToken> { helper::token(&self.0, SyntaxKind::KwPacked) }
     pub fn flexible_token(&self) -> Option<SyntaxToken> { helper::token(&self.0, SyntaxKind::KwFlexible) }
     pub fn array_token(&self) -> Option<SyntaxToken> { helper::token(&self.0, SyntaxKind::KwArray) }
     pub fn range_list(&self) -> Option<RangeList> { helper::node(&self.0) }
@@ -3465,9 +3470,11 @@ impl AstNode for SetType {
     fn syntax(&self) -> &SyntaxNode { &self.0 }
 }
 impl SetType {
+    pub fn packed_token(&self) -> Option<SyntaxToken> { helper::token(&self.0, SyntaxKind::KwPacked) }
     pub fn set_token(&self) -> Option<SyntaxToken> { helper::token(&self.0, SyntaxKind::KwSet) }
     pub fn of_token(&self) -> Option<SyntaxToken> { helper::token(&self.0, SyntaxKind::KwOf) }
     pub fn elem_ty(&self) -> Option<Type> { helper::node(&self.0) }
+    pub fn size_spec(&self) -> Option<SizeSpec> { helper::node(&self.0) }
 }
 #[derive(Debug, PartialEq, Eq, Hash)]
 #[repr(transparent)]

--- a/compiler/toc_validate/src/stmt.rs
+++ b/compiler/toc_validate/src/stmt.rs
@@ -487,7 +487,7 @@ pub(super) fn validate_import_stmt(stmt: ast::ImportStmt, ctx: &mut ValidateCtx)
 }
 
 pub(super) fn validate_import_item(item: ast::ImportItem, ctx: &mut ValidateCtx) {
-    let forward_attr = item.attrs().and_then(|attr| match attr {
+    let forward_attr = item.attrs().find_map(|attr| match attr {
         ast::ImportAttr::ForwardAttr(attr) => Some(attr),
         _ => None,
     });


### PR DESCRIPTION
Align syntax more with what we can parse.
Also expands where `packed` and size spec can be used, in alignment with reference Turing.