### PR TITLE
Add Deferred HIR Name resolution

### DIFF
--- a/compiler/toc_analysis/src/const_eval.rs
+++ b/compiler/toc_analysis/src/const_eval.rs
@@ -27,7 +27,7 @@ use toc_hir::{body::BodyId, expr::BodyExpr, library::LibraryId};
 
 pub(crate) use errors::ErrorKind;
 
-pub use errors::ConstError;
+pub use errors::{ConstError, NotConst};
 pub use integer::ConstInt;
 pub use value::ConstValue;
 

--- a/compiler/toc_analysis/src/const_eval/query.rs
+++ b/compiler/toc_analysis/src/const_eval/query.rs
@@ -8,7 +8,11 @@ use toc_hir::{
 };
 
 use crate::{
-    const_eval::{errors::ErrorKind, ops::ConstOp, ConstError, ConstInt},
+    const_eval::{
+        errors::{ErrorKind, NotConst},
+        ops::ConstOp,
+        ConstError, ConstInt,
+    },
     ty,
 };
 
@@ -40,7 +44,7 @@ pub(crate) fn evaluate_const(
         Const::Unevaluated(_, _) => match &body.kind {
             toc_hir::body::BodyKind::Stmts(..) => {
                 return Err(ConstError::new(
-                    ErrorKind::NotConstExpr(None),
+                    ErrorKind::NotConstExpr(NotConst::Expr),
                     body.span.lookup_in(span_map),
                 ))
             }
@@ -125,7 +129,9 @@ pub(crate) fn evaluate_const(
                             toc_hir::symbol::Resolve::Err => {
                                 // Not a const expr
                                 return Err(ConstError::new(
-                                    ErrorKind::NotConstExpr(None),
+                                    ErrorKind::NotConstExpr(NotConst::Binding(
+                                        library_id, *binding,
+                                    )),
                                     expr_span,
                                 ));
                             }
@@ -149,7 +155,7 @@ pub(crate) fn evaluate_const(
                             None => {
                                 // Not a const expr
                                 return Err(ConstError::new(
-                                    ErrorKind::NotConstExpr(Some(canonical_def)),
+                                    ErrorKind::NotConstExpr(NotConst::Def(canonical_def)),
                                     expr_span,
                                 ));
                             }
@@ -210,7 +216,7 @@ pub(crate) fn evaluate_const(
                         // Never a const expr
                         // TODO: Use the self's associated def_id
                         return Err(ConstError::new(
-                            ErrorKind::NotConstExpr(Default::default()),
+                            ErrorKind::NotConstExpr(NotConst::Expr),
                             expr_span,
                         ));
                     }
@@ -262,18 +268,27 @@ pub(crate) fn evaluate_const(
                         // FIXME: Handle const-eval field lookups for modules
                         // Note: This will expose us to evaluation cycles, so those need to be handled as well
                         // when the time comes
-                        return Err(ConstError::new(ErrorKind::NotConstExpr(None), expr_span));
+                        return Err(ConstError::new(
+                            ErrorKind::NotConstExpr(NotConst::Expr),
+                            expr_span,
+                        ));
                     }
                 }
             }
             expr::ExprKind::Call(_) => {
                 // There are some functions which are allowed to be const-fns, but they're all builtins
                 // It's okay to treat it as not const-evaluable
-                return Err(ConstError::new(ErrorKind::NotConstExpr(None), expr_span));
+                return Err(ConstError::new(
+                    ErrorKind::NotConstExpr(NotConst::Expr),
+                    expr_span,
+                ));
             }
             _ => {
                 // The rest of the exprs aren't ever evaluable at compile time
-                return Err(ConstError::new(ErrorKind::NotConstExpr(None), expr_span));
+                return Err(ConstError::new(
+                    ErrorKind::NotConstExpr(NotConst::Expr),
+                    expr_span,
+                ));
             }
         }
     }

--- a/compiler/toc_analysis/src/const_eval/snapshots/toc_analysis__const_eval__test__error_no_const_expr-2.snap
+++ b/compiler/toc_analysis/src/const_eval/snapshots/toc_analysis__const_eval__test__error_no_const_expr-2.snap
@@ -1,12 +1,10 @@
 ---
 source: compiler/toc_analysis/src/const_eval/test.rs
-assertion_line: 15
 expression: "var a := 1\nconst b := a\nconst c := b\n"
-
 ---
 "a"@(FileId(1), 4..5) -> Integer(ConstInt { magnitude: 1, sign: Positive, width: As32 })
-"b"@(FileId(1), 17..18) -> ConstError { kind: NotConstExpr(Some(DefId(LibraryId(0), LocalDefId(0)))), span: (FileId(1), 22..23) }
-"c"@(FileId(1), 30..31) -> ConstError { kind: NotConstExpr(Some(DefId(LibraryId(0), LocalDefId(0)))), span: (FileId(1), 22..23) }
+"b"@(FileId(1), 17..18) -> ConstError { kind: NotConstExpr(Def(DefId(LibraryId(0), LocalDefId(0)))), span: (FileId(1), 22..23) }
+"c"@(FileId(1), 30..31) -> ConstError { kind: NotConstExpr(Def(DefId(LibraryId(0), LocalDefId(0)))), span: (FileId(1), 22..23) }
 
 error in file FileId(1) at 22..23: cannot compute `a` at compile-time
 | error in file FileId(1) for 22..23: `a` is a reference to a variable, not a constant

--- a/compiler/toc_analysis/src/const_eval/snapshots/toc_analysis__const_eval__test__error_no_const_expr-3.snap
+++ b/compiler/toc_analysis/src/const_eval/snapshots/toc_analysis__const_eval__test__error_no_const_expr-3.snap
@@ -1,10 +1,8 @@
 ---
 source: compiler/toc_analysis/src/const_eval/test.rs
-assertion_line: 13
 expression: "type a : int\nconst b := a\n"
-
 ---
-"b"@(FileId(1), 19..20) -> ConstError { kind: NotConstExpr(Some(DefId(LibraryId(0), LocalDefId(0)))), span: (FileId(1), 24..25) }
+"b"@(FileId(1), 19..20) -> ConstError { kind: NotConstExpr(Def(DefId(LibraryId(0), LocalDefId(0)))), span: (FileId(1), 24..25) }
 
 error in file FileId(1) at 24..25: cannot compute `a` at compile-time
 | error in file FileId(1) for 24..25: `a` is a reference to a type, not a constant

--- a/compiler/toc_analysis/src/const_eval/snapshots/toc_analysis__const_eval__test__error_no_const_expr-4.snap
+++ b/compiler/toc_analysis/src/const_eval/snapshots/toc_analysis__const_eval__test__error_no_const_expr-4.snap
@@ -1,9 +1,7 @@
 ---
 source: compiler/toc_analysis/src/const_eval/test.rs
-assertion_line: 13
 expression: "const b := a"
-
 ---
-"b"@(FileId(1), 6..7) -> ConstError { kind: NotConstExpr(Some(DefId(LibraryId(0), LocalDefId(0)))), span: (FileId(1), 11..12) }
+"b"@(FileId(1), 6..7) -> ConstError { kind: NotConstExpr(Binding(LibraryId(0), Spanned("a", SpanId(3)))), span: (FileId(1), 11..12) }
 
 

--- a/compiler/toc_analysis/src/const_eval/snapshots/toc_analysis__const_eval__test__error_no_const_expr-6.snap
+++ b/compiler/toc_analysis/src/const_eval/snapshots/toc_analysis__const_eval__test__error_no_const_expr-6.snap
@@ -1,0 +1,9 @@
+---
+source: compiler/toc_analysis/src/const_eval/test.rs
+expression: "\n    module base\n        export ~. tail\n    end base\n\n    module target\n        import tail\n        const _ := tail\n    end target\n    "
+---
+"_"@(FileId(1), 106..107) -> ConstError { kind: NotConstExpr(Binding(LibraryId(0), Spanned("tail", SpanId(9)))), span: (FileId(1), 111..115) }
+
+error in file FileId(1) at 111..115: cannot compute `tail` at compile-time
+| error in file FileId(1) for 111..115: expression cannot be computed at compile-time
+

--- a/compiler/toc_analysis/src/const_eval/snapshots/toc_analysis__const_eval__test__error_no_const_expr.snap
+++ b/compiler/toc_analysis/src/const_eval/snapshots/toc_analysis__const_eval__test__error_no_const_expr.snap
@@ -1,11 +1,9 @@
 ---
 source: compiler/toc_analysis/src/const_eval/test.rs
-assertion_line: 13
 expression: "var a := 1\nconst b := a\n"
-
 ---
 "a"@(FileId(1), 4..5) -> Integer(ConstInt { magnitude: 1, sign: Positive, width: As32 })
-"b"@(FileId(1), 17..18) -> ConstError { kind: NotConstExpr(Some(DefId(LibraryId(0), LocalDefId(0)))), span: (FileId(1), 22..23) }
+"b"@(FileId(1), 17..18) -> ConstError { kind: NotConstExpr(Def(DefId(LibraryId(0), LocalDefId(0)))), span: (FileId(1), 22..23) }
 
 error in file FileId(1) at 22..23: cannot compute `a` at compile-time
 | error in file FileId(1) for 22..23: `a` is a reference to a variable, not a constant

--- a/compiler/toc_analysis/src/const_eval/snapshots/toc_analysis__const_eval__test__error_no_fields_other.snap
+++ b/compiler/toc_analysis/src/const_eval/snapshots/toc_analysis__const_eval__test__error_no_fields_other.snap
@@ -1,11 +1,9 @@
 ---
 source: compiler/toc_analysis/src/const_eval/test.rs
-assertion_line: 12
 expression: "const a := 1 const _ := a.o"
-
 ---
 "a"@(FileId(1), 6..7) -> Integer(ConstInt { magnitude: 1, sign: Positive, width: As32 })
-"_"@(FileId(1), 19..20) -> ConstError { kind: NotConstExpr(None), span: (FileId(1), 24..27) }
+"_"@(FileId(1), 19..20) -> ConstError { kind: NotConstExpr(Expr), span: (FileId(1), 24..27) }
 
 error in file FileId(1) at 24..27: cannot compute expression at compile-time
 | error in file FileId(1) for 24..27: expression cannot be computed at compile-time

--- a/compiler/toc_analysis/src/const_eval/test.rs
+++ b/compiler/toc_analysis/src/const_eval/test.rs
@@ -772,6 +772,18 @@ fn error_no_const_expr() {
     // Using a missing expression
     assert_const_eval("const b := ()");
 
+    // Referencing an unresolved import
+    assert_const_eval("
+    module base
+        export ~. tail
+    end base
+
+    module target
+        import tail
+        const _ := tail
+    end target
+    ");
+
     // Referencing `self`
     // TODO: Uncomment when `self` is lowered again
     /*

--- a/compiler/toc_analysis/src/const_eval/test.rs
+++ b/compiler/toc_analysis/src/const_eval/test.rs
@@ -773,7 +773,8 @@ fn error_no_const_expr() {
     assert_const_eval("const b := ()");
 
     // Referencing an unresolved import
-    assert_const_eval("
+    assert_const_eval(
+        "
     module base
         export ~. tail
     end base
@@ -782,7 +783,8 @@ fn error_no_const_expr() {
         import tail
         const _ := tail
     end target
-    ");
+    ",
+    );
 
     // Referencing `self`
     // TODO: Uncomment when `self` is lowered again

--- a/compiler/toc_analysis/src/ty/query.rs
+++ b/compiler/toc_analysis/src/ty/query.rs
@@ -118,9 +118,12 @@ fn lookup_binding_def(db: &dyn TypeDatabase, bind_src: BindingSource) -> Option<
 
             // Only name exprs and fields can produce a binding
             match &library.body(body_id).expr(expr_id).kind {
-                expr::ExprKind::Missing => (None),
+                expr::ExprKind::Missing => None,
                 expr::ExprKind::Name(name) => match name {
-                    expr::Name::Name(def_id) => (Some(DefId(lib_id, *def_id))),
+                    expr::Name::Name(binding) => match library.binding_resolve(*binding) {
+                        symbol::Resolve::Def(local_def) => Some(DefId(lib_id, local_def)),
+                        symbol::Resolve::Err => None,
+                    },
                     expr::Name::Self_ => todo!(),
                 },
                 expr::ExprKind::Field(field) => {
@@ -208,8 +211,11 @@ pub(super) fn value_produced(
             match &library.body(body_id).expr(expr_id).kind {
                 expr::ExprKind::Missing => Err(NotValue::Missing),
                 expr::ExprKind::Name(name) => match name {
-                    expr::Name::Name(def_id) => {
-                        let def_id = DefId(lib_id, *def_id);
+                    expr::Name::Name(binding) => {
+                        let def_id = match library.binding_resolve(*binding) {
+                            symbol::Resolve::Def(local_def) => (DefId(lib_id, local_def)),
+                            symbol::Resolve::Err => return Err(NotValue::Missing),
+                        };
 
                         match db.def_owner(def_id) {
                             Some(DefOwner::Export(mod_id, export_id)) => {
@@ -566,9 +572,14 @@ pub(crate) fn find_exported_def(
     match &library.body(body_id).expr(expr_id).kind {
         expr::ExprKind::Name(expr) => {
             match expr {
-                expr::Name::Name(local_def) => {
+                expr::Name::Name(binding) => {
                     // Take from the def
-                    db.exporting_def(DefId(library_id, *local_def).into())
+                    let def_id = match library.binding_resolve(*binding) {
+                        symbol::Resolve::Def(local_def) => (DefId(library_id, local_def)),
+                        symbol::Resolve::Err => return None,
+                    };
+
+                    db.exporting_def(def_id.into())
                 }
                 expr::Name::Self_ => None,
             }

--- a/compiler/toc_analysis/src/typeck.rs
+++ b/compiler/toc_analysis/src/typeck.rs
@@ -509,7 +509,10 @@ impl TypeCheck<'_> {
             item::ImportMutability::Explicit(muta, span) => (muta, span),
         };
 
-        let canon_def = self.db.resolve_def(DefId(self.library_id, item.def_id));
+        let canon_def = match self.db.resolve_def(DefId(self.library_id, item.def_id)) {
+            Ok(def) => def,
+            Err(_) => return,
+        };
         let real_mut = self.db.value_produced(canon_def.into());
 
         let is_applicable = match real_mut {
@@ -2023,20 +2026,22 @@ impl TypeCheck<'_> {
             }
 
             // Poke through any remaining indirection
-            db.resolve_def(def_id)
+            db.resolve_def(def_id).ok()
         };
 
-        if !db.symbol_kind(def_id).is_missing_or(SymbolKind::is_type) {
-            let span = span.lookup_in(library);
+        if let Some(def_id) = def_id {
+            if !db.symbol_kind(def_id).is_missing_or(SymbolKind::is_type) {
+                let span = span.lookup_in(library);
 
-            self.report_mismatched_binding(
-                SymbolKind::Type,
-                def_id.into(),
-                span,
-                span,
-                |thing| format!("cannot use {thing} as a type alias"),
-                None,
-            );
+                self.report_mismatched_binding(
+                    SymbolKind::Type,
+                    def_id.into(),
+                    span,
+                    span,
+                    |thing| format!("cannot use {thing} as a type alias"),
+                    None,
+                );
+            }
         }
     }
 
@@ -2653,7 +2658,9 @@ impl TypeCheck<'_> {
         let (thing, def_info) = match db.binding_def(value_src.into()) {
             Some(unresolved_def) => {
                 // From some def
-                let def_id = db.resolve_def(unresolved_def);
+                let def_id = db
+                    .resolve_def(unresolved_def)
+                    .expect("needs to be a resolved def");
                 let binding_to = match db.symbol_kind(def_id) {
                     Some(binding_to) => binding_to,
                     None => return true,

--- a/compiler/toc_analysis/src/typeck.rs
+++ b/compiler/toc_analysis/src/typeck.rs
@@ -1986,7 +1986,13 @@ impl TypeCheck<'_> {
         let def_id = {
             let in_module = db.inside_module(id.in_library(*library_id).into());
             // Walk the segment path while we still can
-            let mut def_id = DefId(*library_id, *ty.base_def.item());
+            let mut def_id = {
+                let library = db.library(*library_id);
+                match library.binding_resolve(ty.base_def) {
+                    toc_hir::symbol::Resolve::Def(local_def) => DefId(*library_id, local_def),
+                    toc_hir::symbol::Resolve::Err => return,
+                }
+            };
 
             for segment in &ty.segments {
                 let fields = db.fields_of((def_id, in_module).into());

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_enums_equal.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_enums_equal.snap
@@ -1,6 +1,6 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-expression: "\n    % Different enums\n    type e1 : enum(v)\n    type e2 : enum(v)\n    var ae1 : e1\n    var be2 : e2\n    var aas : enum(v)\n\n    % should all produce boolean anyway\n    var _v_res : boolean\n\n    _v_res := ae1 = be2\n    _v_res := be1 = ae2\n    _v_res := aes = ae1\n    _v_res := ae1 = aes\n    "
+expression: "\n    % Different enums\n    type e1 : enum(v)\n    type e2 : enum(v)\n    var ae : e1\n    var be : e2\n    var aA : enum(v)\n    var bA : enum(v)\n\n    % should all produce boolean anyway\n    var _v_res : boolean\n\n    _v_res := ae = be\n    _v_res := be = ae\n    _v_res := aA = ae\n    _v_res := ae = aA\n    _v_res := aA = bA\n    "
 ---
 "v"@(FileId(1), 42..43) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "v"@(FileId(1), 42..43), )
 "e1"@(FileId(1), 37..44) [Enum]: <error>
@@ -8,19 +8,39 @@ expression: "\n    % Different enums\n    type e1 : enum(v)\n    type e2 : enum(
 "v"@(FileId(1), 64..65) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(4))] ( "v"@(FileId(1), 64..65), )
 "e2"@(FileId(1), 59..66) [Enum]: <error>
 "e2"@(FileId(1), 54..56) [Type]: enum[DefId(LibraryId(0), LocalDefId(4))] ( "v"@(FileId(1), 64..65), )
-"ae1"@(FileId(1), 75..78) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "v"@(FileId(1), 42..43), )
-"be2"@(FileId(1), 92..95) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(4))] ( "v"@(FileId(1), 64..65), )
-"v"@(FileId(1), 120..121) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(9))] ( "v"@(FileId(1), 120..121), )
-"<anonymous>"@(FileId(1), 115..122) [Enum]: <error>
-"aas"@(FileId(1), 109..112) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(9))] ( "v"@(FileId(1), 120..121), )
-"_v_res"@(FileId(1), 172..178) [ConstVar(Var, No)]: boolean
-"be1"@(FileId(1), 228..231) [Undeclared]: <error>
-"ae2"@(FileId(1), 234..237) [Undeclared]: <error>
-"aes"@(FileId(1), 252..255) [Undeclared]: <error>
+"ae"@(FileId(1), 75..77) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "v"@(FileId(1), 42..43), )
+"be"@(FileId(1), 91..93) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(4))] ( "v"@(FileId(1), 64..65), )
+"v"@(FileId(1), 117..118) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(9))] ( "v"@(FileId(1), 117..118), )
+"<anonymous>"@(FileId(1), 112..119) [Enum]: <error>
+"aA"@(FileId(1), 107..109) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(9))] ( "v"@(FileId(1), 117..118), )
+"v"@(FileId(1), 138..139) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(12))] ( "v"@(FileId(1), 138..139), )
+"<anonymous>"@(FileId(1), 133..140) [Enum]: <error>
+"bA"@(FileId(1), 128..130) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(12))] ( "v"@(FileId(1), 138..139), )
+"_v_res"@(FileId(1), 190..196) [ConstVar(Var, No)]: boolean
 "<root>"@(dummy) [Module(No)]: <error>
 
-error in file FileId(1) at 208..209: mismatched types for `=`
-| note in file FileId(1) for 210..213: this is of type `enum e2`
-| note in file FileId(1) for 204..207: this is of type `enum e1`
-| error in file FileId(1) for 208..209: `enum e1` cannot be compared to `enum e2`
+error in file FileId(1) at 225..226: mismatched types for `=`
+| note in file FileId(1) for 227..229: this is of type `enum e2`
+| note in file FileId(1) for 222..224: this is of type `enum e1`
+| error in file FileId(1) for 225..226: `enum e1` cannot be compared to `enum e2`
+| info: operands must both be the same type
+error in file FileId(1) at 247..248: mismatched types for `=`
+| note in file FileId(1) for 249..251: this is of type `enum e1`
+| note in file FileId(1) for 244..246: this is of type `enum e2`
+| error in file FileId(1) for 247..248: `enum e2` cannot be compared to `enum e1`
+| info: operands must both be the same type
+error in file FileId(1) at 269..270: mismatched types for `=`
+| note in file FileId(1) for 271..273: this is of type `enum e1`
+| note in file FileId(1) for 266..268: this is of type `enum <anonymous>`
+| error in file FileId(1) for 269..270: `enum <anonymous>` cannot be compared to `enum e1`
+| info: operands must both be the same type
+error in file FileId(1) at 291..292: mismatched types for `=`
+| note in file FileId(1) for 293..295: this is of type `enum <anonymous>`
+| note in file FileId(1) for 288..290: this is of type `enum e1`
+| error in file FileId(1) for 291..292: `enum e1` cannot be compared to `enum <anonymous>`
+| info: operands must both be the same type
+error in file FileId(1) at 313..314: mismatched types for `=`
+| note in file FileId(1) for 315..317: this is of type `enum <anonymous>`
+| note in file FileId(1) for 310..312: this is of type `enum <anonymous>`
+| error in file FileId(1) for 313..314: `enum <anonymous>` cannot be compared to `enum <anonymous>`
 | info: operands must both be the same type

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_enums_greater.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_enums_greater.snap
@@ -1,6 +1,6 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-expression: "\n    % Different enums\n    type e1 : enum(v)\n    type e2 : enum(v)\n    var ae1 : e1\n    var be2 : e2\n    var aas : enum(v)\n\n    % should all produce boolean anyway\n    var _v_res : boolean\n\n    _v_res := ae1 > be2\n    _v_res := be1 > ae2\n    _v_res := aes > ae1\n    _v_res := ae1 > aes\n    "
+expression: "\n    % Different enums\n    type e1 : enum(v)\n    type e2 : enum(v)\n    var ae : e1\n    var be : e2\n    var aA : enum(v)\n    var bA : enum(v)\n\n    % should all produce boolean anyway\n    var _v_res : boolean\n\n    _v_res := ae > be\n    _v_res := be > ae\n    _v_res := aA > ae\n    _v_res := ae > aA\n    _v_res := aA > bA\n    "
 ---
 "v"@(FileId(1), 42..43) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "v"@(FileId(1), 42..43), )
 "e1"@(FileId(1), 37..44) [Enum]: <error>
@@ -8,19 +8,39 @@ expression: "\n    % Different enums\n    type e1 : enum(v)\n    type e2 : enum(
 "v"@(FileId(1), 64..65) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(4))] ( "v"@(FileId(1), 64..65), )
 "e2"@(FileId(1), 59..66) [Enum]: <error>
 "e2"@(FileId(1), 54..56) [Type]: enum[DefId(LibraryId(0), LocalDefId(4))] ( "v"@(FileId(1), 64..65), )
-"ae1"@(FileId(1), 75..78) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "v"@(FileId(1), 42..43), )
-"be2"@(FileId(1), 92..95) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(4))] ( "v"@(FileId(1), 64..65), )
-"v"@(FileId(1), 120..121) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(9))] ( "v"@(FileId(1), 120..121), )
-"<anonymous>"@(FileId(1), 115..122) [Enum]: <error>
-"aas"@(FileId(1), 109..112) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(9))] ( "v"@(FileId(1), 120..121), )
-"_v_res"@(FileId(1), 172..178) [ConstVar(Var, No)]: boolean
-"be1"@(FileId(1), 228..231) [Undeclared]: <error>
-"ae2"@(FileId(1), 234..237) [Undeclared]: <error>
-"aes"@(FileId(1), 252..255) [Undeclared]: <error>
+"ae"@(FileId(1), 75..77) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "v"@(FileId(1), 42..43), )
+"be"@(FileId(1), 91..93) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(4))] ( "v"@(FileId(1), 64..65), )
+"v"@(FileId(1), 117..118) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(9))] ( "v"@(FileId(1), 117..118), )
+"<anonymous>"@(FileId(1), 112..119) [Enum]: <error>
+"aA"@(FileId(1), 107..109) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(9))] ( "v"@(FileId(1), 117..118), )
+"v"@(FileId(1), 138..139) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(12))] ( "v"@(FileId(1), 138..139), )
+"<anonymous>"@(FileId(1), 133..140) [Enum]: <error>
+"bA"@(FileId(1), 128..130) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(12))] ( "v"@(FileId(1), 138..139), )
+"_v_res"@(FileId(1), 190..196) [ConstVar(Var, No)]: boolean
 "<root>"@(dummy) [Module(No)]: <error>
 
-error in file FileId(1) at 208..209: mismatched types for `>`
-| note in file FileId(1) for 210..213: this is of type `enum e2`
-| note in file FileId(1) for 204..207: this is of type `enum e1`
-| error in file FileId(1) for 208..209: `enum e1` cannot be compared to `enum e2`
+error in file FileId(1) at 225..226: mismatched types for `>`
+| note in file FileId(1) for 227..229: this is of type `enum e2`
+| note in file FileId(1) for 222..224: this is of type `enum e1`
+| error in file FileId(1) for 225..226: `enum e1` cannot be compared to `enum e2`
+| info: operands must both be the same type
+error in file FileId(1) at 247..248: mismatched types for `>`
+| note in file FileId(1) for 249..251: this is of type `enum e1`
+| note in file FileId(1) for 244..246: this is of type `enum e2`
+| error in file FileId(1) for 247..248: `enum e2` cannot be compared to `enum e1`
+| info: operands must both be the same type
+error in file FileId(1) at 269..270: mismatched types for `>`
+| note in file FileId(1) for 271..273: this is of type `enum e1`
+| note in file FileId(1) for 266..268: this is of type `enum <anonymous>`
+| error in file FileId(1) for 269..270: `enum <anonymous>` cannot be compared to `enum e1`
+| info: operands must both be the same type
+error in file FileId(1) at 291..292: mismatched types for `>`
+| note in file FileId(1) for 293..295: this is of type `enum <anonymous>`
+| note in file FileId(1) for 288..290: this is of type `enum e1`
+| error in file FileId(1) for 291..292: `enum e1` cannot be compared to `enum <anonymous>`
+| info: operands must both be the same type
+error in file FileId(1) at 313..314: mismatched types for `>`
+| note in file FileId(1) for 315..317: this is of type `enum <anonymous>`
+| note in file FileId(1) for 310..312: this is of type `enum <anonymous>`
+| error in file FileId(1) for 313..314: `enum <anonymous>` cannot be compared to `enum <anonymous>`
 | info: operands must both be the same type

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_enums_greater_eq.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_enums_greater_eq.snap
@@ -1,6 +1,6 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-expression: "\n    % Different enums\n    type e1 : enum(v)\n    type e2 : enum(v)\n    var ae1 : e1\n    var be2 : e2\n    var aas : enum(v)\n\n    % should all produce boolean anyway\n    var _v_res : boolean\n\n    _v_res := ae1 >= be2\n    _v_res := be1 >= ae2\n    _v_res := aes >= ae1\n    _v_res := ae1 >= aes\n    "
+expression: "\n    % Different enums\n    type e1 : enum(v)\n    type e2 : enum(v)\n    var ae : e1\n    var be : e2\n    var aA : enum(v)\n    var bA : enum(v)\n\n    % should all produce boolean anyway\n    var _v_res : boolean\n\n    _v_res := ae >= be\n    _v_res := be >= ae\n    _v_res := aA >= ae\n    _v_res := ae >= aA\n    _v_res := aA >= bA\n    "
 ---
 "v"@(FileId(1), 42..43) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "v"@(FileId(1), 42..43), )
 "e1"@(FileId(1), 37..44) [Enum]: <error>
@@ -8,19 +8,39 @@ expression: "\n    % Different enums\n    type e1 : enum(v)\n    type e2 : enum(
 "v"@(FileId(1), 64..65) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(4))] ( "v"@(FileId(1), 64..65), )
 "e2"@(FileId(1), 59..66) [Enum]: <error>
 "e2"@(FileId(1), 54..56) [Type]: enum[DefId(LibraryId(0), LocalDefId(4))] ( "v"@(FileId(1), 64..65), )
-"ae1"@(FileId(1), 75..78) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "v"@(FileId(1), 42..43), )
-"be2"@(FileId(1), 92..95) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(4))] ( "v"@(FileId(1), 64..65), )
-"v"@(FileId(1), 120..121) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(9))] ( "v"@(FileId(1), 120..121), )
-"<anonymous>"@(FileId(1), 115..122) [Enum]: <error>
-"aas"@(FileId(1), 109..112) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(9))] ( "v"@(FileId(1), 120..121), )
-"_v_res"@(FileId(1), 172..178) [ConstVar(Var, No)]: boolean
-"be1"@(FileId(1), 229..232) [Undeclared]: <error>
-"ae2"@(FileId(1), 236..239) [Undeclared]: <error>
-"aes"@(FileId(1), 254..257) [Undeclared]: <error>
+"ae"@(FileId(1), 75..77) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "v"@(FileId(1), 42..43), )
+"be"@(FileId(1), 91..93) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(4))] ( "v"@(FileId(1), 64..65), )
+"v"@(FileId(1), 117..118) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(9))] ( "v"@(FileId(1), 117..118), )
+"<anonymous>"@(FileId(1), 112..119) [Enum]: <error>
+"aA"@(FileId(1), 107..109) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(9))] ( "v"@(FileId(1), 117..118), )
+"v"@(FileId(1), 138..139) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(12))] ( "v"@(FileId(1), 138..139), )
+"<anonymous>"@(FileId(1), 133..140) [Enum]: <error>
+"bA"@(FileId(1), 128..130) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(12))] ( "v"@(FileId(1), 138..139), )
+"_v_res"@(FileId(1), 190..196) [ConstVar(Var, No)]: boolean
 "<root>"@(dummy) [Module(No)]: <error>
 
-error in file FileId(1) at 208..210: mismatched types for `>=`
-| note in file FileId(1) for 211..214: this is of type `enum e2`
-| note in file FileId(1) for 204..207: this is of type `enum e1`
-| error in file FileId(1) for 208..210: `enum e1` cannot be compared to `enum e2`
+error in file FileId(1) at 225..227: mismatched types for `>=`
+| note in file FileId(1) for 228..230: this is of type `enum e2`
+| note in file FileId(1) for 222..224: this is of type `enum e1`
+| error in file FileId(1) for 225..227: `enum e1` cannot be compared to `enum e2`
+| info: operands must both be the same type
+error in file FileId(1) at 248..250: mismatched types for `>=`
+| note in file FileId(1) for 251..253: this is of type `enum e1`
+| note in file FileId(1) for 245..247: this is of type `enum e2`
+| error in file FileId(1) for 248..250: `enum e2` cannot be compared to `enum e1`
+| info: operands must both be the same type
+error in file FileId(1) at 271..273: mismatched types for `>=`
+| note in file FileId(1) for 274..276: this is of type `enum e1`
+| note in file FileId(1) for 268..270: this is of type `enum <anonymous>`
+| error in file FileId(1) for 271..273: `enum <anonymous>` cannot be compared to `enum e1`
+| info: operands must both be the same type
+error in file FileId(1) at 294..296: mismatched types for `>=`
+| note in file FileId(1) for 297..299: this is of type `enum <anonymous>`
+| note in file FileId(1) for 291..293: this is of type `enum e1`
+| error in file FileId(1) for 294..296: `enum e1` cannot be compared to `enum <anonymous>`
+| info: operands must both be the same type
+error in file FileId(1) at 317..319: mismatched types for `>=`
+| note in file FileId(1) for 320..322: this is of type `enum <anonymous>`
+| note in file FileId(1) for 314..316: this is of type `enum <anonymous>`
+| error in file FileId(1) for 317..319: `enum <anonymous>` cannot be compared to `enum <anonymous>`
 | info: operands must both be the same type

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_enums_less.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_enums_less.snap
@@ -1,6 +1,6 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-expression: "\n    % Different enums\n    type e1 : enum(v)\n    type e2 : enum(v)\n    var ae1 : e1\n    var be2 : e2\n    var aas : enum(v)\n\n    % should all produce boolean anyway\n    var _v_res : boolean\n\n    _v_res := ae1 < be2\n    _v_res := be1 < ae2\n    _v_res := aes < ae1\n    _v_res := ae1 < aes\n    "
+expression: "\n    % Different enums\n    type e1 : enum(v)\n    type e2 : enum(v)\n    var ae : e1\n    var be : e2\n    var aA : enum(v)\n    var bA : enum(v)\n\n    % should all produce boolean anyway\n    var _v_res : boolean\n\n    _v_res := ae < be\n    _v_res := be < ae\n    _v_res := aA < ae\n    _v_res := ae < aA\n    _v_res := aA < bA\n    "
 ---
 "v"@(FileId(1), 42..43) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "v"@(FileId(1), 42..43), )
 "e1"@(FileId(1), 37..44) [Enum]: <error>
@@ -8,19 +8,39 @@ expression: "\n    % Different enums\n    type e1 : enum(v)\n    type e2 : enum(
 "v"@(FileId(1), 64..65) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(4))] ( "v"@(FileId(1), 64..65), )
 "e2"@(FileId(1), 59..66) [Enum]: <error>
 "e2"@(FileId(1), 54..56) [Type]: enum[DefId(LibraryId(0), LocalDefId(4))] ( "v"@(FileId(1), 64..65), )
-"ae1"@(FileId(1), 75..78) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "v"@(FileId(1), 42..43), )
-"be2"@(FileId(1), 92..95) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(4))] ( "v"@(FileId(1), 64..65), )
-"v"@(FileId(1), 120..121) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(9))] ( "v"@(FileId(1), 120..121), )
-"<anonymous>"@(FileId(1), 115..122) [Enum]: <error>
-"aas"@(FileId(1), 109..112) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(9))] ( "v"@(FileId(1), 120..121), )
-"_v_res"@(FileId(1), 172..178) [ConstVar(Var, No)]: boolean
-"be1"@(FileId(1), 228..231) [Undeclared]: <error>
-"ae2"@(FileId(1), 234..237) [Undeclared]: <error>
-"aes"@(FileId(1), 252..255) [Undeclared]: <error>
+"ae"@(FileId(1), 75..77) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "v"@(FileId(1), 42..43), )
+"be"@(FileId(1), 91..93) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(4))] ( "v"@(FileId(1), 64..65), )
+"v"@(FileId(1), 117..118) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(9))] ( "v"@(FileId(1), 117..118), )
+"<anonymous>"@(FileId(1), 112..119) [Enum]: <error>
+"aA"@(FileId(1), 107..109) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(9))] ( "v"@(FileId(1), 117..118), )
+"v"@(FileId(1), 138..139) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(12))] ( "v"@(FileId(1), 138..139), )
+"<anonymous>"@(FileId(1), 133..140) [Enum]: <error>
+"bA"@(FileId(1), 128..130) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(12))] ( "v"@(FileId(1), 138..139), )
+"_v_res"@(FileId(1), 190..196) [ConstVar(Var, No)]: boolean
 "<root>"@(dummy) [Module(No)]: <error>
 
-error in file FileId(1) at 208..209: mismatched types for `<`
-| note in file FileId(1) for 210..213: this is of type `enum e2`
-| note in file FileId(1) for 204..207: this is of type `enum e1`
-| error in file FileId(1) for 208..209: `enum e1` cannot be compared to `enum e2`
+error in file FileId(1) at 225..226: mismatched types for `<`
+| note in file FileId(1) for 227..229: this is of type `enum e2`
+| note in file FileId(1) for 222..224: this is of type `enum e1`
+| error in file FileId(1) for 225..226: `enum e1` cannot be compared to `enum e2`
+| info: operands must both be the same type
+error in file FileId(1) at 247..248: mismatched types for `<`
+| note in file FileId(1) for 249..251: this is of type `enum e1`
+| note in file FileId(1) for 244..246: this is of type `enum e2`
+| error in file FileId(1) for 247..248: `enum e2` cannot be compared to `enum e1`
+| info: operands must both be the same type
+error in file FileId(1) at 269..270: mismatched types for `<`
+| note in file FileId(1) for 271..273: this is of type `enum e1`
+| note in file FileId(1) for 266..268: this is of type `enum <anonymous>`
+| error in file FileId(1) for 269..270: `enum <anonymous>` cannot be compared to `enum e1`
+| info: operands must both be the same type
+error in file FileId(1) at 291..292: mismatched types for `<`
+| note in file FileId(1) for 293..295: this is of type `enum <anonymous>`
+| note in file FileId(1) for 288..290: this is of type `enum e1`
+| error in file FileId(1) for 291..292: `enum e1` cannot be compared to `enum <anonymous>`
+| info: operands must both be the same type
+error in file FileId(1) at 313..314: mismatched types for `<`
+| note in file FileId(1) for 315..317: this is of type `enum <anonymous>`
+| note in file FileId(1) for 310..312: this is of type `enum <anonymous>`
+| error in file FileId(1) for 313..314: `enum <anonymous>` cannot be compared to `enum <anonymous>`
 | info: operands must both be the same type

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_enums_less_eq.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_enums_less_eq.snap
@@ -1,6 +1,6 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-expression: "\n    % Different enums\n    type e1 : enum(v)\n    type e2 : enum(v)\n    var ae1 : e1\n    var be2 : e2\n    var aas : enum(v)\n\n    % should all produce boolean anyway\n    var _v_res : boolean\n\n    _v_res := ae1 <= be2\n    _v_res := be1 <= ae2\n    _v_res := aes <= ae1\n    _v_res := ae1 <= aes\n    "
+expression: "\n    % Different enums\n    type e1 : enum(v)\n    type e2 : enum(v)\n    var ae : e1\n    var be : e2\n    var aA : enum(v)\n    var bA : enum(v)\n\n    % should all produce boolean anyway\n    var _v_res : boolean\n\n    _v_res := ae <= be\n    _v_res := be <= ae\n    _v_res := aA <= ae\n    _v_res := ae <= aA\n    _v_res := aA <= bA\n    "
 ---
 "v"@(FileId(1), 42..43) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "v"@(FileId(1), 42..43), )
 "e1"@(FileId(1), 37..44) [Enum]: <error>
@@ -8,19 +8,39 @@ expression: "\n    % Different enums\n    type e1 : enum(v)\n    type e2 : enum(
 "v"@(FileId(1), 64..65) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(4))] ( "v"@(FileId(1), 64..65), )
 "e2"@(FileId(1), 59..66) [Enum]: <error>
 "e2"@(FileId(1), 54..56) [Type]: enum[DefId(LibraryId(0), LocalDefId(4))] ( "v"@(FileId(1), 64..65), )
-"ae1"@(FileId(1), 75..78) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "v"@(FileId(1), 42..43), )
-"be2"@(FileId(1), 92..95) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(4))] ( "v"@(FileId(1), 64..65), )
-"v"@(FileId(1), 120..121) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(9))] ( "v"@(FileId(1), 120..121), )
-"<anonymous>"@(FileId(1), 115..122) [Enum]: <error>
-"aas"@(FileId(1), 109..112) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(9))] ( "v"@(FileId(1), 120..121), )
-"_v_res"@(FileId(1), 172..178) [ConstVar(Var, No)]: boolean
-"be1"@(FileId(1), 229..232) [Undeclared]: <error>
-"ae2"@(FileId(1), 236..239) [Undeclared]: <error>
-"aes"@(FileId(1), 254..257) [Undeclared]: <error>
+"ae"@(FileId(1), 75..77) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "v"@(FileId(1), 42..43), )
+"be"@(FileId(1), 91..93) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(4))] ( "v"@(FileId(1), 64..65), )
+"v"@(FileId(1), 117..118) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(9))] ( "v"@(FileId(1), 117..118), )
+"<anonymous>"@(FileId(1), 112..119) [Enum]: <error>
+"aA"@(FileId(1), 107..109) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(9))] ( "v"@(FileId(1), 117..118), )
+"v"@(FileId(1), 138..139) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(12))] ( "v"@(FileId(1), 138..139), )
+"<anonymous>"@(FileId(1), 133..140) [Enum]: <error>
+"bA"@(FileId(1), 128..130) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(12))] ( "v"@(FileId(1), 138..139), )
+"_v_res"@(FileId(1), 190..196) [ConstVar(Var, No)]: boolean
 "<root>"@(dummy) [Module(No)]: <error>
 
-error in file FileId(1) at 208..210: mismatched types for `<=`
-| note in file FileId(1) for 211..214: this is of type `enum e2`
-| note in file FileId(1) for 204..207: this is of type `enum e1`
-| error in file FileId(1) for 208..210: `enum e1` cannot be compared to `enum e2`
+error in file FileId(1) at 225..227: mismatched types for `<=`
+| note in file FileId(1) for 228..230: this is of type `enum e2`
+| note in file FileId(1) for 222..224: this is of type `enum e1`
+| error in file FileId(1) for 225..227: `enum e1` cannot be compared to `enum e2`
+| info: operands must both be the same type
+error in file FileId(1) at 248..250: mismatched types for `<=`
+| note in file FileId(1) for 251..253: this is of type `enum e1`
+| note in file FileId(1) for 245..247: this is of type `enum e2`
+| error in file FileId(1) for 248..250: `enum e2` cannot be compared to `enum e1`
+| info: operands must both be the same type
+error in file FileId(1) at 271..273: mismatched types for `<=`
+| note in file FileId(1) for 274..276: this is of type `enum e1`
+| note in file FileId(1) for 268..270: this is of type `enum <anonymous>`
+| error in file FileId(1) for 271..273: `enum <anonymous>` cannot be compared to `enum e1`
+| info: operands must both be the same type
+error in file FileId(1) at 294..296: mismatched types for `<=`
+| note in file FileId(1) for 297..299: this is of type `enum <anonymous>`
+| note in file FileId(1) for 291..293: this is of type `enum e1`
+| error in file FileId(1) for 294..296: `enum e1` cannot be compared to `enum <anonymous>`
+| info: operands must both be the same type
+error in file FileId(1) at 317..319: mismatched types for `<=`
+| note in file FileId(1) for 320..322: this is of type `enum <anonymous>`
+| note in file FileId(1) for 314..316: this is of type `enum <anonymous>`
+| error in file FileId(1) for 317..319: `enum <anonymous>` cannot be compared to `enum <anonymous>`
 | info: operands must both be the same type

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_enums_not_equal.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_enums_not_equal.snap
@@ -1,6 +1,6 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-expression: "\n    % Different enums\n    type e1 : enum(v)\n    type e2 : enum(v)\n    var ae1 : e1\n    var be2 : e2\n    var aas : enum(v)\n\n    % should all produce boolean anyway\n    var _v_res : boolean\n\n    _v_res := ae1 not= be2\n    _v_res := be1 not= ae2\n    _v_res := aes not= ae1\n    _v_res := ae1 not= aes\n    "
+expression: "\n    % Different enums\n    type e1 : enum(v)\n    type e2 : enum(v)\n    var ae : e1\n    var be : e2\n    var aA : enum(v)\n    var bA : enum(v)\n\n    % should all produce boolean anyway\n    var _v_res : boolean\n\n    _v_res := ae not= be\n    _v_res := be not= ae\n    _v_res := aA not= ae\n    _v_res := ae not= aA\n    _v_res := aA not= bA\n    "
 ---
 "v"@(FileId(1), 42..43) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "v"@(FileId(1), 42..43), )
 "e1"@(FileId(1), 37..44) [Enum]: <error>
@@ -8,19 +8,39 @@ expression: "\n    % Different enums\n    type e1 : enum(v)\n    type e2 : enum(
 "v"@(FileId(1), 64..65) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(4))] ( "v"@(FileId(1), 64..65), )
 "e2"@(FileId(1), 59..66) [Enum]: <error>
 "e2"@(FileId(1), 54..56) [Type]: enum[DefId(LibraryId(0), LocalDefId(4))] ( "v"@(FileId(1), 64..65), )
-"ae1"@(FileId(1), 75..78) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "v"@(FileId(1), 42..43), )
-"be2"@(FileId(1), 92..95) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(4))] ( "v"@(FileId(1), 64..65), )
-"v"@(FileId(1), 120..121) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(9))] ( "v"@(FileId(1), 120..121), )
-"<anonymous>"@(FileId(1), 115..122) [Enum]: <error>
-"aas"@(FileId(1), 109..112) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(9))] ( "v"@(FileId(1), 120..121), )
-"_v_res"@(FileId(1), 172..178) [ConstVar(Var, No)]: boolean
-"be1"@(FileId(1), 231..234) [Undeclared]: <error>
-"ae2"@(FileId(1), 240..243) [Undeclared]: <error>
-"aes"@(FileId(1), 258..261) [Undeclared]: <error>
+"ae"@(FileId(1), 75..77) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "v"@(FileId(1), 42..43), )
+"be"@(FileId(1), 91..93) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(4))] ( "v"@(FileId(1), 64..65), )
+"v"@(FileId(1), 117..118) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(9))] ( "v"@(FileId(1), 117..118), )
+"<anonymous>"@(FileId(1), 112..119) [Enum]: <error>
+"aA"@(FileId(1), 107..109) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(9))] ( "v"@(FileId(1), 117..118), )
+"v"@(FileId(1), 138..139) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(12))] ( "v"@(FileId(1), 138..139), )
+"<anonymous>"@(FileId(1), 133..140) [Enum]: <error>
+"bA"@(FileId(1), 128..130) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(12))] ( "v"@(FileId(1), 138..139), )
+"_v_res"@(FileId(1), 190..196) [ConstVar(Var, No)]: boolean
 "<root>"@(dummy) [Module(No)]: <error>
 
-error in file FileId(1) at 208..212: mismatched types for `not =`
-| note in file FileId(1) for 213..216: this is of type `enum e2`
-| note in file FileId(1) for 204..207: this is of type `enum e1`
-| error in file FileId(1) for 208..212: `enum e1` cannot be compared to `enum e2`
+error in file FileId(1) at 225..229: mismatched types for `not =`
+| note in file FileId(1) for 230..232: this is of type `enum e2`
+| note in file FileId(1) for 222..224: this is of type `enum e1`
+| error in file FileId(1) for 225..229: `enum e1` cannot be compared to `enum e2`
+| info: operands must both be the same type
+error in file FileId(1) at 250..254: mismatched types for `not =`
+| note in file FileId(1) for 255..257: this is of type `enum e1`
+| note in file FileId(1) for 247..249: this is of type `enum e2`
+| error in file FileId(1) for 250..254: `enum e2` cannot be compared to `enum e1`
+| info: operands must both be the same type
+error in file FileId(1) at 275..279: mismatched types for `not =`
+| note in file FileId(1) for 280..282: this is of type `enum e1`
+| note in file FileId(1) for 272..274: this is of type `enum <anonymous>`
+| error in file FileId(1) for 275..279: `enum <anonymous>` cannot be compared to `enum e1`
+| info: operands must both be the same type
+error in file FileId(1) at 300..304: mismatched types for `not =`
+| note in file FileId(1) for 305..307: this is of type `enum <anonymous>`
+| note in file FileId(1) for 297..299: this is of type `enum e1`
+| error in file FileId(1) for 300..304: `enum e1` cannot be compared to `enum <anonymous>`
+| info: operands must both be the same type
+error in file FileId(1) at 325..329: mismatched types for `not =`
+| note in file FileId(1) for 330..332: this is of type `enum <anonymous>`
+| note in file FileId(1) for 322..324: this is of type `enum <anonymous>`
+| error in file FileId(1) for 325..329: `enum <anonymous>` cannot be compared to `enum <anonymous>`
 | info: operands must both be the same type

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_equal.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_equal.snap
@@ -1,6 +1,6 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-expression: "\n    % Numerics\n    var r : real\n    var i : int\n    var n : nat\n\n    % Other scalars\n    var b : boolean\n\n    % Sized charseqs\n    var c : char\n    var c_sz : char(6)\n    var s : string\n    var s_sz : string(6)\n\n    % Different sets\n    type s1 : set of boolean\n    type s2 : set of boolean\n    var as1 : s1\n    var bs2 : s2\n    var aas : set of boolean\n\n    % should all produce boolean anyway\n    var _v_res : boolean\n\n    _v_res := r = b\n    _v_res := r = c\n    _v_res := r = c_sz\n    _v_res := r = s\n    _v_res := r = s_sz\n\n    _v_res := i = b\n    _v_res := i = c\n    _v_res := i = c_sz\n    _v_res := i = s\n    _v_res := i = s_sz\n\n    _v_res := n = b\n    _v_res := n = c\n    _v_res := n = c_sz\n    _v_res := n = s\n    _v_res := n = s_sz\n\n    _v_res := b = r\n    _v_res := b = i\n    _v_res := b = n\n    _v_res := b = c\n    _v_res := b = c_sz\n    _v_res := b = s\n    _v_res := b = s_sz\n\n    _v_res := c = r\n    _v_res := c = i\n    _v_res := c = n\n    _v_res := c = b\n\n    _v_res := c_sz = r\n    _v_res := c_sz = i\n    _v_res := c_sz = n\n    _v_res := c_sz = b\n\n    _v_res := s = r\n    _v_res := s = i\n    _v_res := s = n\n    _v_res := s = b\n\n    _v_res := s_sz = r\n    _v_res := s_sz = i\n    _v_res := s_sz = n\n    _v_res := s_sz = b\n\n    % Incompatible sets\n    _v_res := as1 = bs2\n    _v_res := bs1 = as2\n    _v_res := aas = as1\n    _v_res := as1 = aas\n    "
+expression: "\n    % Numerics\n    var r : real\n    var i : int\n    var n : nat\n\n    % Other scalars\n    var b : boolean\n\n    % Sized charseqs\n    var c : char\n    var c_sz : char(6)\n    var s : string\n    var s_sz : string(6)\n\n    % Different sets\n    type s1 : set of boolean\n    type s2 : set of boolean\n    var as1, as2 : s1\n    var bs1, bs2 : s2\n    var aas : set of boolean\n\n    % should all produce boolean anyway\n    var _v_res : boolean\n\n    _v_res := r = b\n    _v_res := r = c\n    _v_res := r = c_sz\n    _v_res := r = s\n    _v_res := r = s_sz\n\n    _v_res := i = b\n    _v_res := i = c\n    _v_res := i = c_sz\n    _v_res := i = s\n    _v_res := i = s_sz\n\n    _v_res := n = b\n    _v_res := n = c\n    _v_res := n = c_sz\n    _v_res := n = s\n    _v_res := n = s_sz\n\n    _v_res := b = r\n    _v_res := b = i\n    _v_res := b = n\n    _v_res := b = c\n    _v_res := b = c_sz\n    _v_res := b = s\n    _v_res := b = s_sz\n\n    _v_res := c = r\n    _v_res := c = i\n    _v_res := c = n\n    _v_res := c = b\n\n    _v_res := c_sz = r\n    _v_res := c_sz = i\n    _v_res := c_sz = n\n    _v_res := c_sz = b\n\n    _v_res := s = r\n    _v_res := s = i\n    _v_res := s = n\n    _v_res := s = b\n\n    _v_res := s_sz = r\n    _v_res := s_sz = i\n    _v_res := s_sz = n\n    _v_res := s_sz = b\n\n    % Incompatible sets\n    _v_res := as1 = bs2\n    _v_res := bs1 = as2\n    _v_res := aas = as1\n    _v_res := as1 = aas\n    "
 ---
 "r"@(FileId(1), 24..25) [ConstVar(Var, No)]: real
 "i"@(FileId(1), 41..42) [ConstVar(Var, No)]: int
@@ -15,216 +15,221 @@ expression: "\n    % Numerics\n    var r : real\n    var i : int\n    var n : na
 "s2"@(FileId(1), 277..291) [Set]: <error>
 "s2"@(FileId(1), 272..274) [Type]: set[DefId(LibraryId(0), LocalDefId(10))] of boolean
 "as1"@(FileId(1), 300..303) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(8))] of boolean
-"bs2"@(FileId(1), 317..320) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(10))] of boolean
-"<anonymous>"@(FileId(1), 340..354) [Set]: <error>
-"aas"@(FileId(1), 334..337) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(14))] of boolean
-"_v_res"@(FileId(1), 404..410) [ConstVar(Var, No)]: boolean
-"bs1"@(FileId(1), 1300..1303) [Undeclared]: <error>
-"as2"@(FileId(1), 1306..1309) [Undeclared]: <error>
+"as2"@(FileId(1), 305..308) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(8))] of boolean
+"bs1"@(FileId(1), 322..325) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(10))] of boolean
+"bs2"@(FileId(1), 327..330) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(10))] of boolean
+"<anonymous>"@(FileId(1), 350..364) [Set]: <error>
+"aas"@(FileId(1), 344..347) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(16))] of boolean
+"_v_res"@(FileId(1), 414..420) [ConstVar(Var, No)]: boolean
 "<root>"@(dummy) [Module(No)]: <error>
 
-error in file FileId(1) at 438..439: mismatched types for `=`
-| note in file FileId(1) for 440..441: this is of type `boolean`
-| note in file FileId(1) for 436..437: this is of type `real`
-| error in file FileId(1) for 438..439: `real` cannot be compared to `boolean`
+error in file FileId(1) at 448..449: mismatched types for `=`
+| note in file FileId(1) for 450..451: this is of type `boolean`
+| note in file FileId(1) for 446..447: this is of type `real`
+| error in file FileId(1) for 448..449: `real` cannot be compared to `boolean`
 | info: operands must both be the same type
-error in file FileId(1) at 458..459: mismatched types for `=`
-| note in file FileId(1) for 460..461: this is of type `char`
-| note in file FileId(1) for 456..457: this is of type `real`
-| error in file FileId(1) for 458..459: `real` cannot be compared to `char`
+error in file FileId(1) at 468..469: mismatched types for `=`
+| note in file FileId(1) for 470..471: this is of type `char`
+| note in file FileId(1) for 466..467: this is of type `real`
+| error in file FileId(1) for 468..469: `real` cannot be compared to `char`
 | info: operands must both be the same type
-error in file FileId(1) at 478..479: mismatched types for `=`
-| note in file FileId(1) for 480..484: this is of type `char(6)`
-| note in file FileId(1) for 476..477: this is of type `real`
-| error in file FileId(1) for 478..479: `real` cannot be compared to `char(6)`
+error in file FileId(1) at 488..489: mismatched types for `=`
+| note in file FileId(1) for 490..494: this is of type `char(6)`
+| note in file FileId(1) for 486..487: this is of type `real`
+| error in file FileId(1) for 488..489: `real` cannot be compared to `char(6)`
 | info: operands must both be the same type
-error in file FileId(1) at 501..502: mismatched types for `=`
-| note in file FileId(1) for 503..504: this is of type `string`
-| note in file FileId(1) for 499..500: this is of type `real`
-| error in file FileId(1) for 501..502: `real` cannot be compared to `string`
+error in file FileId(1) at 511..512: mismatched types for `=`
+| note in file FileId(1) for 513..514: this is of type `string`
+| note in file FileId(1) for 509..510: this is of type `real`
+| error in file FileId(1) for 511..512: `real` cannot be compared to `string`
 | info: operands must both be the same type
-error in file FileId(1) at 521..522: mismatched types for `=`
-| note in file FileId(1) for 523..527: this is of type `string(6)`
-| note in file FileId(1) for 519..520: this is of type `real`
-| error in file FileId(1) for 521..522: `real` cannot be compared to `string(6)`
+error in file FileId(1) at 531..532: mismatched types for `=`
+| note in file FileId(1) for 533..537: this is of type `string(6)`
+| note in file FileId(1) for 529..530: this is of type `real`
+| error in file FileId(1) for 531..532: `real` cannot be compared to `string(6)`
 | info: operands must both be the same type
-error in file FileId(1) at 545..546: mismatched types for `=`
-| note in file FileId(1) for 547..548: this is of type `boolean`
-| note in file FileId(1) for 543..544: this is of type `int`
-| error in file FileId(1) for 545..546: `int` cannot be compared to `boolean`
+error in file FileId(1) at 555..556: mismatched types for `=`
+| note in file FileId(1) for 557..558: this is of type `boolean`
+| note in file FileId(1) for 553..554: this is of type `int`
+| error in file FileId(1) for 555..556: `int` cannot be compared to `boolean`
 | info: operands must both be the same type
-error in file FileId(1) at 565..566: mismatched types for `=`
-| note in file FileId(1) for 567..568: this is of type `char`
-| note in file FileId(1) for 563..564: this is of type `int`
-| error in file FileId(1) for 565..566: `int` cannot be compared to `char`
+error in file FileId(1) at 575..576: mismatched types for `=`
+| note in file FileId(1) for 577..578: this is of type `char`
+| note in file FileId(1) for 573..574: this is of type `int`
+| error in file FileId(1) for 575..576: `int` cannot be compared to `char`
 | info: operands must both be the same type
-error in file FileId(1) at 585..586: mismatched types for `=`
-| note in file FileId(1) for 587..591: this is of type `char(6)`
-| note in file FileId(1) for 583..584: this is of type `int`
-| error in file FileId(1) for 585..586: `int` cannot be compared to `char(6)`
+error in file FileId(1) at 595..596: mismatched types for `=`
+| note in file FileId(1) for 597..601: this is of type `char(6)`
+| note in file FileId(1) for 593..594: this is of type `int`
+| error in file FileId(1) for 595..596: `int` cannot be compared to `char(6)`
 | info: operands must both be the same type
-error in file FileId(1) at 608..609: mismatched types for `=`
-| note in file FileId(1) for 610..611: this is of type `string`
-| note in file FileId(1) for 606..607: this is of type `int`
-| error in file FileId(1) for 608..609: `int` cannot be compared to `string`
+error in file FileId(1) at 618..619: mismatched types for `=`
+| note in file FileId(1) for 620..621: this is of type `string`
+| note in file FileId(1) for 616..617: this is of type `int`
+| error in file FileId(1) for 618..619: `int` cannot be compared to `string`
 | info: operands must both be the same type
-error in file FileId(1) at 628..629: mismatched types for `=`
-| note in file FileId(1) for 630..634: this is of type `string(6)`
-| note in file FileId(1) for 626..627: this is of type `int`
-| error in file FileId(1) for 628..629: `int` cannot be compared to `string(6)`
+error in file FileId(1) at 638..639: mismatched types for `=`
+| note in file FileId(1) for 640..644: this is of type `string(6)`
+| note in file FileId(1) for 636..637: this is of type `int`
+| error in file FileId(1) for 638..639: `int` cannot be compared to `string(6)`
 | info: operands must both be the same type
-error in file FileId(1) at 652..653: mismatched types for `=`
-| note in file FileId(1) for 654..655: this is of type `boolean`
-| note in file FileId(1) for 650..651: this is of type `nat`
-| error in file FileId(1) for 652..653: `nat` cannot be compared to `boolean`
+error in file FileId(1) at 662..663: mismatched types for `=`
+| note in file FileId(1) for 664..665: this is of type `boolean`
+| note in file FileId(1) for 660..661: this is of type `nat`
+| error in file FileId(1) for 662..663: `nat` cannot be compared to `boolean`
 | info: operands must both be the same type
-error in file FileId(1) at 672..673: mismatched types for `=`
-| note in file FileId(1) for 674..675: this is of type `char`
-| note in file FileId(1) for 670..671: this is of type `nat`
-| error in file FileId(1) for 672..673: `nat` cannot be compared to `char`
+error in file FileId(1) at 682..683: mismatched types for `=`
+| note in file FileId(1) for 684..685: this is of type `char`
+| note in file FileId(1) for 680..681: this is of type `nat`
+| error in file FileId(1) for 682..683: `nat` cannot be compared to `char`
 | info: operands must both be the same type
-error in file FileId(1) at 692..693: mismatched types for `=`
-| note in file FileId(1) for 694..698: this is of type `char(6)`
-| note in file FileId(1) for 690..691: this is of type `nat`
-| error in file FileId(1) for 692..693: `nat` cannot be compared to `char(6)`
+error in file FileId(1) at 702..703: mismatched types for `=`
+| note in file FileId(1) for 704..708: this is of type `char(6)`
+| note in file FileId(1) for 700..701: this is of type `nat`
+| error in file FileId(1) for 702..703: `nat` cannot be compared to `char(6)`
 | info: operands must both be the same type
-error in file FileId(1) at 715..716: mismatched types for `=`
-| note in file FileId(1) for 717..718: this is of type `string`
-| note in file FileId(1) for 713..714: this is of type `nat`
-| error in file FileId(1) for 715..716: `nat` cannot be compared to `string`
+error in file FileId(1) at 725..726: mismatched types for `=`
+| note in file FileId(1) for 727..728: this is of type `string`
+| note in file FileId(1) for 723..724: this is of type `nat`
+| error in file FileId(1) for 725..726: `nat` cannot be compared to `string`
 | info: operands must both be the same type
-error in file FileId(1) at 735..736: mismatched types for `=`
-| note in file FileId(1) for 737..741: this is of type `string(6)`
-| note in file FileId(1) for 733..734: this is of type `nat`
-| error in file FileId(1) for 735..736: `nat` cannot be compared to `string(6)`
+error in file FileId(1) at 745..746: mismatched types for `=`
+| note in file FileId(1) for 747..751: this is of type `string(6)`
+| note in file FileId(1) for 743..744: this is of type `nat`
+| error in file FileId(1) for 745..746: `nat` cannot be compared to `string(6)`
 | info: operands must both be the same type
-error in file FileId(1) at 759..760: mismatched types for `=`
-| note in file FileId(1) for 761..762: this is of type `real`
-| note in file FileId(1) for 757..758: this is of type `boolean`
-| error in file FileId(1) for 759..760: `boolean` cannot be compared to `real`
+error in file FileId(1) at 769..770: mismatched types for `=`
+| note in file FileId(1) for 771..772: this is of type `real`
+| note in file FileId(1) for 767..768: this is of type `boolean`
+| error in file FileId(1) for 769..770: `boolean` cannot be compared to `real`
 | info: operands must both be the same type
-error in file FileId(1) at 779..780: mismatched types for `=`
-| note in file FileId(1) for 781..782: this is of type `int`
-| note in file FileId(1) for 777..778: this is of type `boolean`
-| error in file FileId(1) for 779..780: `boolean` cannot be compared to `int`
+error in file FileId(1) at 789..790: mismatched types for `=`
+| note in file FileId(1) for 791..792: this is of type `int`
+| note in file FileId(1) for 787..788: this is of type `boolean`
+| error in file FileId(1) for 789..790: `boolean` cannot be compared to `int`
 | info: operands must both be the same type
-error in file FileId(1) at 799..800: mismatched types for `=`
-| note in file FileId(1) for 801..802: this is of type `nat`
-| note in file FileId(1) for 797..798: this is of type `boolean`
-| error in file FileId(1) for 799..800: `boolean` cannot be compared to `nat`
+error in file FileId(1) at 809..810: mismatched types for `=`
+| note in file FileId(1) for 811..812: this is of type `nat`
+| note in file FileId(1) for 807..808: this is of type `boolean`
+| error in file FileId(1) for 809..810: `boolean` cannot be compared to `nat`
 | info: operands must both be the same type
-error in file FileId(1) at 819..820: mismatched types for `=`
-| note in file FileId(1) for 821..822: this is of type `char`
-| note in file FileId(1) for 817..818: this is of type `boolean`
-| error in file FileId(1) for 819..820: `boolean` cannot be compared to `char`
+error in file FileId(1) at 829..830: mismatched types for `=`
+| note in file FileId(1) for 831..832: this is of type `char`
+| note in file FileId(1) for 827..828: this is of type `boolean`
+| error in file FileId(1) for 829..830: `boolean` cannot be compared to `char`
 | info: operands must both be the same type
-error in file FileId(1) at 839..840: mismatched types for `=`
-| note in file FileId(1) for 841..845: this is of type `char(6)`
-| note in file FileId(1) for 837..838: this is of type `boolean`
-| error in file FileId(1) for 839..840: `boolean` cannot be compared to `char(6)`
+error in file FileId(1) at 849..850: mismatched types for `=`
+| note in file FileId(1) for 851..855: this is of type `char(6)`
+| note in file FileId(1) for 847..848: this is of type `boolean`
+| error in file FileId(1) for 849..850: `boolean` cannot be compared to `char(6)`
 | info: operands must both be the same type
-error in file FileId(1) at 862..863: mismatched types for `=`
-| note in file FileId(1) for 864..865: this is of type `string`
-| note in file FileId(1) for 860..861: this is of type `boolean`
-| error in file FileId(1) for 862..863: `boolean` cannot be compared to `string`
+error in file FileId(1) at 872..873: mismatched types for `=`
+| note in file FileId(1) for 874..875: this is of type `string`
+| note in file FileId(1) for 870..871: this is of type `boolean`
+| error in file FileId(1) for 872..873: `boolean` cannot be compared to `string`
 | info: operands must both be the same type
-error in file FileId(1) at 882..883: mismatched types for `=`
-| note in file FileId(1) for 884..888: this is of type `string(6)`
-| note in file FileId(1) for 880..881: this is of type `boolean`
-| error in file FileId(1) for 882..883: `boolean` cannot be compared to `string(6)`
+error in file FileId(1) at 892..893: mismatched types for `=`
+| note in file FileId(1) for 894..898: this is of type `string(6)`
+| note in file FileId(1) for 890..891: this is of type `boolean`
+| error in file FileId(1) for 892..893: `boolean` cannot be compared to `string(6)`
 | info: operands must both be the same type
-error in file FileId(1) at 906..907: mismatched types for `=`
-| note in file FileId(1) for 908..909: this is of type `real`
-| note in file FileId(1) for 904..905: this is of type `char`
-| error in file FileId(1) for 906..907: `char` cannot be compared to `real`
+error in file FileId(1) at 916..917: mismatched types for `=`
+| note in file FileId(1) for 918..919: this is of type `real`
+| note in file FileId(1) for 914..915: this is of type `char`
+| error in file FileId(1) for 916..917: `char` cannot be compared to `real`
 | info: operands must both be the same type
-error in file FileId(1) at 926..927: mismatched types for `=`
-| note in file FileId(1) for 928..929: this is of type `int`
-| note in file FileId(1) for 924..925: this is of type `char`
-| error in file FileId(1) for 926..927: `char` cannot be compared to `int`
+error in file FileId(1) at 936..937: mismatched types for `=`
+| note in file FileId(1) for 938..939: this is of type `int`
+| note in file FileId(1) for 934..935: this is of type `char`
+| error in file FileId(1) for 936..937: `char` cannot be compared to `int`
 | info: operands must both be the same type
-error in file FileId(1) at 946..947: mismatched types for `=`
-| note in file FileId(1) for 948..949: this is of type `nat`
-| note in file FileId(1) for 944..945: this is of type `char`
-| error in file FileId(1) for 946..947: `char` cannot be compared to `nat`
+error in file FileId(1) at 956..957: mismatched types for `=`
+| note in file FileId(1) for 958..959: this is of type `nat`
+| note in file FileId(1) for 954..955: this is of type `char`
+| error in file FileId(1) for 956..957: `char` cannot be compared to `nat`
 | info: operands must both be the same type
-error in file FileId(1) at 966..967: mismatched types for `=`
-| note in file FileId(1) for 968..969: this is of type `boolean`
-| note in file FileId(1) for 964..965: this is of type `char`
-| error in file FileId(1) for 966..967: `char` cannot be compared to `boolean`
+error in file FileId(1) at 976..977: mismatched types for `=`
+| note in file FileId(1) for 978..979: this is of type `boolean`
+| note in file FileId(1) for 974..975: this is of type `char`
+| error in file FileId(1) for 976..977: `char` cannot be compared to `boolean`
 | info: operands must both be the same type
-error in file FileId(1) at 990..991: mismatched types for `=`
-| note in file FileId(1) for 992..993: this is of type `real`
-| note in file FileId(1) for 985..989: this is of type `char(6)`
-| error in file FileId(1) for 990..991: `char(6)` cannot be compared to `real`
+error in file FileId(1) at 1000..1001: mismatched types for `=`
+| note in file FileId(1) for 1002..1003: this is of type `real`
+| note in file FileId(1) for 995..999: this is of type `char(6)`
+| error in file FileId(1) for 1000..1001: `char(6)` cannot be compared to `real`
 | info: operands must both be the same type
-error in file FileId(1) at 1013..1014: mismatched types for `=`
-| note in file FileId(1) for 1015..1016: this is of type `int`
-| note in file FileId(1) for 1008..1012: this is of type `char(6)`
-| error in file FileId(1) for 1013..1014: `char(6)` cannot be compared to `int`
+error in file FileId(1) at 1023..1024: mismatched types for `=`
+| note in file FileId(1) for 1025..1026: this is of type `int`
+| note in file FileId(1) for 1018..1022: this is of type `char(6)`
+| error in file FileId(1) for 1023..1024: `char(6)` cannot be compared to `int`
 | info: operands must both be the same type
-error in file FileId(1) at 1036..1037: mismatched types for `=`
-| note in file FileId(1) for 1038..1039: this is of type `nat`
-| note in file FileId(1) for 1031..1035: this is of type `char(6)`
-| error in file FileId(1) for 1036..1037: `char(6)` cannot be compared to `nat`
+error in file FileId(1) at 1046..1047: mismatched types for `=`
+| note in file FileId(1) for 1048..1049: this is of type `nat`
+| note in file FileId(1) for 1041..1045: this is of type `char(6)`
+| error in file FileId(1) for 1046..1047: `char(6)` cannot be compared to `nat`
 | info: operands must both be the same type
-error in file FileId(1) at 1059..1060: mismatched types for `=`
-| note in file FileId(1) for 1061..1062: this is of type `boolean`
-| note in file FileId(1) for 1054..1058: this is of type `char(6)`
-| error in file FileId(1) for 1059..1060: `char(6)` cannot be compared to `boolean`
+error in file FileId(1) at 1069..1070: mismatched types for `=`
+| note in file FileId(1) for 1071..1072: this is of type `boolean`
+| note in file FileId(1) for 1064..1068: this is of type `char(6)`
+| error in file FileId(1) for 1069..1070: `char(6)` cannot be compared to `boolean`
 | info: operands must both be the same type
-error in file FileId(1) at 1080..1081: mismatched types for `=`
-| note in file FileId(1) for 1082..1083: this is of type `real`
-| note in file FileId(1) for 1078..1079: this is of type `string`
-| error in file FileId(1) for 1080..1081: `string` cannot be compared to `real`
+error in file FileId(1) at 1090..1091: mismatched types for `=`
+| note in file FileId(1) for 1092..1093: this is of type `real`
+| note in file FileId(1) for 1088..1089: this is of type `string`
+| error in file FileId(1) for 1090..1091: `string` cannot be compared to `real`
 | info: operands must both be the same type
-error in file FileId(1) at 1100..1101: mismatched types for `=`
-| note in file FileId(1) for 1102..1103: this is of type `int`
-| note in file FileId(1) for 1098..1099: this is of type `string`
-| error in file FileId(1) for 1100..1101: `string` cannot be compared to `int`
+error in file FileId(1) at 1110..1111: mismatched types for `=`
+| note in file FileId(1) for 1112..1113: this is of type `int`
+| note in file FileId(1) for 1108..1109: this is of type `string`
+| error in file FileId(1) for 1110..1111: `string` cannot be compared to `int`
 | info: operands must both be the same type
-error in file FileId(1) at 1120..1121: mismatched types for `=`
-| note in file FileId(1) for 1122..1123: this is of type `nat`
-| note in file FileId(1) for 1118..1119: this is of type `string`
-| error in file FileId(1) for 1120..1121: `string` cannot be compared to `nat`
+error in file FileId(1) at 1130..1131: mismatched types for `=`
+| note in file FileId(1) for 1132..1133: this is of type `nat`
+| note in file FileId(1) for 1128..1129: this is of type `string`
+| error in file FileId(1) for 1130..1131: `string` cannot be compared to `nat`
 | info: operands must both be the same type
-error in file FileId(1) at 1140..1141: mismatched types for `=`
-| note in file FileId(1) for 1142..1143: this is of type `boolean`
-| note in file FileId(1) for 1138..1139: this is of type `string`
-| error in file FileId(1) for 1140..1141: `string` cannot be compared to `boolean`
+error in file FileId(1) at 1150..1151: mismatched types for `=`
+| note in file FileId(1) for 1152..1153: this is of type `boolean`
+| note in file FileId(1) for 1148..1149: this is of type `string`
+| error in file FileId(1) for 1150..1151: `string` cannot be compared to `boolean`
 | info: operands must both be the same type
-error in file FileId(1) at 1164..1165: mismatched types for `=`
-| note in file FileId(1) for 1166..1167: this is of type `real`
-| note in file FileId(1) for 1159..1163: this is of type `string(6)`
-| error in file FileId(1) for 1164..1165: `string(6)` cannot be compared to `real`
+error in file FileId(1) at 1174..1175: mismatched types for `=`
+| note in file FileId(1) for 1176..1177: this is of type `real`
+| note in file FileId(1) for 1169..1173: this is of type `string(6)`
+| error in file FileId(1) for 1174..1175: `string(6)` cannot be compared to `real`
 | info: operands must both be the same type
-error in file FileId(1) at 1187..1188: mismatched types for `=`
-| note in file FileId(1) for 1189..1190: this is of type `int`
-| note in file FileId(1) for 1182..1186: this is of type `string(6)`
-| error in file FileId(1) for 1187..1188: `string(6)` cannot be compared to `int`
+error in file FileId(1) at 1197..1198: mismatched types for `=`
+| note in file FileId(1) for 1199..1200: this is of type `int`
+| note in file FileId(1) for 1192..1196: this is of type `string(6)`
+| error in file FileId(1) for 1197..1198: `string(6)` cannot be compared to `int`
 | info: operands must both be the same type
-error in file FileId(1) at 1210..1211: mismatched types for `=`
-| note in file FileId(1) for 1212..1213: this is of type `nat`
-| note in file FileId(1) for 1205..1209: this is of type `string(6)`
-| error in file FileId(1) for 1210..1211: `string(6)` cannot be compared to `nat`
+error in file FileId(1) at 1220..1221: mismatched types for `=`
+| note in file FileId(1) for 1222..1223: this is of type `nat`
+| note in file FileId(1) for 1215..1219: this is of type `string(6)`
+| error in file FileId(1) for 1220..1221: `string(6)` cannot be compared to `nat`
 | info: operands must both be the same type
-error in file FileId(1) at 1233..1234: mismatched types for `=`
-| note in file FileId(1) for 1235..1236: this is of type `boolean`
-| note in file FileId(1) for 1228..1232: this is of type `string(6)`
-| error in file FileId(1) for 1233..1234: `string(6)` cannot be compared to `boolean`
+error in file FileId(1) at 1243..1244: mismatched types for `=`
+| note in file FileId(1) for 1245..1246: this is of type `boolean`
+| note in file FileId(1) for 1238..1242: this is of type `string(6)`
+| error in file FileId(1) for 1243..1244: `string(6)` cannot be compared to `boolean`
 | info: operands must both be the same type
-error in file FileId(1) at 1280..1281: mismatched types for `=`
-| note in file FileId(1) for 1282..1285: this is of type `set s2 (of boolean)`
-| note in file FileId(1) for 1276..1279: this is of type `set s1 (of boolean)`
-| error in file FileId(1) for 1280..1281: `set s1 (of boolean)` cannot be compared to `set s2 (of boolean)`
+error in file FileId(1) at 1290..1291: mismatched types for `=`
+| note in file FileId(1) for 1292..1295: this is of type `set s2 (of boolean)`
+| note in file FileId(1) for 1286..1289: this is of type `set s1 (of boolean)`
+| error in file FileId(1) for 1290..1291: `set s1 (of boolean)` cannot be compared to `set s2 (of boolean)`
 | info: operands must both be the same type
-error in file FileId(1) at 1328..1329: mismatched types for `=`
-| note in file FileId(1) for 1330..1333: this is of type `set s1 (of boolean)`
-| note in file FileId(1) for 1324..1327: this is of type `set <anonymous> (of boolean)`
-| error in file FileId(1) for 1328..1329: `set <anonymous> (of boolean)` cannot be compared to `set s1 (of boolean)`
+error in file FileId(1) at 1314..1315: mismatched types for `=`
+| note in file FileId(1) for 1316..1319: this is of type `set s1 (of boolean)`
+| note in file FileId(1) for 1310..1313: this is of type `set s2 (of boolean)`
+| error in file FileId(1) for 1314..1315: `set s2 (of boolean)` cannot be compared to `set s1 (of boolean)`
 | info: operands must both be the same type
-error in file FileId(1) at 1352..1353: mismatched types for `=`
-| note in file FileId(1) for 1354..1357: this is of type `set <anonymous> (of boolean)`
-| note in file FileId(1) for 1348..1351: this is of type `set s1 (of boolean)`
-| error in file FileId(1) for 1352..1353: `set s1 (of boolean)` cannot be compared to `set <anonymous> (of boolean)`
+error in file FileId(1) at 1338..1339: mismatched types for `=`
+| note in file FileId(1) for 1340..1343: this is of type `set s1 (of boolean)`
+| note in file FileId(1) for 1334..1337: this is of type `set <anonymous> (of boolean)`
+| error in file FileId(1) for 1338..1339: `set <anonymous> (of boolean)` cannot be compared to `set s1 (of boolean)`
+| info: operands must both be the same type
+error in file FileId(1) at 1362..1363: mismatched types for `=`
+| note in file FileId(1) for 1364..1367: this is of type `set <anonymous> (of boolean)`
+| note in file FileId(1) for 1358..1361: this is of type `set s1 (of boolean)`
+| error in file FileId(1) for 1362..1363: `set s1 (of boolean)` cannot be compared to `set <anonymous> (of boolean)`
 | info: operands must both be the same type

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_greater.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_greater.snap
@@ -1,6 +1,6 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-expression: "\n    % Numerics\n    var r : real\n    var i : int\n    var n : nat\n\n    % Other scalars\n    var b : boolean\n\n    % Sized charseqs\n    var c : char\n    var c_sz : char(6)\n    var s : string\n    var s_sz : string(6)\n\n    % Different sets\n    type s1 : set of boolean\n    type s2 : set of boolean\n    var as1 : s1\n    var bs2 : s2\n    var aas : set of boolean\n\n    % should all produce boolean anyway\n    var _v_res : boolean\n\n    _v_res := r > b\n    _v_res := r > c\n    _v_res := r > c_sz\n    _v_res := r > s\n    _v_res := r > s_sz\n\n    _v_res := i > b\n    _v_res := i > c\n    _v_res := i > c_sz\n    _v_res := i > s\n    _v_res := i > s_sz\n\n    _v_res := n > b\n    _v_res := n > c\n    _v_res := n > c_sz\n    _v_res := n > s\n    _v_res := n > s_sz\n\n    _v_res := b > r\n    _v_res := b > i\n    _v_res := b > n\n    _v_res := b > c\n    _v_res := b > c_sz\n    _v_res := b > s\n    _v_res := b > s_sz\n\n    _v_res := c > r\n    _v_res := c > i\n    _v_res := c > n\n    _v_res := c > b\n\n    _v_res := c_sz > r\n    _v_res := c_sz > i\n    _v_res := c_sz > n\n    _v_res := c_sz > b\n\n    _v_res := s > r\n    _v_res := s > i\n    _v_res := s > n\n    _v_res := s > b\n\n    _v_res := s_sz > r\n    _v_res := s_sz > i\n    _v_res := s_sz > n\n    _v_res := s_sz > b\n\n    % Incompatible sets\n    _v_res := as1 > bs2\n    _v_res := bs1 > as2\n    _v_res := aas > as1\n    _v_res := as1 > aas\n    "
+expression: "\n    % Numerics\n    var r : real\n    var i : int\n    var n : nat\n\n    % Other scalars\n    var b : boolean\n\n    % Sized charseqs\n    var c : char\n    var c_sz : char(6)\n    var s : string\n    var s_sz : string(6)\n\n    % Different sets\n    type s1 : set of boolean\n    type s2 : set of boolean\n    var as1, as2 : s1\n    var bs1, bs2 : s2\n    var aas : set of boolean\n\n    % should all produce boolean anyway\n    var _v_res : boolean\n\n    _v_res := r > b\n    _v_res := r > c\n    _v_res := r > c_sz\n    _v_res := r > s\n    _v_res := r > s_sz\n\n    _v_res := i > b\n    _v_res := i > c\n    _v_res := i > c_sz\n    _v_res := i > s\n    _v_res := i > s_sz\n\n    _v_res := n > b\n    _v_res := n > c\n    _v_res := n > c_sz\n    _v_res := n > s\n    _v_res := n > s_sz\n\n    _v_res := b > r\n    _v_res := b > i\n    _v_res := b > n\n    _v_res := b > c\n    _v_res := b > c_sz\n    _v_res := b > s\n    _v_res := b > s_sz\n\n    _v_res := c > r\n    _v_res := c > i\n    _v_res := c > n\n    _v_res := c > b\n\n    _v_res := c_sz > r\n    _v_res := c_sz > i\n    _v_res := c_sz > n\n    _v_res := c_sz > b\n\n    _v_res := s > r\n    _v_res := s > i\n    _v_res := s > n\n    _v_res := s > b\n\n    _v_res := s_sz > r\n    _v_res := s_sz > i\n    _v_res := s_sz > n\n    _v_res := s_sz > b\n\n    % Incompatible sets\n    _v_res := as1 > bs2\n    _v_res := bs1 > as2\n    _v_res := aas > as1\n    _v_res := as1 > aas\n    "
 ---
 "r"@(FileId(1), 24..25) [ConstVar(Var, No)]: real
 "i"@(FileId(1), 41..42) [ConstVar(Var, No)]: int
@@ -15,216 +15,221 @@ expression: "\n    % Numerics\n    var r : real\n    var i : int\n    var n : na
 "s2"@(FileId(1), 277..291) [Set]: <error>
 "s2"@(FileId(1), 272..274) [Type]: set[DefId(LibraryId(0), LocalDefId(10))] of boolean
 "as1"@(FileId(1), 300..303) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(8))] of boolean
-"bs2"@(FileId(1), 317..320) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(10))] of boolean
-"<anonymous>"@(FileId(1), 340..354) [Set]: <error>
-"aas"@(FileId(1), 334..337) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(14))] of boolean
-"_v_res"@(FileId(1), 404..410) [ConstVar(Var, No)]: boolean
-"bs1"@(FileId(1), 1300..1303) [Undeclared]: <error>
-"as2"@(FileId(1), 1306..1309) [Undeclared]: <error>
+"as2"@(FileId(1), 305..308) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(8))] of boolean
+"bs1"@(FileId(1), 322..325) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(10))] of boolean
+"bs2"@(FileId(1), 327..330) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(10))] of boolean
+"<anonymous>"@(FileId(1), 350..364) [Set]: <error>
+"aas"@(FileId(1), 344..347) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(16))] of boolean
+"_v_res"@(FileId(1), 414..420) [ConstVar(Var, No)]: boolean
 "<root>"@(dummy) [Module(No)]: <error>
 
-error in file FileId(1) at 438..439: mismatched types for `>`
-| note in file FileId(1) for 440..441: this is of type `boolean`
-| note in file FileId(1) for 436..437: this is of type `real`
-| error in file FileId(1) for 438..439: `real` cannot be compared to `boolean`
+error in file FileId(1) at 448..449: mismatched types for `>`
+| note in file FileId(1) for 450..451: this is of type `boolean`
+| note in file FileId(1) for 446..447: this is of type `real`
+| error in file FileId(1) for 448..449: `real` cannot be compared to `boolean`
 | info: operands must both be the same type
-error in file FileId(1) at 458..459: mismatched types for `>`
-| note in file FileId(1) for 460..461: this is of type `char`
-| note in file FileId(1) for 456..457: this is of type `real`
-| error in file FileId(1) for 458..459: `real` cannot be compared to `char`
+error in file FileId(1) at 468..469: mismatched types for `>`
+| note in file FileId(1) for 470..471: this is of type `char`
+| note in file FileId(1) for 466..467: this is of type `real`
+| error in file FileId(1) for 468..469: `real` cannot be compared to `char`
 | info: operands must both be the same type
-error in file FileId(1) at 478..479: mismatched types for `>`
-| note in file FileId(1) for 480..484: this is of type `char(6)`
-| note in file FileId(1) for 476..477: this is of type `real`
-| error in file FileId(1) for 478..479: `real` cannot be compared to `char(6)`
+error in file FileId(1) at 488..489: mismatched types for `>`
+| note in file FileId(1) for 490..494: this is of type `char(6)`
+| note in file FileId(1) for 486..487: this is of type `real`
+| error in file FileId(1) for 488..489: `real` cannot be compared to `char(6)`
 | info: operands must both be the same type
-error in file FileId(1) at 501..502: mismatched types for `>`
-| note in file FileId(1) for 503..504: this is of type `string`
-| note in file FileId(1) for 499..500: this is of type `real`
-| error in file FileId(1) for 501..502: `real` cannot be compared to `string`
+error in file FileId(1) at 511..512: mismatched types for `>`
+| note in file FileId(1) for 513..514: this is of type `string`
+| note in file FileId(1) for 509..510: this is of type `real`
+| error in file FileId(1) for 511..512: `real` cannot be compared to `string`
 | info: operands must both be the same type
-error in file FileId(1) at 521..522: mismatched types for `>`
-| note in file FileId(1) for 523..527: this is of type `string(6)`
-| note in file FileId(1) for 519..520: this is of type `real`
-| error in file FileId(1) for 521..522: `real` cannot be compared to `string(6)`
+error in file FileId(1) at 531..532: mismatched types for `>`
+| note in file FileId(1) for 533..537: this is of type `string(6)`
+| note in file FileId(1) for 529..530: this is of type `real`
+| error in file FileId(1) for 531..532: `real` cannot be compared to `string(6)`
 | info: operands must both be the same type
-error in file FileId(1) at 545..546: mismatched types for `>`
-| note in file FileId(1) for 547..548: this is of type `boolean`
-| note in file FileId(1) for 543..544: this is of type `int`
-| error in file FileId(1) for 545..546: `int` cannot be compared to `boolean`
+error in file FileId(1) at 555..556: mismatched types for `>`
+| note in file FileId(1) for 557..558: this is of type `boolean`
+| note in file FileId(1) for 553..554: this is of type `int`
+| error in file FileId(1) for 555..556: `int` cannot be compared to `boolean`
 | info: operands must both be the same type
-error in file FileId(1) at 565..566: mismatched types for `>`
-| note in file FileId(1) for 567..568: this is of type `char`
-| note in file FileId(1) for 563..564: this is of type `int`
-| error in file FileId(1) for 565..566: `int` cannot be compared to `char`
+error in file FileId(1) at 575..576: mismatched types for `>`
+| note in file FileId(1) for 577..578: this is of type `char`
+| note in file FileId(1) for 573..574: this is of type `int`
+| error in file FileId(1) for 575..576: `int` cannot be compared to `char`
 | info: operands must both be the same type
-error in file FileId(1) at 585..586: mismatched types for `>`
-| note in file FileId(1) for 587..591: this is of type `char(6)`
-| note in file FileId(1) for 583..584: this is of type `int`
-| error in file FileId(1) for 585..586: `int` cannot be compared to `char(6)`
+error in file FileId(1) at 595..596: mismatched types for `>`
+| note in file FileId(1) for 597..601: this is of type `char(6)`
+| note in file FileId(1) for 593..594: this is of type `int`
+| error in file FileId(1) for 595..596: `int` cannot be compared to `char(6)`
 | info: operands must both be the same type
-error in file FileId(1) at 608..609: mismatched types for `>`
-| note in file FileId(1) for 610..611: this is of type `string`
-| note in file FileId(1) for 606..607: this is of type `int`
-| error in file FileId(1) for 608..609: `int` cannot be compared to `string`
+error in file FileId(1) at 618..619: mismatched types for `>`
+| note in file FileId(1) for 620..621: this is of type `string`
+| note in file FileId(1) for 616..617: this is of type `int`
+| error in file FileId(1) for 618..619: `int` cannot be compared to `string`
 | info: operands must both be the same type
-error in file FileId(1) at 628..629: mismatched types for `>`
-| note in file FileId(1) for 630..634: this is of type `string(6)`
-| note in file FileId(1) for 626..627: this is of type `int`
-| error in file FileId(1) for 628..629: `int` cannot be compared to `string(6)`
+error in file FileId(1) at 638..639: mismatched types for `>`
+| note in file FileId(1) for 640..644: this is of type `string(6)`
+| note in file FileId(1) for 636..637: this is of type `int`
+| error in file FileId(1) for 638..639: `int` cannot be compared to `string(6)`
 | info: operands must both be the same type
-error in file FileId(1) at 652..653: mismatched types for `>`
-| note in file FileId(1) for 654..655: this is of type `boolean`
-| note in file FileId(1) for 650..651: this is of type `nat`
-| error in file FileId(1) for 652..653: `nat` cannot be compared to `boolean`
+error in file FileId(1) at 662..663: mismatched types for `>`
+| note in file FileId(1) for 664..665: this is of type `boolean`
+| note in file FileId(1) for 660..661: this is of type `nat`
+| error in file FileId(1) for 662..663: `nat` cannot be compared to `boolean`
 | info: operands must both be the same type
-error in file FileId(1) at 672..673: mismatched types for `>`
-| note in file FileId(1) for 674..675: this is of type `char`
-| note in file FileId(1) for 670..671: this is of type `nat`
-| error in file FileId(1) for 672..673: `nat` cannot be compared to `char`
+error in file FileId(1) at 682..683: mismatched types for `>`
+| note in file FileId(1) for 684..685: this is of type `char`
+| note in file FileId(1) for 680..681: this is of type `nat`
+| error in file FileId(1) for 682..683: `nat` cannot be compared to `char`
 | info: operands must both be the same type
-error in file FileId(1) at 692..693: mismatched types for `>`
-| note in file FileId(1) for 694..698: this is of type `char(6)`
-| note in file FileId(1) for 690..691: this is of type `nat`
-| error in file FileId(1) for 692..693: `nat` cannot be compared to `char(6)`
+error in file FileId(1) at 702..703: mismatched types for `>`
+| note in file FileId(1) for 704..708: this is of type `char(6)`
+| note in file FileId(1) for 700..701: this is of type `nat`
+| error in file FileId(1) for 702..703: `nat` cannot be compared to `char(6)`
 | info: operands must both be the same type
-error in file FileId(1) at 715..716: mismatched types for `>`
-| note in file FileId(1) for 717..718: this is of type `string`
-| note in file FileId(1) for 713..714: this is of type `nat`
-| error in file FileId(1) for 715..716: `nat` cannot be compared to `string`
+error in file FileId(1) at 725..726: mismatched types for `>`
+| note in file FileId(1) for 727..728: this is of type `string`
+| note in file FileId(1) for 723..724: this is of type `nat`
+| error in file FileId(1) for 725..726: `nat` cannot be compared to `string`
 | info: operands must both be the same type
-error in file FileId(1) at 735..736: mismatched types for `>`
-| note in file FileId(1) for 737..741: this is of type `string(6)`
-| note in file FileId(1) for 733..734: this is of type `nat`
-| error in file FileId(1) for 735..736: `nat` cannot be compared to `string(6)`
+error in file FileId(1) at 745..746: mismatched types for `>`
+| note in file FileId(1) for 747..751: this is of type `string(6)`
+| note in file FileId(1) for 743..744: this is of type `nat`
+| error in file FileId(1) for 745..746: `nat` cannot be compared to `string(6)`
 | info: operands must both be the same type
-error in file FileId(1) at 759..760: mismatched types for `>`
-| note in file FileId(1) for 761..762: this is of type `real`
-| note in file FileId(1) for 757..758: this is of type `boolean`
-| error in file FileId(1) for 759..760: `boolean` cannot be compared to `real`
+error in file FileId(1) at 769..770: mismatched types for `>`
+| note in file FileId(1) for 771..772: this is of type `real`
+| note in file FileId(1) for 767..768: this is of type `boolean`
+| error in file FileId(1) for 769..770: `boolean` cannot be compared to `real`
 | info: operands must both be the same type
-error in file FileId(1) at 779..780: mismatched types for `>`
-| note in file FileId(1) for 781..782: this is of type `int`
-| note in file FileId(1) for 777..778: this is of type `boolean`
-| error in file FileId(1) for 779..780: `boolean` cannot be compared to `int`
+error in file FileId(1) at 789..790: mismatched types for `>`
+| note in file FileId(1) for 791..792: this is of type `int`
+| note in file FileId(1) for 787..788: this is of type `boolean`
+| error in file FileId(1) for 789..790: `boolean` cannot be compared to `int`
 | info: operands must both be the same type
-error in file FileId(1) at 799..800: mismatched types for `>`
-| note in file FileId(1) for 801..802: this is of type `nat`
-| note in file FileId(1) for 797..798: this is of type `boolean`
-| error in file FileId(1) for 799..800: `boolean` cannot be compared to `nat`
+error in file FileId(1) at 809..810: mismatched types for `>`
+| note in file FileId(1) for 811..812: this is of type `nat`
+| note in file FileId(1) for 807..808: this is of type `boolean`
+| error in file FileId(1) for 809..810: `boolean` cannot be compared to `nat`
 | info: operands must both be the same type
-error in file FileId(1) at 819..820: mismatched types for `>`
-| note in file FileId(1) for 821..822: this is of type `char`
-| note in file FileId(1) for 817..818: this is of type `boolean`
-| error in file FileId(1) for 819..820: `boolean` cannot be compared to `char`
+error in file FileId(1) at 829..830: mismatched types for `>`
+| note in file FileId(1) for 831..832: this is of type `char`
+| note in file FileId(1) for 827..828: this is of type `boolean`
+| error in file FileId(1) for 829..830: `boolean` cannot be compared to `char`
 | info: operands must both be the same type
-error in file FileId(1) at 839..840: mismatched types for `>`
-| note in file FileId(1) for 841..845: this is of type `char(6)`
-| note in file FileId(1) for 837..838: this is of type `boolean`
-| error in file FileId(1) for 839..840: `boolean` cannot be compared to `char(6)`
+error in file FileId(1) at 849..850: mismatched types for `>`
+| note in file FileId(1) for 851..855: this is of type `char(6)`
+| note in file FileId(1) for 847..848: this is of type `boolean`
+| error in file FileId(1) for 849..850: `boolean` cannot be compared to `char(6)`
 | info: operands must both be the same type
-error in file FileId(1) at 862..863: mismatched types for `>`
-| note in file FileId(1) for 864..865: this is of type `string`
-| note in file FileId(1) for 860..861: this is of type `boolean`
-| error in file FileId(1) for 862..863: `boolean` cannot be compared to `string`
+error in file FileId(1) at 872..873: mismatched types for `>`
+| note in file FileId(1) for 874..875: this is of type `string`
+| note in file FileId(1) for 870..871: this is of type `boolean`
+| error in file FileId(1) for 872..873: `boolean` cannot be compared to `string`
 | info: operands must both be the same type
-error in file FileId(1) at 882..883: mismatched types for `>`
-| note in file FileId(1) for 884..888: this is of type `string(6)`
-| note in file FileId(1) for 880..881: this is of type `boolean`
-| error in file FileId(1) for 882..883: `boolean` cannot be compared to `string(6)`
+error in file FileId(1) at 892..893: mismatched types for `>`
+| note in file FileId(1) for 894..898: this is of type `string(6)`
+| note in file FileId(1) for 890..891: this is of type `boolean`
+| error in file FileId(1) for 892..893: `boolean` cannot be compared to `string(6)`
 | info: operands must both be the same type
-error in file FileId(1) at 906..907: mismatched types for `>`
-| note in file FileId(1) for 908..909: this is of type `real`
-| note in file FileId(1) for 904..905: this is of type `char`
-| error in file FileId(1) for 906..907: `char` cannot be compared to `real`
+error in file FileId(1) at 916..917: mismatched types for `>`
+| note in file FileId(1) for 918..919: this is of type `real`
+| note in file FileId(1) for 914..915: this is of type `char`
+| error in file FileId(1) for 916..917: `char` cannot be compared to `real`
 | info: operands must both be the same type
-error in file FileId(1) at 926..927: mismatched types for `>`
-| note in file FileId(1) for 928..929: this is of type `int`
-| note in file FileId(1) for 924..925: this is of type `char`
-| error in file FileId(1) for 926..927: `char` cannot be compared to `int`
+error in file FileId(1) at 936..937: mismatched types for `>`
+| note in file FileId(1) for 938..939: this is of type `int`
+| note in file FileId(1) for 934..935: this is of type `char`
+| error in file FileId(1) for 936..937: `char` cannot be compared to `int`
 | info: operands must both be the same type
-error in file FileId(1) at 946..947: mismatched types for `>`
-| note in file FileId(1) for 948..949: this is of type `nat`
-| note in file FileId(1) for 944..945: this is of type `char`
-| error in file FileId(1) for 946..947: `char` cannot be compared to `nat`
+error in file FileId(1) at 956..957: mismatched types for `>`
+| note in file FileId(1) for 958..959: this is of type `nat`
+| note in file FileId(1) for 954..955: this is of type `char`
+| error in file FileId(1) for 956..957: `char` cannot be compared to `nat`
 | info: operands must both be the same type
-error in file FileId(1) at 966..967: mismatched types for `>`
-| note in file FileId(1) for 968..969: this is of type `boolean`
-| note in file FileId(1) for 964..965: this is of type `char`
-| error in file FileId(1) for 966..967: `char` cannot be compared to `boolean`
+error in file FileId(1) at 976..977: mismatched types for `>`
+| note in file FileId(1) for 978..979: this is of type `boolean`
+| note in file FileId(1) for 974..975: this is of type `char`
+| error in file FileId(1) for 976..977: `char` cannot be compared to `boolean`
 | info: operands must both be the same type
-error in file FileId(1) at 990..991: mismatched types for `>`
-| note in file FileId(1) for 992..993: this is of type `real`
-| note in file FileId(1) for 985..989: this is of type `char(6)`
-| error in file FileId(1) for 990..991: `char(6)` cannot be compared to `real`
+error in file FileId(1) at 1000..1001: mismatched types for `>`
+| note in file FileId(1) for 1002..1003: this is of type `real`
+| note in file FileId(1) for 995..999: this is of type `char(6)`
+| error in file FileId(1) for 1000..1001: `char(6)` cannot be compared to `real`
 | info: operands must both be the same type
-error in file FileId(1) at 1013..1014: mismatched types for `>`
-| note in file FileId(1) for 1015..1016: this is of type `int`
-| note in file FileId(1) for 1008..1012: this is of type `char(6)`
-| error in file FileId(1) for 1013..1014: `char(6)` cannot be compared to `int`
+error in file FileId(1) at 1023..1024: mismatched types for `>`
+| note in file FileId(1) for 1025..1026: this is of type `int`
+| note in file FileId(1) for 1018..1022: this is of type `char(6)`
+| error in file FileId(1) for 1023..1024: `char(6)` cannot be compared to `int`
 | info: operands must both be the same type
-error in file FileId(1) at 1036..1037: mismatched types for `>`
-| note in file FileId(1) for 1038..1039: this is of type `nat`
-| note in file FileId(1) for 1031..1035: this is of type `char(6)`
-| error in file FileId(1) for 1036..1037: `char(6)` cannot be compared to `nat`
+error in file FileId(1) at 1046..1047: mismatched types for `>`
+| note in file FileId(1) for 1048..1049: this is of type `nat`
+| note in file FileId(1) for 1041..1045: this is of type `char(6)`
+| error in file FileId(1) for 1046..1047: `char(6)` cannot be compared to `nat`
 | info: operands must both be the same type
-error in file FileId(1) at 1059..1060: mismatched types for `>`
-| note in file FileId(1) for 1061..1062: this is of type `boolean`
-| note in file FileId(1) for 1054..1058: this is of type `char(6)`
-| error in file FileId(1) for 1059..1060: `char(6)` cannot be compared to `boolean`
+error in file FileId(1) at 1069..1070: mismatched types for `>`
+| note in file FileId(1) for 1071..1072: this is of type `boolean`
+| note in file FileId(1) for 1064..1068: this is of type `char(6)`
+| error in file FileId(1) for 1069..1070: `char(6)` cannot be compared to `boolean`
 | info: operands must both be the same type
-error in file FileId(1) at 1080..1081: mismatched types for `>`
-| note in file FileId(1) for 1082..1083: this is of type `real`
-| note in file FileId(1) for 1078..1079: this is of type `string`
-| error in file FileId(1) for 1080..1081: `string` cannot be compared to `real`
+error in file FileId(1) at 1090..1091: mismatched types for `>`
+| note in file FileId(1) for 1092..1093: this is of type `real`
+| note in file FileId(1) for 1088..1089: this is of type `string`
+| error in file FileId(1) for 1090..1091: `string` cannot be compared to `real`
 | info: operands must both be the same type
-error in file FileId(1) at 1100..1101: mismatched types for `>`
-| note in file FileId(1) for 1102..1103: this is of type `int`
-| note in file FileId(1) for 1098..1099: this is of type `string`
-| error in file FileId(1) for 1100..1101: `string` cannot be compared to `int`
+error in file FileId(1) at 1110..1111: mismatched types for `>`
+| note in file FileId(1) for 1112..1113: this is of type `int`
+| note in file FileId(1) for 1108..1109: this is of type `string`
+| error in file FileId(1) for 1110..1111: `string` cannot be compared to `int`
 | info: operands must both be the same type
-error in file FileId(1) at 1120..1121: mismatched types for `>`
-| note in file FileId(1) for 1122..1123: this is of type `nat`
-| note in file FileId(1) for 1118..1119: this is of type `string`
-| error in file FileId(1) for 1120..1121: `string` cannot be compared to `nat`
+error in file FileId(1) at 1130..1131: mismatched types for `>`
+| note in file FileId(1) for 1132..1133: this is of type `nat`
+| note in file FileId(1) for 1128..1129: this is of type `string`
+| error in file FileId(1) for 1130..1131: `string` cannot be compared to `nat`
 | info: operands must both be the same type
-error in file FileId(1) at 1140..1141: mismatched types for `>`
-| note in file FileId(1) for 1142..1143: this is of type `boolean`
-| note in file FileId(1) for 1138..1139: this is of type `string`
-| error in file FileId(1) for 1140..1141: `string` cannot be compared to `boolean`
+error in file FileId(1) at 1150..1151: mismatched types for `>`
+| note in file FileId(1) for 1152..1153: this is of type `boolean`
+| note in file FileId(1) for 1148..1149: this is of type `string`
+| error in file FileId(1) for 1150..1151: `string` cannot be compared to `boolean`
 | info: operands must both be the same type
-error in file FileId(1) at 1164..1165: mismatched types for `>`
-| note in file FileId(1) for 1166..1167: this is of type `real`
-| note in file FileId(1) for 1159..1163: this is of type `string(6)`
-| error in file FileId(1) for 1164..1165: `string(6)` cannot be compared to `real`
+error in file FileId(1) at 1174..1175: mismatched types for `>`
+| note in file FileId(1) for 1176..1177: this is of type `real`
+| note in file FileId(1) for 1169..1173: this is of type `string(6)`
+| error in file FileId(1) for 1174..1175: `string(6)` cannot be compared to `real`
 | info: operands must both be the same type
-error in file FileId(1) at 1187..1188: mismatched types for `>`
-| note in file FileId(1) for 1189..1190: this is of type `int`
-| note in file FileId(1) for 1182..1186: this is of type `string(6)`
-| error in file FileId(1) for 1187..1188: `string(6)` cannot be compared to `int`
+error in file FileId(1) at 1197..1198: mismatched types for `>`
+| note in file FileId(1) for 1199..1200: this is of type `int`
+| note in file FileId(1) for 1192..1196: this is of type `string(6)`
+| error in file FileId(1) for 1197..1198: `string(6)` cannot be compared to `int`
 | info: operands must both be the same type
-error in file FileId(1) at 1210..1211: mismatched types for `>`
-| note in file FileId(1) for 1212..1213: this is of type `nat`
-| note in file FileId(1) for 1205..1209: this is of type `string(6)`
-| error in file FileId(1) for 1210..1211: `string(6)` cannot be compared to `nat`
+error in file FileId(1) at 1220..1221: mismatched types for `>`
+| note in file FileId(1) for 1222..1223: this is of type `nat`
+| note in file FileId(1) for 1215..1219: this is of type `string(6)`
+| error in file FileId(1) for 1220..1221: `string(6)` cannot be compared to `nat`
 | info: operands must both be the same type
-error in file FileId(1) at 1233..1234: mismatched types for `>`
-| note in file FileId(1) for 1235..1236: this is of type `boolean`
-| note in file FileId(1) for 1228..1232: this is of type `string(6)`
-| error in file FileId(1) for 1233..1234: `string(6)` cannot be compared to `boolean`
+error in file FileId(1) at 1243..1244: mismatched types for `>`
+| note in file FileId(1) for 1245..1246: this is of type `boolean`
+| note in file FileId(1) for 1238..1242: this is of type `string(6)`
+| error in file FileId(1) for 1243..1244: `string(6)` cannot be compared to `boolean`
 | info: operands must both be the same type
-error in file FileId(1) at 1280..1281: mismatched types for `>`
-| note in file FileId(1) for 1282..1285: this is of type `set s2 (of boolean)`
-| note in file FileId(1) for 1276..1279: this is of type `set s1 (of boolean)`
-| error in file FileId(1) for 1280..1281: `set s1 (of boolean)` cannot be compared to `set s2 (of boolean)`
+error in file FileId(1) at 1290..1291: mismatched types for `>`
+| note in file FileId(1) for 1292..1295: this is of type `set s2 (of boolean)`
+| note in file FileId(1) for 1286..1289: this is of type `set s1 (of boolean)`
+| error in file FileId(1) for 1290..1291: `set s1 (of boolean)` cannot be compared to `set s2 (of boolean)`
 | info: operands must both be the same type
-error in file FileId(1) at 1328..1329: mismatched types for `>`
-| note in file FileId(1) for 1330..1333: this is of type `set s1 (of boolean)`
-| note in file FileId(1) for 1324..1327: this is of type `set <anonymous> (of boolean)`
-| error in file FileId(1) for 1328..1329: `set <anonymous> (of boolean)` cannot be compared to `set s1 (of boolean)`
+error in file FileId(1) at 1314..1315: mismatched types for `>`
+| note in file FileId(1) for 1316..1319: this is of type `set s1 (of boolean)`
+| note in file FileId(1) for 1310..1313: this is of type `set s2 (of boolean)`
+| error in file FileId(1) for 1314..1315: `set s2 (of boolean)` cannot be compared to `set s1 (of boolean)`
 | info: operands must both be the same type
-error in file FileId(1) at 1352..1353: mismatched types for `>`
-| note in file FileId(1) for 1354..1357: this is of type `set <anonymous> (of boolean)`
-| note in file FileId(1) for 1348..1351: this is of type `set s1 (of boolean)`
-| error in file FileId(1) for 1352..1353: `set s1 (of boolean)` cannot be compared to `set <anonymous> (of boolean)`
+error in file FileId(1) at 1338..1339: mismatched types for `>`
+| note in file FileId(1) for 1340..1343: this is of type `set s1 (of boolean)`
+| note in file FileId(1) for 1334..1337: this is of type `set <anonymous> (of boolean)`
+| error in file FileId(1) for 1338..1339: `set <anonymous> (of boolean)` cannot be compared to `set s1 (of boolean)`
+| info: operands must both be the same type
+error in file FileId(1) at 1362..1363: mismatched types for `>`
+| note in file FileId(1) for 1364..1367: this is of type `set <anonymous> (of boolean)`
+| note in file FileId(1) for 1358..1361: this is of type `set s1 (of boolean)`
+| error in file FileId(1) for 1362..1363: `set s1 (of boolean)` cannot be compared to `set <anonymous> (of boolean)`
 | info: operands must both be the same type

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_greater_eq.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_greater_eq.snap
@@ -1,6 +1,6 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-expression: "\n    % Numerics\n    var r : real\n    var i : int\n    var n : nat\n\n    % Other scalars\n    var b : boolean\n\n    % Sized charseqs\n    var c : char\n    var c_sz : char(6)\n    var s : string\n    var s_sz : string(6)\n\n    % Different sets\n    type s1 : set of boolean\n    type s2 : set of boolean\n    var as1 : s1\n    var bs2 : s2\n    var aas : set of boolean\n\n    % should all produce boolean anyway\n    var _v_res : boolean\n\n    _v_res := r >= b\n    _v_res := r >= c\n    _v_res := r >= c_sz\n    _v_res := r >= s\n    _v_res := r >= s_sz\n\n    _v_res := i >= b\n    _v_res := i >= c\n    _v_res := i >= c_sz\n    _v_res := i >= s\n    _v_res := i >= s_sz\n\n    _v_res := n >= b\n    _v_res := n >= c\n    _v_res := n >= c_sz\n    _v_res := n >= s\n    _v_res := n >= s_sz\n\n    _v_res := b >= r\n    _v_res := b >= i\n    _v_res := b >= n\n    _v_res := b >= c\n    _v_res := b >= c_sz\n    _v_res := b >= s\n    _v_res := b >= s_sz\n\n    _v_res := c >= r\n    _v_res := c >= i\n    _v_res := c >= n\n    _v_res := c >= b\n\n    _v_res := c_sz >= r\n    _v_res := c_sz >= i\n    _v_res := c_sz >= n\n    _v_res := c_sz >= b\n\n    _v_res := s >= r\n    _v_res := s >= i\n    _v_res := s >= n\n    _v_res := s >= b\n\n    _v_res := s_sz >= r\n    _v_res := s_sz >= i\n    _v_res := s_sz >= n\n    _v_res := s_sz >= b\n\n    % Incompatible sets\n    _v_res := as1 >= bs2\n    _v_res := bs1 >= as2\n    _v_res := aas >= as1\n    _v_res := as1 >= aas\n    "
+expression: "\n    % Numerics\n    var r : real\n    var i : int\n    var n : nat\n\n    % Other scalars\n    var b : boolean\n\n    % Sized charseqs\n    var c : char\n    var c_sz : char(6)\n    var s : string\n    var s_sz : string(6)\n\n    % Different sets\n    type s1 : set of boolean\n    type s2 : set of boolean\n    var as1, as2 : s1\n    var bs1, bs2 : s2\n    var aas : set of boolean\n\n    % should all produce boolean anyway\n    var _v_res : boolean\n\n    _v_res := r >= b\n    _v_res := r >= c\n    _v_res := r >= c_sz\n    _v_res := r >= s\n    _v_res := r >= s_sz\n\n    _v_res := i >= b\n    _v_res := i >= c\n    _v_res := i >= c_sz\n    _v_res := i >= s\n    _v_res := i >= s_sz\n\n    _v_res := n >= b\n    _v_res := n >= c\n    _v_res := n >= c_sz\n    _v_res := n >= s\n    _v_res := n >= s_sz\n\n    _v_res := b >= r\n    _v_res := b >= i\n    _v_res := b >= n\n    _v_res := b >= c\n    _v_res := b >= c_sz\n    _v_res := b >= s\n    _v_res := b >= s_sz\n\n    _v_res := c >= r\n    _v_res := c >= i\n    _v_res := c >= n\n    _v_res := c >= b\n\n    _v_res := c_sz >= r\n    _v_res := c_sz >= i\n    _v_res := c_sz >= n\n    _v_res := c_sz >= b\n\n    _v_res := s >= r\n    _v_res := s >= i\n    _v_res := s >= n\n    _v_res := s >= b\n\n    _v_res := s_sz >= r\n    _v_res := s_sz >= i\n    _v_res := s_sz >= n\n    _v_res := s_sz >= b\n\n    % Incompatible sets\n    _v_res := as1 >= bs2\n    _v_res := bs1 >= as2\n    _v_res := aas >= as1\n    _v_res := as1 >= aas\n    "
 ---
 "r"@(FileId(1), 24..25) [ConstVar(Var, No)]: real
 "i"@(FileId(1), 41..42) [ConstVar(Var, No)]: int
@@ -15,216 +15,221 @@ expression: "\n    % Numerics\n    var r : real\n    var i : int\n    var n : na
 "s2"@(FileId(1), 277..291) [Set]: <error>
 "s2"@(FileId(1), 272..274) [Type]: set[DefId(LibraryId(0), LocalDefId(10))] of boolean
 "as1"@(FileId(1), 300..303) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(8))] of boolean
-"bs2"@(FileId(1), 317..320) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(10))] of boolean
-"<anonymous>"@(FileId(1), 340..354) [Set]: <error>
-"aas"@(FileId(1), 334..337) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(14))] of boolean
-"_v_res"@(FileId(1), 404..410) [ConstVar(Var, No)]: boolean
-"bs1"@(FileId(1), 1339..1342) [Undeclared]: <error>
-"as2"@(FileId(1), 1346..1349) [Undeclared]: <error>
+"as2"@(FileId(1), 305..308) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(8))] of boolean
+"bs1"@(FileId(1), 322..325) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(10))] of boolean
+"bs2"@(FileId(1), 327..330) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(10))] of boolean
+"<anonymous>"@(FileId(1), 350..364) [Set]: <error>
+"aas"@(FileId(1), 344..347) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(16))] of boolean
+"_v_res"@(FileId(1), 414..420) [ConstVar(Var, No)]: boolean
 "<root>"@(dummy) [Module(No)]: <error>
 
-error in file FileId(1) at 438..440: mismatched types for `>=`
-| note in file FileId(1) for 441..442: this is of type `boolean`
-| note in file FileId(1) for 436..437: this is of type `real`
-| error in file FileId(1) for 438..440: `real` cannot be compared to `boolean`
+error in file FileId(1) at 448..450: mismatched types for `>=`
+| note in file FileId(1) for 451..452: this is of type `boolean`
+| note in file FileId(1) for 446..447: this is of type `real`
+| error in file FileId(1) for 448..450: `real` cannot be compared to `boolean`
 | info: operands must both be the same type
-error in file FileId(1) at 459..461: mismatched types for `>=`
-| note in file FileId(1) for 462..463: this is of type `char`
-| note in file FileId(1) for 457..458: this is of type `real`
-| error in file FileId(1) for 459..461: `real` cannot be compared to `char`
+error in file FileId(1) at 469..471: mismatched types for `>=`
+| note in file FileId(1) for 472..473: this is of type `char`
+| note in file FileId(1) for 467..468: this is of type `real`
+| error in file FileId(1) for 469..471: `real` cannot be compared to `char`
 | info: operands must both be the same type
-error in file FileId(1) at 480..482: mismatched types for `>=`
-| note in file FileId(1) for 483..487: this is of type `char(6)`
-| note in file FileId(1) for 478..479: this is of type `real`
-| error in file FileId(1) for 480..482: `real` cannot be compared to `char(6)`
+error in file FileId(1) at 490..492: mismatched types for `>=`
+| note in file FileId(1) for 493..497: this is of type `char(6)`
+| note in file FileId(1) for 488..489: this is of type `real`
+| error in file FileId(1) for 490..492: `real` cannot be compared to `char(6)`
 | info: operands must both be the same type
-error in file FileId(1) at 504..506: mismatched types for `>=`
-| note in file FileId(1) for 507..508: this is of type `string`
-| note in file FileId(1) for 502..503: this is of type `real`
-| error in file FileId(1) for 504..506: `real` cannot be compared to `string`
+error in file FileId(1) at 514..516: mismatched types for `>=`
+| note in file FileId(1) for 517..518: this is of type `string`
+| note in file FileId(1) for 512..513: this is of type `real`
+| error in file FileId(1) for 514..516: `real` cannot be compared to `string`
 | info: operands must both be the same type
-error in file FileId(1) at 525..527: mismatched types for `>=`
-| note in file FileId(1) for 528..532: this is of type `string(6)`
-| note in file FileId(1) for 523..524: this is of type `real`
-| error in file FileId(1) for 525..527: `real` cannot be compared to `string(6)`
+error in file FileId(1) at 535..537: mismatched types for `>=`
+| note in file FileId(1) for 538..542: this is of type `string(6)`
+| note in file FileId(1) for 533..534: this is of type `real`
+| error in file FileId(1) for 535..537: `real` cannot be compared to `string(6)`
 | info: operands must both be the same type
-error in file FileId(1) at 550..552: mismatched types for `>=`
-| note in file FileId(1) for 553..554: this is of type `boolean`
-| note in file FileId(1) for 548..549: this is of type `int`
-| error in file FileId(1) for 550..552: `int` cannot be compared to `boolean`
+error in file FileId(1) at 560..562: mismatched types for `>=`
+| note in file FileId(1) for 563..564: this is of type `boolean`
+| note in file FileId(1) for 558..559: this is of type `int`
+| error in file FileId(1) for 560..562: `int` cannot be compared to `boolean`
 | info: operands must both be the same type
-error in file FileId(1) at 571..573: mismatched types for `>=`
-| note in file FileId(1) for 574..575: this is of type `char`
-| note in file FileId(1) for 569..570: this is of type `int`
-| error in file FileId(1) for 571..573: `int` cannot be compared to `char`
+error in file FileId(1) at 581..583: mismatched types for `>=`
+| note in file FileId(1) for 584..585: this is of type `char`
+| note in file FileId(1) for 579..580: this is of type `int`
+| error in file FileId(1) for 581..583: `int` cannot be compared to `char`
 | info: operands must both be the same type
-error in file FileId(1) at 592..594: mismatched types for `>=`
-| note in file FileId(1) for 595..599: this is of type `char(6)`
-| note in file FileId(1) for 590..591: this is of type `int`
-| error in file FileId(1) for 592..594: `int` cannot be compared to `char(6)`
+error in file FileId(1) at 602..604: mismatched types for `>=`
+| note in file FileId(1) for 605..609: this is of type `char(6)`
+| note in file FileId(1) for 600..601: this is of type `int`
+| error in file FileId(1) for 602..604: `int` cannot be compared to `char(6)`
 | info: operands must both be the same type
-error in file FileId(1) at 616..618: mismatched types for `>=`
-| note in file FileId(1) for 619..620: this is of type `string`
-| note in file FileId(1) for 614..615: this is of type `int`
-| error in file FileId(1) for 616..618: `int` cannot be compared to `string`
+error in file FileId(1) at 626..628: mismatched types for `>=`
+| note in file FileId(1) for 629..630: this is of type `string`
+| note in file FileId(1) for 624..625: this is of type `int`
+| error in file FileId(1) for 626..628: `int` cannot be compared to `string`
 | info: operands must both be the same type
-error in file FileId(1) at 637..639: mismatched types for `>=`
-| note in file FileId(1) for 640..644: this is of type `string(6)`
-| note in file FileId(1) for 635..636: this is of type `int`
-| error in file FileId(1) for 637..639: `int` cannot be compared to `string(6)`
+error in file FileId(1) at 647..649: mismatched types for `>=`
+| note in file FileId(1) for 650..654: this is of type `string(6)`
+| note in file FileId(1) for 645..646: this is of type `int`
+| error in file FileId(1) for 647..649: `int` cannot be compared to `string(6)`
 | info: operands must both be the same type
-error in file FileId(1) at 662..664: mismatched types for `>=`
-| note in file FileId(1) for 665..666: this is of type `boolean`
-| note in file FileId(1) for 660..661: this is of type `nat`
-| error in file FileId(1) for 662..664: `nat` cannot be compared to `boolean`
+error in file FileId(1) at 672..674: mismatched types for `>=`
+| note in file FileId(1) for 675..676: this is of type `boolean`
+| note in file FileId(1) for 670..671: this is of type `nat`
+| error in file FileId(1) for 672..674: `nat` cannot be compared to `boolean`
 | info: operands must both be the same type
-error in file FileId(1) at 683..685: mismatched types for `>=`
-| note in file FileId(1) for 686..687: this is of type `char`
-| note in file FileId(1) for 681..682: this is of type `nat`
-| error in file FileId(1) for 683..685: `nat` cannot be compared to `char`
+error in file FileId(1) at 693..695: mismatched types for `>=`
+| note in file FileId(1) for 696..697: this is of type `char`
+| note in file FileId(1) for 691..692: this is of type `nat`
+| error in file FileId(1) for 693..695: `nat` cannot be compared to `char`
 | info: operands must both be the same type
-error in file FileId(1) at 704..706: mismatched types for `>=`
-| note in file FileId(1) for 707..711: this is of type `char(6)`
-| note in file FileId(1) for 702..703: this is of type `nat`
-| error in file FileId(1) for 704..706: `nat` cannot be compared to `char(6)`
+error in file FileId(1) at 714..716: mismatched types for `>=`
+| note in file FileId(1) for 717..721: this is of type `char(6)`
+| note in file FileId(1) for 712..713: this is of type `nat`
+| error in file FileId(1) for 714..716: `nat` cannot be compared to `char(6)`
 | info: operands must both be the same type
-error in file FileId(1) at 728..730: mismatched types for `>=`
-| note in file FileId(1) for 731..732: this is of type `string`
-| note in file FileId(1) for 726..727: this is of type `nat`
-| error in file FileId(1) for 728..730: `nat` cannot be compared to `string`
+error in file FileId(1) at 738..740: mismatched types for `>=`
+| note in file FileId(1) for 741..742: this is of type `string`
+| note in file FileId(1) for 736..737: this is of type `nat`
+| error in file FileId(1) for 738..740: `nat` cannot be compared to `string`
 | info: operands must both be the same type
-error in file FileId(1) at 749..751: mismatched types for `>=`
-| note in file FileId(1) for 752..756: this is of type `string(6)`
-| note in file FileId(1) for 747..748: this is of type `nat`
-| error in file FileId(1) for 749..751: `nat` cannot be compared to `string(6)`
+error in file FileId(1) at 759..761: mismatched types for `>=`
+| note in file FileId(1) for 762..766: this is of type `string(6)`
+| note in file FileId(1) for 757..758: this is of type `nat`
+| error in file FileId(1) for 759..761: `nat` cannot be compared to `string(6)`
 | info: operands must both be the same type
-error in file FileId(1) at 774..776: mismatched types for `>=`
-| note in file FileId(1) for 777..778: this is of type `real`
-| note in file FileId(1) for 772..773: this is of type `boolean`
-| error in file FileId(1) for 774..776: `boolean` cannot be compared to `real`
+error in file FileId(1) at 784..786: mismatched types for `>=`
+| note in file FileId(1) for 787..788: this is of type `real`
+| note in file FileId(1) for 782..783: this is of type `boolean`
+| error in file FileId(1) for 784..786: `boolean` cannot be compared to `real`
 | info: operands must both be the same type
-error in file FileId(1) at 795..797: mismatched types for `>=`
-| note in file FileId(1) for 798..799: this is of type `int`
-| note in file FileId(1) for 793..794: this is of type `boolean`
-| error in file FileId(1) for 795..797: `boolean` cannot be compared to `int`
+error in file FileId(1) at 805..807: mismatched types for `>=`
+| note in file FileId(1) for 808..809: this is of type `int`
+| note in file FileId(1) for 803..804: this is of type `boolean`
+| error in file FileId(1) for 805..807: `boolean` cannot be compared to `int`
 | info: operands must both be the same type
-error in file FileId(1) at 816..818: mismatched types for `>=`
-| note in file FileId(1) for 819..820: this is of type `nat`
-| note in file FileId(1) for 814..815: this is of type `boolean`
-| error in file FileId(1) for 816..818: `boolean` cannot be compared to `nat`
+error in file FileId(1) at 826..828: mismatched types for `>=`
+| note in file FileId(1) for 829..830: this is of type `nat`
+| note in file FileId(1) for 824..825: this is of type `boolean`
+| error in file FileId(1) for 826..828: `boolean` cannot be compared to `nat`
 | info: operands must both be the same type
-error in file FileId(1) at 837..839: mismatched types for `>=`
-| note in file FileId(1) for 840..841: this is of type `char`
-| note in file FileId(1) for 835..836: this is of type `boolean`
-| error in file FileId(1) for 837..839: `boolean` cannot be compared to `char`
+error in file FileId(1) at 847..849: mismatched types for `>=`
+| note in file FileId(1) for 850..851: this is of type `char`
+| note in file FileId(1) for 845..846: this is of type `boolean`
+| error in file FileId(1) for 847..849: `boolean` cannot be compared to `char`
 | info: operands must both be the same type
-error in file FileId(1) at 858..860: mismatched types for `>=`
-| note in file FileId(1) for 861..865: this is of type `char(6)`
-| note in file FileId(1) for 856..857: this is of type `boolean`
-| error in file FileId(1) for 858..860: `boolean` cannot be compared to `char(6)`
+error in file FileId(1) at 868..870: mismatched types for `>=`
+| note in file FileId(1) for 871..875: this is of type `char(6)`
+| note in file FileId(1) for 866..867: this is of type `boolean`
+| error in file FileId(1) for 868..870: `boolean` cannot be compared to `char(6)`
 | info: operands must both be the same type
-error in file FileId(1) at 882..884: mismatched types for `>=`
-| note in file FileId(1) for 885..886: this is of type `string`
-| note in file FileId(1) for 880..881: this is of type `boolean`
-| error in file FileId(1) for 882..884: `boolean` cannot be compared to `string`
+error in file FileId(1) at 892..894: mismatched types for `>=`
+| note in file FileId(1) for 895..896: this is of type `string`
+| note in file FileId(1) for 890..891: this is of type `boolean`
+| error in file FileId(1) for 892..894: `boolean` cannot be compared to `string`
 | info: operands must both be the same type
-error in file FileId(1) at 903..905: mismatched types for `>=`
-| note in file FileId(1) for 906..910: this is of type `string(6)`
-| note in file FileId(1) for 901..902: this is of type `boolean`
-| error in file FileId(1) for 903..905: `boolean` cannot be compared to `string(6)`
+error in file FileId(1) at 913..915: mismatched types for `>=`
+| note in file FileId(1) for 916..920: this is of type `string(6)`
+| note in file FileId(1) for 911..912: this is of type `boolean`
+| error in file FileId(1) for 913..915: `boolean` cannot be compared to `string(6)`
 | info: operands must both be the same type
-error in file FileId(1) at 928..930: mismatched types for `>=`
-| note in file FileId(1) for 931..932: this is of type `real`
-| note in file FileId(1) for 926..927: this is of type `char`
-| error in file FileId(1) for 928..930: `char` cannot be compared to `real`
+error in file FileId(1) at 938..940: mismatched types for `>=`
+| note in file FileId(1) for 941..942: this is of type `real`
+| note in file FileId(1) for 936..937: this is of type `char`
+| error in file FileId(1) for 938..940: `char` cannot be compared to `real`
 | info: operands must both be the same type
-error in file FileId(1) at 949..951: mismatched types for `>=`
-| note in file FileId(1) for 952..953: this is of type `int`
-| note in file FileId(1) for 947..948: this is of type `char`
-| error in file FileId(1) for 949..951: `char` cannot be compared to `int`
+error in file FileId(1) at 959..961: mismatched types for `>=`
+| note in file FileId(1) for 962..963: this is of type `int`
+| note in file FileId(1) for 957..958: this is of type `char`
+| error in file FileId(1) for 959..961: `char` cannot be compared to `int`
 | info: operands must both be the same type
-error in file FileId(1) at 970..972: mismatched types for `>=`
-| note in file FileId(1) for 973..974: this is of type `nat`
-| note in file FileId(1) for 968..969: this is of type `char`
-| error in file FileId(1) for 970..972: `char` cannot be compared to `nat`
+error in file FileId(1) at 980..982: mismatched types for `>=`
+| note in file FileId(1) for 983..984: this is of type `nat`
+| note in file FileId(1) for 978..979: this is of type `char`
+| error in file FileId(1) for 980..982: `char` cannot be compared to `nat`
 | info: operands must both be the same type
-error in file FileId(1) at 991..993: mismatched types for `>=`
-| note in file FileId(1) for 994..995: this is of type `boolean`
-| note in file FileId(1) for 989..990: this is of type `char`
-| error in file FileId(1) for 991..993: `char` cannot be compared to `boolean`
+error in file FileId(1) at 1001..1003: mismatched types for `>=`
+| note in file FileId(1) for 1004..1005: this is of type `boolean`
+| note in file FileId(1) for 999..1000: this is of type `char`
+| error in file FileId(1) for 1001..1003: `char` cannot be compared to `boolean`
 | info: operands must both be the same type
-error in file FileId(1) at 1016..1018: mismatched types for `>=`
-| note in file FileId(1) for 1019..1020: this is of type `real`
-| note in file FileId(1) for 1011..1015: this is of type `char(6)`
-| error in file FileId(1) for 1016..1018: `char(6)` cannot be compared to `real`
+error in file FileId(1) at 1026..1028: mismatched types for `>=`
+| note in file FileId(1) for 1029..1030: this is of type `real`
+| note in file FileId(1) for 1021..1025: this is of type `char(6)`
+| error in file FileId(1) for 1026..1028: `char(6)` cannot be compared to `real`
 | info: operands must both be the same type
-error in file FileId(1) at 1040..1042: mismatched types for `>=`
-| note in file FileId(1) for 1043..1044: this is of type `int`
-| note in file FileId(1) for 1035..1039: this is of type `char(6)`
-| error in file FileId(1) for 1040..1042: `char(6)` cannot be compared to `int`
+error in file FileId(1) at 1050..1052: mismatched types for `>=`
+| note in file FileId(1) for 1053..1054: this is of type `int`
+| note in file FileId(1) for 1045..1049: this is of type `char(6)`
+| error in file FileId(1) for 1050..1052: `char(6)` cannot be compared to `int`
 | info: operands must both be the same type
-error in file FileId(1) at 1064..1066: mismatched types for `>=`
-| note in file FileId(1) for 1067..1068: this is of type `nat`
-| note in file FileId(1) for 1059..1063: this is of type `char(6)`
-| error in file FileId(1) for 1064..1066: `char(6)` cannot be compared to `nat`
+error in file FileId(1) at 1074..1076: mismatched types for `>=`
+| note in file FileId(1) for 1077..1078: this is of type `nat`
+| note in file FileId(1) for 1069..1073: this is of type `char(6)`
+| error in file FileId(1) for 1074..1076: `char(6)` cannot be compared to `nat`
 | info: operands must both be the same type
-error in file FileId(1) at 1088..1090: mismatched types for `>=`
-| note in file FileId(1) for 1091..1092: this is of type `boolean`
-| note in file FileId(1) for 1083..1087: this is of type `char(6)`
-| error in file FileId(1) for 1088..1090: `char(6)` cannot be compared to `boolean`
+error in file FileId(1) at 1098..1100: mismatched types for `>=`
+| note in file FileId(1) for 1101..1102: this is of type `boolean`
+| note in file FileId(1) for 1093..1097: this is of type `char(6)`
+| error in file FileId(1) for 1098..1100: `char(6)` cannot be compared to `boolean`
 | info: operands must both be the same type
-error in file FileId(1) at 1110..1112: mismatched types for `>=`
-| note in file FileId(1) for 1113..1114: this is of type `real`
-| note in file FileId(1) for 1108..1109: this is of type `string`
-| error in file FileId(1) for 1110..1112: `string` cannot be compared to `real`
+error in file FileId(1) at 1120..1122: mismatched types for `>=`
+| note in file FileId(1) for 1123..1124: this is of type `real`
+| note in file FileId(1) for 1118..1119: this is of type `string`
+| error in file FileId(1) for 1120..1122: `string` cannot be compared to `real`
 | info: operands must both be the same type
-error in file FileId(1) at 1131..1133: mismatched types for `>=`
-| note in file FileId(1) for 1134..1135: this is of type `int`
-| note in file FileId(1) for 1129..1130: this is of type `string`
-| error in file FileId(1) for 1131..1133: `string` cannot be compared to `int`
+error in file FileId(1) at 1141..1143: mismatched types for `>=`
+| note in file FileId(1) for 1144..1145: this is of type `int`
+| note in file FileId(1) for 1139..1140: this is of type `string`
+| error in file FileId(1) for 1141..1143: `string` cannot be compared to `int`
 | info: operands must both be the same type
-error in file FileId(1) at 1152..1154: mismatched types for `>=`
-| note in file FileId(1) for 1155..1156: this is of type `nat`
-| note in file FileId(1) for 1150..1151: this is of type `string`
-| error in file FileId(1) for 1152..1154: `string` cannot be compared to `nat`
+error in file FileId(1) at 1162..1164: mismatched types for `>=`
+| note in file FileId(1) for 1165..1166: this is of type `nat`
+| note in file FileId(1) for 1160..1161: this is of type `string`
+| error in file FileId(1) for 1162..1164: `string` cannot be compared to `nat`
 | info: operands must both be the same type
-error in file FileId(1) at 1173..1175: mismatched types for `>=`
-| note in file FileId(1) for 1176..1177: this is of type `boolean`
-| note in file FileId(1) for 1171..1172: this is of type `string`
-| error in file FileId(1) for 1173..1175: `string` cannot be compared to `boolean`
+error in file FileId(1) at 1183..1185: mismatched types for `>=`
+| note in file FileId(1) for 1186..1187: this is of type `boolean`
+| note in file FileId(1) for 1181..1182: this is of type `string`
+| error in file FileId(1) for 1183..1185: `string` cannot be compared to `boolean`
 | info: operands must both be the same type
-error in file FileId(1) at 1198..1200: mismatched types for `>=`
-| note in file FileId(1) for 1201..1202: this is of type `real`
-| note in file FileId(1) for 1193..1197: this is of type `string(6)`
-| error in file FileId(1) for 1198..1200: `string(6)` cannot be compared to `real`
+error in file FileId(1) at 1208..1210: mismatched types for `>=`
+| note in file FileId(1) for 1211..1212: this is of type `real`
+| note in file FileId(1) for 1203..1207: this is of type `string(6)`
+| error in file FileId(1) for 1208..1210: `string(6)` cannot be compared to `real`
 | info: operands must both be the same type
-error in file FileId(1) at 1222..1224: mismatched types for `>=`
-| note in file FileId(1) for 1225..1226: this is of type `int`
-| note in file FileId(1) for 1217..1221: this is of type `string(6)`
-| error in file FileId(1) for 1222..1224: `string(6)` cannot be compared to `int`
+error in file FileId(1) at 1232..1234: mismatched types for `>=`
+| note in file FileId(1) for 1235..1236: this is of type `int`
+| note in file FileId(1) for 1227..1231: this is of type `string(6)`
+| error in file FileId(1) for 1232..1234: `string(6)` cannot be compared to `int`
 | info: operands must both be the same type
-error in file FileId(1) at 1246..1248: mismatched types for `>=`
-| note in file FileId(1) for 1249..1250: this is of type `nat`
-| note in file FileId(1) for 1241..1245: this is of type `string(6)`
-| error in file FileId(1) for 1246..1248: `string(6)` cannot be compared to `nat`
+error in file FileId(1) at 1256..1258: mismatched types for `>=`
+| note in file FileId(1) for 1259..1260: this is of type `nat`
+| note in file FileId(1) for 1251..1255: this is of type `string(6)`
+| error in file FileId(1) for 1256..1258: `string(6)` cannot be compared to `nat`
 | info: operands must both be the same type
-error in file FileId(1) at 1270..1272: mismatched types for `>=`
-| note in file FileId(1) for 1273..1274: this is of type `boolean`
-| note in file FileId(1) for 1265..1269: this is of type `string(6)`
-| error in file FileId(1) for 1270..1272: `string(6)` cannot be compared to `boolean`
+error in file FileId(1) at 1280..1282: mismatched types for `>=`
+| note in file FileId(1) for 1283..1284: this is of type `boolean`
+| note in file FileId(1) for 1275..1279: this is of type `string(6)`
+| error in file FileId(1) for 1280..1282: `string(6)` cannot be compared to `boolean`
 | info: operands must both be the same type
-error in file FileId(1) at 1318..1320: mismatched types for `>=`
-| note in file FileId(1) for 1321..1324: this is of type `set s2 (of boolean)`
-| note in file FileId(1) for 1314..1317: this is of type `set s1 (of boolean)`
-| error in file FileId(1) for 1318..1320: `set s1 (of boolean)` cannot be compared to `set s2 (of boolean)`
+error in file FileId(1) at 1328..1330: mismatched types for `>=`
+| note in file FileId(1) for 1331..1334: this is of type `set s2 (of boolean)`
+| note in file FileId(1) for 1324..1327: this is of type `set s1 (of boolean)`
+| error in file FileId(1) for 1328..1330: `set s1 (of boolean)` cannot be compared to `set s2 (of boolean)`
 | info: operands must both be the same type
-error in file FileId(1) at 1368..1370: mismatched types for `>=`
-| note in file FileId(1) for 1371..1374: this is of type `set s1 (of boolean)`
-| note in file FileId(1) for 1364..1367: this is of type `set <anonymous> (of boolean)`
-| error in file FileId(1) for 1368..1370: `set <anonymous> (of boolean)` cannot be compared to `set s1 (of boolean)`
+error in file FileId(1) at 1353..1355: mismatched types for `>=`
+| note in file FileId(1) for 1356..1359: this is of type `set s1 (of boolean)`
+| note in file FileId(1) for 1349..1352: this is of type `set s2 (of boolean)`
+| error in file FileId(1) for 1353..1355: `set s2 (of boolean)` cannot be compared to `set s1 (of boolean)`
 | info: operands must both be the same type
-error in file FileId(1) at 1393..1395: mismatched types for `>=`
-| note in file FileId(1) for 1396..1399: this is of type `set <anonymous> (of boolean)`
-| note in file FileId(1) for 1389..1392: this is of type `set s1 (of boolean)`
-| error in file FileId(1) for 1393..1395: `set s1 (of boolean)` cannot be compared to `set <anonymous> (of boolean)`
+error in file FileId(1) at 1378..1380: mismatched types for `>=`
+| note in file FileId(1) for 1381..1384: this is of type `set s1 (of boolean)`
+| note in file FileId(1) for 1374..1377: this is of type `set <anonymous> (of boolean)`
+| error in file FileId(1) for 1378..1380: `set <anonymous> (of boolean)` cannot be compared to `set s1 (of boolean)`
+| info: operands must both be the same type
+error in file FileId(1) at 1403..1405: mismatched types for `>=`
+| note in file FileId(1) for 1406..1409: this is of type `set <anonymous> (of boolean)`
+| note in file FileId(1) for 1399..1402: this is of type `set s1 (of boolean)`
+| error in file FileId(1) for 1403..1405: `set s1 (of boolean)` cannot be compared to `set <anonymous> (of boolean)`
 | info: operands must both be the same type

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_less.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_less.snap
@@ -1,6 +1,6 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-expression: "\n    % Numerics\n    var r : real\n    var i : int\n    var n : nat\n\n    % Other scalars\n    var b : boolean\n\n    % Sized charseqs\n    var c : char\n    var c_sz : char(6)\n    var s : string\n    var s_sz : string(6)\n\n    % Different sets\n    type s1 : set of boolean\n    type s2 : set of boolean\n    var as1 : s1\n    var bs2 : s2\n    var aas : set of boolean\n\n    % should all produce boolean anyway\n    var _v_res : boolean\n\n    _v_res := r < b\n    _v_res := r < c\n    _v_res := r < c_sz\n    _v_res := r < s\n    _v_res := r < s_sz\n\n    _v_res := i < b\n    _v_res := i < c\n    _v_res := i < c_sz\n    _v_res := i < s\n    _v_res := i < s_sz\n\n    _v_res := n < b\n    _v_res := n < c\n    _v_res := n < c_sz\n    _v_res := n < s\n    _v_res := n < s_sz\n\n    _v_res := b < r\n    _v_res := b < i\n    _v_res := b < n\n    _v_res := b < c\n    _v_res := b < c_sz\n    _v_res := b < s\n    _v_res := b < s_sz\n\n    _v_res := c < r\n    _v_res := c < i\n    _v_res := c < n\n    _v_res := c < b\n\n    _v_res := c_sz < r\n    _v_res := c_sz < i\n    _v_res := c_sz < n\n    _v_res := c_sz < b\n\n    _v_res := s < r\n    _v_res := s < i\n    _v_res := s < n\n    _v_res := s < b\n\n    _v_res := s_sz < r\n    _v_res := s_sz < i\n    _v_res := s_sz < n\n    _v_res := s_sz < b\n\n    % Incompatible sets\n    _v_res := as1 < bs2\n    _v_res := bs1 < as2\n    _v_res := aas < as1\n    _v_res := as1 < aas\n    "
+expression: "\n    % Numerics\n    var r : real\n    var i : int\n    var n : nat\n\n    % Other scalars\n    var b : boolean\n\n    % Sized charseqs\n    var c : char\n    var c_sz : char(6)\n    var s : string\n    var s_sz : string(6)\n\n    % Different sets\n    type s1 : set of boolean\n    type s2 : set of boolean\n    var as1, as2 : s1\n    var bs1, bs2 : s2\n    var aas : set of boolean\n\n    % should all produce boolean anyway\n    var _v_res : boolean\n\n    _v_res := r < b\n    _v_res := r < c\n    _v_res := r < c_sz\n    _v_res := r < s\n    _v_res := r < s_sz\n\n    _v_res := i < b\n    _v_res := i < c\n    _v_res := i < c_sz\n    _v_res := i < s\n    _v_res := i < s_sz\n\n    _v_res := n < b\n    _v_res := n < c\n    _v_res := n < c_sz\n    _v_res := n < s\n    _v_res := n < s_sz\n\n    _v_res := b < r\n    _v_res := b < i\n    _v_res := b < n\n    _v_res := b < c\n    _v_res := b < c_sz\n    _v_res := b < s\n    _v_res := b < s_sz\n\n    _v_res := c < r\n    _v_res := c < i\n    _v_res := c < n\n    _v_res := c < b\n\n    _v_res := c_sz < r\n    _v_res := c_sz < i\n    _v_res := c_sz < n\n    _v_res := c_sz < b\n\n    _v_res := s < r\n    _v_res := s < i\n    _v_res := s < n\n    _v_res := s < b\n\n    _v_res := s_sz < r\n    _v_res := s_sz < i\n    _v_res := s_sz < n\n    _v_res := s_sz < b\n\n    % Incompatible sets\n    _v_res := as1 < bs2\n    _v_res := bs1 < as2\n    _v_res := aas < as1\n    _v_res := as1 < aas\n    "
 ---
 "r"@(FileId(1), 24..25) [ConstVar(Var, No)]: real
 "i"@(FileId(1), 41..42) [ConstVar(Var, No)]: int
@@ -15,216 +15,221 @@ expression: "\n    % Numerics\n    var r : real\n    var i : int\n    var n : na
 "s2"@(FileId(1), 277..291) [Set]: <error>
 "s2"@(FileId(1), 272..274) [Type]: set[DefId(LibraryId(0), LocalDefId(10))] of boolean
 "as1"@(FileId(1), 300..303) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(8))] of boolean
-"bs2"@(FileId(1), 317..320) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(10))] of boolean
-"<anonymous>"@(FileId(1), 340..354) [Set]: <error>
-"aas"@(FileId(1), 334..337) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(14))] of boolean
-"_v_res"@(FileId(1), 404..410) [ConstVar(Var, No)]: boolean
-"bs1"@(FileId(1), 1300..1303) [Undeclared]: <error>
-"as2"@(FileId(1), 1306..1309) [Undeclared]: <error>
+"as2"@(FileId(1), 305..308) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(8))] of boolean
+"bs1"@(FileId(1), 322..325) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(10))] of boolean
+"bs2"@(FileId(1), 327..330) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(10))] of boolean
+"<anonymous>"@(FileId(1), 350..364) [Set]: <error>
+"aas"@(FileId(1), 344..347) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(16))] of boolean
+"_v_res"@(FileId(1), 414..420) [ConstVar(Var, No)]: boolean
 "<root>"@(dummy) [Module(No)]: <error>
 
-error in file FileId(1) at 438..439: mismatched types for `<`
-| note in file FileId(1) for 440..441: this is of type `boolean`
-| note in file FileId(1) for 436..437: this is of type `real`
-| error in file FileId(1) for 438..439: `real` cannot be compared to `boolean`
+error in file FileId(1) at 448..449: mismatched types for `<`
+| note in file FileId(1) for 450..451: this is of type `boolean`
+| note in file FileId(1) for 446..447: this is of type `real`
+| error in file FileId(1) for 448..449: `real` cannot be compared to `boolean`
 | info: operands must both be the same type
-error in file FileId(1) at 458..459: mismatched types for `<`
-| note in file FileId(1) for 460..461: this is of type `char`
-| note in file FileId(1) for 456..457: this is of type `real`
-| error in file FileId(1) for 458..459: `real` cannot be compared to `char`
+error in file FileId(1) at 468..469: mismatched types for `<`
+| note in file FileId(1) for 470..471: this is of type `char`
+| note in file FileId(1) for 466..467: this is of type `real`
+| error in file FileId(1) for 468..469: `real` cannot be compared to `char`
 | info: operands must both be the same type
-error in file FileId(1) at 478..479: mismatched types for `<`
-| note in file FileId(1) for 480..484: this is of type `char(6)`
-| note in file FileId(1) for 476..477: this is of type `real`
-| error in file FileId(1) for 478..479: `real` cannot be compared to `char(6)`
+error in file FileId(1) at 488..489: mismatched types for `<`
+| note in file FileId(1) for 490..494: this is of type `char(6)`
+| note in file FileId(1) for 486..487: this is of type `real`
+| error in file FileId(1) for 488..489: `real` cannot be compared to `char(6)`
 | info: operands must both be the same type
-error in file FileId(1) at 501..502: mismatched types for `<`
-| note in file FileId(1) for 503..504: this is of type `string`
-| note in file FileId(1) for 499..500: this is of type `real`
-| error in file FileId(1) for 501..502: `real` cannot be compared to `string`
+error in file FileId(1) at 511..512: mismatched types for `<`
+| note in file FileId(1) for 513..514: this is of type `string`
+| note in file FileId(1) for 509..510: this is of type `real`
+| error in file FileId(1) for 511..512: `real` cannot be compared to `string`
 | info: operands must both be the same type
-error in file FileId(1) at 521..522: mismatched types for `<`
-| note in file FileId(1) for 523..527: this is of type `string(6)`
-| note in file FileId(1) for 519..520: this is of type `real`
-| error in file FileId(1) for 521..522: `real` cannot be compared to `string(6)`
+error in file FileId(1) at 531..532: mismatched types for `<`
+| note in file FileId(1) for 533..537: this is of type `string(6)`
+| note in file FileId(1) for 529..530: this is of type `real`
+| error in file FileId(1) for 531..532: `real` cannot be compared to `string(6)`
 | info: operands must both be the same type
-error in file FileId(1) at 545..546: mismatched types for `<`
-| note in file FileId(1) for 547..548: this is of type `boolean`
-| note in file FileId(1) for 543..544: this is of type `int`
-| error in file FileId(1) for 545..546: `int` cannot be compared to `boolean`
+error in file FileId(1) at 555..556: mismatched types for `<`
+| note in file FileId(1) for 557..558: this is of type `boolean`
+| note in file FileId(1) for 553..554: this is of type `int`
+| error in file FileId(1) for 555..556: `int` cannot be compared to `boolean`
 | info: operands must both be the same type
-error in file FileId(1) at 565..566: mismatched types for `<`
-| note in file FileId(1) for 567..568: this is of type `char`
-| note in file FileId(1) for 563..564: this is of type `int`
-| error in file FileId(1) for 565..566: `int` cannot be compared to `char`
+error in file FileId(1) at 575..576: mismatched types for `<`
+| note in file FileId(1) for 577..578: this is of type `char`
+| note in file FileId(1) for 573..574: this is of type `int`
+| error in file FileId(1) for 575..576: `int` cannot be compared to `char`
 | info: operands must both be the same type
-error in file FileId(1) at 585..586: mismatched types for `<`
-| note in file FileId(1) for 587..591: this is of type `char(6)`
-| note in file FileId(1) for 583..584: this is of type `int`
-| error in file FileId(1) for 585..586: `int` cannot be compared to `char(6)`
+error in file FileId(1) at 595..596: mismatched types for `<`
+| note in file FileId(1) for 597..601: this is of type `char(6)`
+| note in file FileId(1) for 593..594: this is of type `int`
+| error in file FileId(1) for 595..596: `int` cannot be compared to `char(6)`
 | info: operands must both be the same type
-error in file FileId(1) at 608..609: mismatched types for `<`
-| note in file FileId(1) for 610..611: this is of type `string`
-| note in file FileId(1) for 606..607: this is of type `int`
-| error in file FileId(1) for 608..609: `int` cannot be compared to `string`
+error in file FileId(1) at 618..619: mismatched types for `<`
+| note in file FileId(1) for 620..621: this is of type `string`
+| note in file FileId(1) for 616..617: this is of type `int`
+| error in file FileId(1) for 618..619: `int` cannot be compared to `string`
 | info: operands must both be the same type
-error in file FileId(1) at 628..629: mismatched types for `<`
-| note in file FileId(1) for 630..634: this is of type `string(6)`
-| note in file FileId(1) for 626..627: this is of type `int`
-| error in file FileId(1) for 628..629: `int` cannot be compared to `string(6)`
+error in file FileId(1) at 638..639: mismatched types for `<`
+| note in file FileId(1) for 640..644: this is of type `string(6)`
+| note in file FileId(1) for 636..637: this is of type `int`
+| error in file FileId(1) for 638..639: `int` cannot be compared to `string(6)`
 | info: operands must both be the same type
-error in file FileId(1) at 652..653: mismatched types for `<`
-| note in file FileId(1) for 654..655: this is of type `boolean`
-| note in file FileId(1) for 650..651: this is of type `nat`
-| error in file FileId(1) for 652..653: `nat` cannot be compared to `boolean`
+error in file FileId(1) at 662..663: mismatched types for `<`
+| note in file FileId(1) for 664..665: this is of type `boolean`
+| note in file FileId(1) for 660..661: this is of type `nat`
+| error in file FileId(1) for 662..663: `nat` cannot be compared to `boolean`
 | info: operands must both be the same type
-error in file FileId(1) at 672..673: mismatched types for `<`
-| note in file FileId(1) for 674..675: this is of type `char`
-| note in file FileId(1) for 670..671: this is of type `nat`
-| error in file FileId(1) for 672..673: `nat` cannot be compared to `char`
+error in file FileId(1) at 682..683: mismatched types for `<`
+| note in file FileId(1) for 684..685: this is of type `char`
+| note in file FileId(1) for 680..681: this is of type `nat`
+| error in file FileId(1) for 682..683: `nat` cannot be compared to `char`
 | info: operands must both be the same type
-error in file FileId(1) at 692..693: mismatched types for `<`
-| note in file FileId(1) for 694..698: this is of type `char(6)`
-| note in file FileId(1) for 690..691: this is of type `nat`
-| error in file FileId(1) for 692..693: `nat` cannot be compared to `char(6)`
+error in file FileId(1) at 702..703: mismatched types for `<`
+| note in file FileId(1) for 704..708: this is of type `char(6)`
+| note in file FileId(1) for 700..701: this is of type `nat`
+| error in file FileId(1) for 702..703: `nat` cannot be compared to `char(6)`
 | info: operands must both be the same type
-error in file FileId(1) at 715..716: mismatched types for `<`
-| note in file FileId(1) for 717..718: this is of type `string`
-| note in file FileId(1) for 713..714: this is of type `nat`
-| error in file FileId(1) for 715..716: `nat` cannot be compared to `string`
+error in file FileId(1) at 725..726: mismatched types for `<`
+| note in file FileId(1) for 727..728: this is of type `string`
+| note in file FileId(1) for 723..724: this is of type `nat`
+| error in file FileId(1) for 725..726: `nat` cannot be compared to `string`
 | info: operands must both be the same type
-error in file FileId(1) at 735..736: mismatched types for `<`
-| note in file FileId(1) for 737..741: this is of type `string(6)`
-| note in file FileId(1) for 733..734: this is of type `nat`
-| error in file FileId(1) for 735..736: `nat` cannot be compared to `string(6)`
+error in file FileId(1) at 745..746: mismatched types for `<`
+| note in file FileId(1) for 747..751: this is of type `string(6)`
+| note in file FileId(1) for 743..744: this is of type `nat`
+| error in file FileId(1) for 745..746: `nat` cannot be compared to `string(6)`
 | info: operands must both be the same type
-error in file FileId(1) at 759..760: mismatched types for `<`
-| note in file FileId(1) for 761..762: this is of type `real`
-| note in file FileId(1) for 757..758: this is of type `boolean`
-| error in file FileId(1) for 759..760: `boolean` cannot be compared to `real`
+error in file FileId(1) at 769..770: mismatched types for `<`
+| note in file FileId(1) for 771..772: this is of type `real`
+| note in file FileId(1) for 767..768: this is of type `boolean`
+| error in file FileId(1) for 769..770: `boolean` cannot be compared to `real`
 | info: operands must both be the same type
-error in file FileId(1) at 779..780: mismatched types for `<`
-| note in file FileId(1) for 781..782: this is of type `int`
-| note in file FileId(1) for 777..778: this is of type `boolean`
-| error in file FileId(1) for 779..780: `boolean` cannot be compared to `int`
+error in file FileId(1) at 789..790: mismatched types for `<`
+| note in file FileId(1) for 791..792: this is of type `int`
+| note in file FileId(1) for 787..788: this is of type `boolean`
+| error in file FileId(1) for 789..790: `boolean` cannot be compared to `int`
 | info: operands must both be the same type
-error in file FileId(1) at 799..800: mismatched types for `<`
-| note in file FileId(1) for 801..802: this is of type `nat`
-| note in file FileId(1) for 797..798: this is of type `boolean`
-| error in file FileId(1) for 799..800: `boolean` cannot be compared to `nat`
+error in file FileId(1) at 809..810: mismatched types for `<`
+| note in file FileId(1) for 811..812: this is of type `nat`
+| note in file FileId(1) for 807..808: this is of type `boolean`
+| error in file FileId(1) for 809..810: `boolean` cannot be compared to `nat`
 | info: operands must both be the same type
-error in file FileId(1) at 819..820: mismatched types for `<`
-| note in file FileId(1) for 821..822: this is of type `char`
-| note in file FileId(1) for 817..818: this is of type `boolean`
-| error in file FileId(1) for 819..820: `boolean` cannot be compared to `char`
+error in file FileId(1) at 829..830: mismatched types for `<`
+| note in file FileId(1) for 831..832: this is of type `char`
+| note in file FileId(1) for 827..828: this is of type `boolean`
+| error in file FileId(1) for 829..830: `boolean` cannot be compared to `char`
 | info: operands must both be the same type
-error in file FileId(1) at 839..840: mismatched types for `<`
-| note in file FileId(1) for 841..845: this is of type `char(6)`
-| note in file FileId(1) for 837..838: this is of type `boolean`
-| error in file FileId(1) for 839..840: `boolean` cannot be compared to `char(6)`
+error in file FileId(1) at 849..850: mismatched types for `<`
+| note in file FileId(1) for 851..855: this is of type `char(6)`
+| note in file FileId(1) for 847..848: this is of type `boolean`
+| error in file FileId(1) for 849..850: `boolean` cannot be compared to `char(6)`
 | info: operands must both be the same type
-error in file FileId(1) at 862..863: mismatched types for `<`
-| note in file FileId(1) for 864..865: this is of type `string`
-| note in file FileId(1) for 860..861: this is of type `boolean`
-| error in file FileId(1) for 862..863: `boolean` cannot be compared to `string`
+error in file FileId(1) at 872..873: mismatched types for `<`
+| note in file FileId(1) for 874..875: this is of type `string`
+| note in file FileId(1) for 870..871: this is of type `boolean`
+| error in file FileId(1) for 872..873: `boolean` cannot be compared to `string`
 | info: operands must both be the same type
-error in file FileId(1) at 882..883: mismatched types for `<`
-| note in file FileId(1) for 884..888: this is of type `string(6)`
-| note in file FileId(1) for 880..881: this is of type `boolean`
-| error in file FileId(1) for 882..883: `boolean` cannot be compared to `string(6)`
+error in file FileId(1) at 892..893: mismatched types for `<`
+| note in file FileId(1) for 894..898: this is of type `string(6)`
+| note in file FileId(1) for 890..891: this is of type `boolean`
+| error in file FileId(1) for 892..893: `boolean` cannot be compared to `string(6)`
 | info: operands must both be the same type
-error in file FileId(1) at 906..907: mismatched types for `<`
-| note in file FileId(1) for 908..909: this is of type `real`
-| note in file FileId(1) for 904..905: this is of type `char`
-| error in file FileId(1) for 906..907: `char` cannot be compared to `real`
+error in file FileId(1) at 916..917: mismatched types for `<`
+| note in file FileId(1) for 918..919: this is of type `real`
+| note in file FileId(1) for 914..915: this is of type `char`
+| error in file FileId(1) for 916..917: `char` cannot be compared to `real`
 | info: operands must both be the same type
-error in file FileId(1) at 926..927: mismatched types for `<`
-| note in file FileId(1) for 928..929: this is of type `int`
-| note in file FileId(1) for 924..925: this is of type `char`
-| error in file FileId(1) for 926..927: `char` cannot be compared to `int`
+error in file FileId(1) at 936..937: mismatched types for `<`
+| note in file FileId(1) for 938..939: this is of type `int`
+| note in file FileId(1) for 934..935: this is of type `char`
+| error in file FileId(1) for 936..937: `char` cannot be compared to `int`
 | info: operands must both be the same type
-error in file FileId(1) at 946..947: mismatched types for `<`
-| note in file FileId(1) for 948..949: this is of type `nat`
-| note in file FileId(1) for 944..945: this is of type `char`
-| error in file FileId(1) for 946..947: `char` cannot be compared to `nat`
+error in file FileId(1) at 956..957: mismatched types for `<`
+| note in file FileId(1) for 958..959: this is of type `nat`
+| note in file FileId(1) for 954..955: this is of type `char`
+| error in file FileId(1) for 956..957: `char` cannot be compared to `nat`
 | info: operands must both be the same type
-error in file FileId(1) at 966..967: mismatched types for `<`
-| note in file FileId(1) for 968..969: this is of type `boolean`
-| note in file FileId(1) for 964..965: this is of type `char`
-| error in file FileId(1) for 966..967: `char` cannot be compared to `boolean`
+error in file FileId(1) at 976..977: mismatched types for `<`
+| note in file FileId(1) for 978..979: this is of type `boolean`
+| note in file FileId(1) for 974..975: this is of type `char`
+| error in file FileId(1) for 976..977: `char` cannot be compared to `boolean`
 | info: operands must both be the same type
-error in file FileId(1) at 990..991: mismatched types for `<`
-| note in file FileId(1) for 992..993: this is of type `real`
-| note in file FileId(1) for 985..989: this is of type `char(6)`
-| error in file FileId(1) for 990..991: `char(6)` cannot be compared to `real`
+error in file FileId(1) at 1000..1001: mismatched types for `<`
+| note in file FileId(1) for 1002..1003: this is of type `real`
+| note in file FileId(1) for 995..999: this is of type `char(6)`
+| error in file FileId(1) for 1000..1001: `char(6)` cannot be compared to `real`
 | info: operands must both be the same type
-error in file FileId(1) at 1013..1014: mismatched types for `<`
-| note in file FileId(1) for 1015..1016: this is of type `int`
-| note in file FileId(1) for 1008..1012: this is of type `char(6)`
-| error in file FileId(1) for 1013..1014: `char(6)` cannot be compared to `int`
+error in file FileId(1) at 1023..1024: mismatched types for `<`
+| note in file FileId(1) for 1025..1026: this is of type `int`
+| note in file FileId(1) for 1018..1022: this is of type `char(6)`
+| error in file FileId(1) for 1023..1024: `char(6)` cannot be compared to `int`
 | info: operands must both be the same type
-error in file FileId(1) at 1036..1037: mismatched types for `<`
-| note in file FileId(1) for 1038..1039: this is of type `nat`
-| note in file FileId(1) for 1031..1035: this is of type `char(6)`
-| error in file FileId(1) for 1036..1037: `char(6)` cannot be compared to `nat`
+error in file FileId(1) at 1046..1047: mismatched types for `<`
+| note in file FileId(1) for 1048..1049: this is of type `nat`
+| note in file FileId(1) for 1041..1045: this is of type `char(6)`
+| error in file FileId(1) for 1046..1047: `char(6)` cannot be compared to `nat`
 | info: operands must both be the same type
-error in file FileId(1) at 1059..1060: mismatched types for `<`
-| note in file FileId(1) for 1061..1062: this is of type `boolean`
-| note in file FileId(1) for 1054..1058: this is of type `char(6)`
-| error in file FileId(1) for 1059..1060: `char(6)` cannot be compared to `boolean`
+error in file FileId(1) at 1069..1070: mismatched types for `<`
+| note in file FileId(1) for 1071..1072: this is of type `boolean`
+| note in file FileId(1) for 1064..1068: this is of type `char(6)`
+| error in file FileId(1) for 1069..1070: `char(6)` cannot be compared to `boolean`
 | info: operands must both be the same type
-error in file FileId(1) at 1080..1081: mismatched types for `<`
-| note in file FileId(1) for 1082..1083: this is of type `real`
-| note in file FileId(1) for 1078..1079: this is of type `string`
-| error in file FileId(1) for 1080..1081: `string` cannot be compared to `real`
+error in file FileId(1) at 1090..1091: mismatched types for `<`
+| note in file FileId(1) for 1092..1093: this is of type `real`
+| note in file FileId(1) for 1088..1089: this is of type `string`
+| error in file FileId(1) for 1090..1091: `string` cannot be compared to `real`
 | info: operands must both be the same type
-error in file FileId(1) at 1100..1101: mismatched types for `<`
-| note in file FileId(1) for 1102..1103: this is of type `int`
-| note in file FileId(1) for 1098..1099: this is of type `string`
-| error in file FileId(1) for 1100..1101: `string` cannot be compared to `int`
+error in file FileId(1) at 1110..1111: mismatched types for `<`
+| note in file FileId(1) for 1112..1113: this is of type `int`
+| note in file FileId(1) for 1108..1109: this is of type `string`
+| error in file FileId(1) for 1110..1111: `string` cannot be compared to `int`
 | info: operands must both be the same type
-error in file FileId(1) at 1120..1121: mismatched types for `<`
-| note in file FileId(1) for 1122..1123: this is of type `nat`
-| note in file FileId(1) for 1118..1119: this is of type `string`
-| error in file FileId(1) for 1120..1121: `string` cannot be compared to `nat`
+error in file FileId(1) at 1130..1131: mismatched types for `<`
+| note in file FileId(1) for 1132..1133: this is of type `nat`
+| note in file FileId(1) for 1128..1129: this is of type `string`
+| error in file FileId(1) for 1130..1131: `string` cannot be compared to `nat`
 | info: operands must both be the same type
-error in file FileId(1) at 1140..1141: mismatched types for `<`
-| note in file FileId(1) for 1142..1143: this is of type `boolean`
-| note in file FileId(1) for 1138..1139: this is of type `string`
-| error in file FileId(1) for 1140..1141: `string` cannot be compared to `boolean`
+error in file FileId(1) at 1150..1151: mismatched types for `<`
+| note in file FileId(1) for 1152..1153: this is of type `boolean`
+| note in file FileId(1) for 1148..1149: this is of type `string`
+| error in file FileId(1) for 1150..1151: `string` cannot be compared to `boolean`
 | info: operands must both be the same type
-error in file FileId(1) at 1164..1165: mismatched types for `<`
-| note in file FileId(1) for 1166..1167: this is of type `real`
-| note in file FileId(1) for 1159..1163: this is of type `string(6)`
-| error in file FileId(1) for 1164..1165: `string(6)` cannot be compared to `real`
+error in file FileId(1) at 1174..1175: mismatched types for `<`
+| note in file FileId(1) for 1176..1177: this is of type `real`
+| note in file FileId(1) for 1169..1173: this is of type `string(6)`
+| error in file FileId(1) for 1174..1175: `string(6)` cannot be compared to `real`
 | info: operands must both be the same type
-error in file FileId(1) at 1187..1188: mismatched types for `<`
-| note in file FileId(1) for 1189..1190: this is of type `int`
-| note in file FileId(1) for 1182..1186: this is of type `string(6)`
-| error in file FileId(1) for 1187..1188: `string(6)` cannot be compared to `int`
+error in file FileId(1) at 1197..1198: mismatched types for `<`
+| note in file FileId(1) for 1199..1200: this is of type `int`
+| note in file FileId(1) for 1192..1196: this is of type `string(6)`
+| error in file FileId(1) for 1197..1198: `string(6)` cannot be compared to `int`
 | info: operands must both be the same type
-error in file FileId(1) at 1210..1211: mismatched types for `<`
-| note in file FileId(1) for 1212..1213: this is of type `nat`
-| note in file FileId(1) for 1205..1209: this is of type `string(6)`
-| error in file FileId(1) for 1210..1211: `string(6)` cannot be compared to `nat`
+error in file FileId(1) at 1220..1221: mismatched types for `<`
+| note in file FileId(1) for 1222..1223: this is of type `nat`
+| note in file FileId(1) for 1215..1219: this is of type `string(6)`
+| error in file FileId(1) for 1220..1221: `string(6)` cannot be compared to `nat`
 | info: operands must both be the same type
-error in file FileId(1) at 1233..1234: mismatched types for `<`
-| note in file FileId(1) for 1235..1236: this is of type `boolean`
-| note in file FileId(1) for 1228..1232: this is of type `string(6)`
-| error in file FileId(1) for 1233..1234: `string(6)` cannot be compared to `boolean`
+error in file FileId(1) at 1243..1244: mismatched types for `<`
+| note in file FileId(1) for 1245..1246: this is of type `boolean`
+| note in file FileId(1) for 1238..1242: this is of type `string(6)`
+| error in file FileId(1) for 1243..1244: `string(6)` cannot be compared to `boolean`
 | info: operands must both be the same type
-error in file FileId(1) at 1280..1281: mismatched types for `<`
-| note in file FileId(1) for 1282..1285: this is of type `set s2 (of boolean)`
-| note in file FileId(1) for 1276..1279: this is of type `set s1 (of boolean)`
-| error in file FileId(1) for 1280..1281: `set s1 (of boolean)` cannot be compared to `set s2 (of boolean)`
+error in file FileId(1) at 1290..1291: mismatched types for `<`
+| note in file FileId(1) for 1292..1295: this is of type `set s2 (of boolean)`
+| note in file FileId(1) for 1286..1289: this is of type `set s1 (of boolean)`
+| error in file FileId(1) for 1290..1291: `set s1 (of boolean)` cannot be compared to `set s2 (of boolean)`
 | info: operands must both be the same type
-error in file FileId(1) at 1328..1329: mismatched types for `<`
-| note in file FileId(1) for 1330..1333: this is of type `set s1 (of boolean)`
-| note in file FileId(1) for 1324..1327: this is of type `set <anonymous> (of boolean)`
-| error in file FileId(1) for 1328..1329: `set <anonymous> (of boolean)` cannot be compared to `set s1 (of boolean)`
+error in file FileId(1) at 1314..1315: mismatched types for `<`
+| note in file FileId(1) for 1316..1319: this is of type `set s1 (of boolean)`
+| note in file FileId(1) for 1310..1313: this is of type `set s2 (of boolean)`
+| error in file FileId(1) for 1314..1315: `set s2 (of boolean)` cannot be compared to `set s1 (of boolean)`
 | info: operands must both be the same type
-error in file FileId(1) at 1352..1353: mismatched types for `<`
-| note in file FileId(1) for 1354..1357: this is of type `set <anonymous> (of boolean)`
-| note in file FileId(1) for 1348..1351: this is of type `set s1 (of boolean)`
-| error in file FileId(1) for 1352..1353: `set s1 (of boolean)` cannot be compared to `set <anonymous> (of boolean)`
+error in file FileId(1) at 1338..1339: mismatched types for `<`
+| note in file FileId(1) for 1340..1343: this is of type `set s1 (of boolean)`
+| note in file FileId(1) for 1334..1337: this is of type `set <anonymous> (of boolean)`
+| error in file FileId(1) for 1338..1339: `set <anonymous> (of boolean)` cannot be compared to `set s1 (of boolean)`
+| info: operands must both be the same type
+error in file FileId(1) at 1362..1363: mismatched types for `<`
+| note in file FileId(1) for 1364..1367: this is of type `set <anonymous> (of boolean)`
+| note in file FileId(1) for 1358..1361: this is of type `set s1 (of boolean)`
+| error in file FileId(1) for 1362..1363: `set s1 (of boolean)` cannot be compared to `set <anonymous> (of boolean)`
 | info: operands must both be the same type

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_less_eq.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_less_eq.snap
@@ -1,6 +1,6 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-expression: "\n    % Numerics\n    var r : real\n    var i : int\n    var n : nat\n\n    % Other scalars\n    var b : boolean\n\n    % Sized charseqs\n    var c : char\n    var c_sz : char(6)\n    var s : string\n    var s_sz : string(6)\n\n    % Different sets\n    type s1 : set of boolean\n    type s2 : set of boolean\n    var as1 : s1\n    var bs2 : s2\n    var aas : set of boolean\n\n    % should all produce boolean anyway\n    var _v_res : boolean\n\n    _v_res := r <= b\n    _v_res := r <= c\n    _v_res := r <= c_sz\n    _v_res := r <= s\n    _v_res := r <= s_sz\n\n    _v_res := i <= b\n    _v_res := i <= c\n    _v_res := i <= c_sz\n    _v_res := i <= s\n    _v_res := i <= s_sz\n\n    _v_res := n <= b\n    _v_res := n <= c\n    _v_res := n <= c_sz\n    _v_res := n <= s\n    _v_res := n <= s_sz\n\n    _v_res := b <= r\n    _v_res := b <= i\n    _v_res := b <= n\n    _v_res := b <= c\n    _v_res := b <= c_sz\n    _v_res := b <= s\n    _v_res := b <= s_sz\n\n    _v_res := c <= r\n    _v_res := c <= i\n    _v_res := c <= n\n    _v_res := c <= b\n\n    _v_res := c_sz <= r\n    _v_res := c_sz <= i\n    _v_res := c_sz <= n\n    _v_res := c_sz <= b\n\n    _v_res := s <= r\n    _v_res := s <= i\n    _v_res := s <= n\n    _v_res := s <= b\n\n    _v_res := s_sz <= r\n    _v_res := s_sz <= i\n    _v_res := s_sz <= n\n    _v_res := s_sz <= b\n\n    % Incompatible sets\n    _v_res := as1 <= bs2\n    _v_res := bs1 <= as2\n    _v_res := aas <= as1\n    _v_res := as1 <= aas\n    "
+expression: "\n    % Numerics\n    var r : real\n    var i : int\n    var n : nat\n\n    % Other scalars\n    var b : boolean\n\n    % Sized charseqs\n    var c : char\n    var c_sz : char(6)\n    var s : string\n    var s_sz : string(6)\n\n    % Different sets\n    type s1 : set of boolean\n    type s2 : set of boolean\n    var as1, as2 : s1\n    var bs1, bs2 : s2\n    var aas : set of boolean\n\n    % should all produce boolean anyway\n    var _v_res : boolean\n\n    _v_res := r <= b\n    _v_res := r <= c\n    _v_res := r <= c_sz\n    _v_res := r <= s\n    _v_res := r <= s_sz\n\n    _v_res := i <= b\n    _v_res := i <= c\n    _v_res := i <= c_sz\n    _v_res := i <= s\n    _v_res := i <= s_sz\n\n    _v_res := n <= b\n    _v_res := n <= c\n    _v_res := n <= c_sz\n    _v_res := n <= s\n    _v_res := n <= s_sz\n\n    _v_res := b <= r\n    _v_res := b <= i\n    _v_res := b <= n\n    _v_res := b <= c\n    _v_res := b <= c_sz\n    _v_res := b <= s\n    _v_res := b <= s_sz\n\n    _v_res := c <= r\n    _v_res := c <= i\n    _v_res := c <= n\n    _v_res := c <= b\n\n    _v_res := c_sz <= r\n    _v_res := c_sz <= i\n    _v_res := c_sz <= n\n    _v_res := c_sz <= b\n\n    _v_res := s <= r\n    _v_res := s <= i\n    _v_res := s <= n\n    _v_res := s <= b\n\n    _v_res := s_sz <= r\n    _v_res := s_sz <= i\n    _v_res := s_sz <= n\n    _v_res := s_sz <= b\n\n    % Incompatible sets\n    _v_res := as1 <= bs2\n    _v_res := bs1 <= as2\n    _v_res := aas <= as1\n    _v_res := as1 <= aas\n    "
 ---
 "r"@(FileId(1), 24..25) [ConstVar(Var, No)]: real
 "i"@(FileId(1), 41..42) [ConstVar(Var, No)]: int
@@ -15,216 +15,221 @@ expression: "\n    % Numerics\n    var r : real\n    var i : int\n    var n : na
 "s2"@(FileId(1), 277..291) [Set]: <error>
 "s2"@(FileId(1), 272..274) [Type]: set[DefId(LibraryId(0), LocalDefId(10))] of boolean
 "as1"@(FileId(1), 300..303) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(8))] of boolean
-"bs2"@(FileId(1), 317..320) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(10))] of boolean
-"<anonymous>"@(FileId(1), 340..354) [Set]: <error>
-"aas"@(FileId(1), 334..337) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(14))] of boolean
-"_v_res"@(FileId(1), 404..410) [ConstVar(Var, No)]: boolean
-"bs1"@(FileId(1), 1339..1342) [Undeclared]: <error>
-"as2"@(FileId(1), 1346..1349) [Undeclared]: <error>
+"as2"@(FileId(1), 305..308) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(8))] of boolean
+"bs1"@(FileId(1), 322..325) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(10))] of boolean
+"bs2"@(FileId(1), 327..330) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(10))] of boolean
+"<anonymous>"@(FileId(1), 350..364) [Set]: <error>
+"aas"@(FileId(1), 344..347) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(16))] of boolean
+"_v_res"@(FileId(1), 414..420) [ConstVar(Var, No)]: boolean
 "<root>"@(dummy) [Module(No)]: <error>
 
-error in file FileId(1) at 438..440: mismatched types for `<=`
-| note in file FileId(1) for 441..442: this is of type `boolean`
-| note in file FileId(1) for 436..437: this is of type `real`
-| error in file FileId(1) for 438..440: `real` cannot be compared to `boolean`
+error in file FileId(1) at 448..450: mismatched types for `<=`
+| note in file FileId(1) for 451..452: this is of type `boolean`
+| note in file FileId(1) for 446..447: this is of type `real`
+| error in file FileId(1) for 448..450: `real` cannot be compared to `boolean`
 | info: operands must both be the same type
-error in file FileId(1) at 459..461: mismatched types for `<=`
-| note in file FileId(1) for 462..463: this is of type `char`
-| note in file FileId(1) for 457..458: this is of type `real`
-| error in file FileId(1) for 459..461: `real` cannot be compared to `char`
+error in file FileId(1) at 469..471: mismatched types for `<=`
+| note in file FileId(1) for 472..473: this is of type `char`
+| note in file FileId(1) for 467..468: this is of type `real`
+| error in file FileId(1) for 469..471: `real` cannot be compared to `char`
 | info: operands must both be the same type
-error in file FileId(1) at 480..482: mismatched types for `<=`
-| note in file FileId(1) for 483..487: this is of type `char(6)`
-| note in file FileId(1) for 478..479: this is of type `real`
-| error in file FileId(1) for 480..482: `real` cannot be compared to `char(6)`
+error in file FileId(1) at 490..492: mismatched types for `<=`
+| note in file FileId(1) for 493..497: this is of type `char(6)`
+| note in file FileId(1) for 488..489: this is of type `real`
+| error in file FileId(1) for 490..492: `real` cannot be compared to `char(6)`
 | info: operands must both be the same type
-error in file FileId(1) at 504..506: mismatched types for `<=`
-| note in file FileId(1) for 507..508: this is of type `string`
-| note in file FileId(1) for 502..503: this is of type `real`
-| error in file FileId(1) for 504..506: `real` cannot be compared to `string`
+error in file FileId(1) at 514..516: mismatched types for `<=`
+| note in file FileId(1) for 517..518: this is of type `string`
+| note in file FileId(1) for 512..513: this is of type `real`
+| error in file FileId(1) for 514..516: `real` cannot be compared to `string`
 | info: operands must both be the same type
-error in file FileId(1) at 525..527: mismatched types for `<=`
-| note in file FileId(1) for 528..532: this is of type `string(6)`
-| note in file FileId(1) for 523..524: this is of type `real`
-| error in file FileId(1) for 525..527: `real` cannot be compared to `string(6)`
+error in file FileId(1) at 535..537: mismatched types for `<=`
+| note in file FileId(1) for 538..542: this is of type `string(6)`
+| note in file FileId(1) for 533..534: this is of type `real`
+| error in file FileId(1) for 535..537: `real` cannot be compared to `string(6)`
 | info: operands must both be the same type
-error in file FileId(1) at 550..552: mismatched types for `<=`
-| note in file FileId(1) for 553..554: this is of type `boolean`
-| note in file FileId(1) for 548..549: this is of type `int`
-| error in file FileId(1) for 550..552: `int` cannot be compared to `boolean`
+error in file FileId(1) at 560..562: mismatched types for `<=`
+| note in file FileId(1) for 563..564: this is of type `boolean`
+| note in file FileId(1) for 558..559: this is of type `int`
+| error in file FileId(1) for 560..562: `int` cannot be compared to `boolean`
 | info: operands must both be the same type
-error in file FileId(1) at 571..573: mismatched types for `<=`
-| note in file FileId(1) for 574..575: this is of type `char`
-| note in file FileId(1) for 569..570: this is of type `int`
-| error in file FileId(1) for 571..573: `int` cannot be compared to `char`
+error in file FileId(1) at 581..583: mismatched types for `<=`
+| note in file FileId(1) for 584..585: this is of type `char`
+| note in file FileId(1) for 579..580: this is of type `int`
+| error in file FileId(1) for 581..583: `int` cannot be compared to `char`
 | info: operands must both be the same type
-error in file FileId(1) at 592..594: mismatched types for `<=`
-| note in file FileId(1) for 595..599: this is of type `char(6)`
-| note in file FileId(1) for 590..591: this is of type `int`
-| error in file FileId(1) for 592..594: `int` cannot be compared to `char(6)`
+error in file FileId(1) at 602..604: mismatched types for `<=`
+| note in file FileId(1) for 605..609: this is of type `char(6)`
+| note in file FileId(1) for 600..601: this is of type `int`
+| error in file FileId(1) for 602..604: `int` cannot be compared to `char(6)`
 | info: operands must both be the same type
-error in file FileId(1) at 616..618: mismatched types for `<=`
-| note in file FileId(1) for 619..620: this is of type `string`
-| note in file FileId(1) for 614..615: this is of type `int`
-| error in file FileId(1) for 616..618: `int` cannot be compared to `string`
+error in file FileId(1) at 626..628: mismatched types for `<=`
+| note in file FileId(1) for 629..630: this is of type `string`
+| note in file FileId(1) for 624..625: this is of type `int`
+| error in file FileId(1) for 626..628: `int` cannot be compared to `string`
 | info: operands must both be the same type
-error in file FileId(1) at 637..639: mismatched types for `<=`
-| note in file FileId(1) for 640..644: this is of type `string(6)`
-| note in file FileId(1) for 635..636: this is of type `int`
-| error in file FileId(1) for 637..639: `int` cannot be compared to `string(6)`
+error in file FileId(1) at 647..649: mismatched types for `<=`
+| note in file FileId(1) for 650..654: this is of type `string(6)`
+| note in file FileId(1) for 645..646: this is of type `int`
+| error in file FileId(1) for 647..649: `int` cannot be compared to `string(6)`
 | info: operands must both be the same type
-error in file FileId(1) at 662..664: mismatched types for `<=`
-| note in file FileId(1) for 665..666: this is of type `boolean`
-| note in file FileId(1) for 660..661: this is of type `nat`
-| error in file FileId(1) for 662..664: `nat` cannot be compared to `boolean`
+error in file FileId(1) at 672..674: mismatched types for `<=`
+| note in file FileId(1) for 675..676: this is of type `boolean`
+| note in file FileId(1) for 670..671: this is of type `nat`
+| error in file FileId(1) for 672..674: `nat` cannot be compared to `boolean`
 | info: operands must both be the same type
-error in file FileId(1) at 683..685: mismatched types for `<=`
-| note in file FileId(1) for 686..687: this is of type `char`
-| note in file FileId(1) for 681..682: this is of type `nat`
-| error in file FileId(1) for 683..685: `nat` cannot be compared to `char`
+error in file FileId(1) at 693..695: mismatched types for `<=`
+| note in file FileId(1) for 696..697: this is of type `char`
+| note in file FileId(1) for 691..692: this is of type `nat`
+| error in file FileId(1) for 693..695: `nat` cannot be compared to `char`
 | info: operands must both be the same type
-error in file FileId(1) at 704..706: mismatched types for `<=`
-| note in file FileId(1) for 707..711: this is of type `char(6)`
-| note in file FileId(1) for 702..703: this is of type `nat`
-| error in file FileId(1) for 704..706: `nat` cannot be compared to `char(6)`
+error in file FileId(1) at 714..716: mismatched types for `<=`
+| note in file FileId(1) for 717..721: this is of type `char(6)`
+| note in file FileId(1) for 712..713: this is of type `nat`
+| error in file FileId(1) for 714..716: `nat` cannot be compared to `char(6)`
 | info: operands must both be the same type
-error in file FileId(1) at 728..730: mismatched types for `<=`
-| note in file FileId(1) for 731..732: this is of type `string`
-| note in file FileId(1) for 726..727: this is of type `nat`
-| error in file FileId(1) for 728..730: `nat` cannot be compared to `string`
+error in file FileId(1) at 738..740: mismatched types for `<=`
+| note in file FileId(1) for 741..742: this is of type `string`
+| note in file FileId(1) for 736..737: this is of type `nat`
+| error in file FileId(1) for 738..740: `nat` cannot be compared to `string`
 | info: operands must both be the same type
-error in file FileId(1) at 749..751: mismatched types for `<=`
-| note in file FileId(1) for 752..756: this is of type `string(6)`
-| note in file FileId(1) for 747..748: this is of type `nat`
-| error in file FileId(1) for 749..751: `nat` cannot be compared to `string(6)`
+error in file FileId(1) at 759..761: mismatched types for `<=`
+| note in file FileId(1) for 762..766: this is of type `string(6)`
+| note in file FileId(1) for 757..758: this is of type `nat`
+| error in file FileId(1) for 759..761: `nat` cannot be compared to `string(6)`
 | info: operands must both be the same type
-error in file FileId(1) at 774..776: mismatched types for `<=`
-| note in file FileId(1) for 777..778: this is of type `real`
-| note in file FileId(1) for 772..773: this is of type `boolean`
-| error in file FileId(1) for 774..776: `boolean` cannot be compared to `real`
+error in file FileId(1) at 784..786: mismatched types for `<=`
+| note in file FileId(1) for 787..788: this is of type `real`
+| note in file FileId(1) for 782..783: this is of type `boolean`
+| error in file FileId(1) for 784..786: `boolean` cannot be compared to `real`
 | info: operands must both be the same type
-error in file FileId(1) at 795..797: mismatched types for `<=`
-| note in file FileId(1) for 798..799: this is of type `int`
-| note in file FileId(1) for 793..794: this is of type `boolean`
-| error in file FileId(1) for 795..797: `boolean` cannot be compared to `int`
+error in file FileId(1) at 805..807: mismatched types for `<=`
+| note in file FileId(1) for 808..809: this is of type `int`
+| note in file FileId(1) for 803..804: this is of type `boolean`
+| error in file FileId(1) for 805..807: `boolean` cannot be compared to `int`
 | info: operands must both be the same type
-error in file FileId(1) at 816..818: mismatched types for `<=`
-| note in file FileId(1) for 819..820: this is of type `nat`
-| note in file FileId(1) for 814..815: this is of type `boolean`
-| error in file FileId(1) for 816..818: `boolean` cannot be compared to `nat`
+error in file FileId(1) at 826..828: mismatched types for `<=`
+| note in file FileId(1) for 829..830: this is of type `nat`
+| note in file FileId(1) for 824..825: this is of type `boolean`
+| error in file FileId(1) for 826..828: `boolean` cannot be compared to `nat`
 | info: operands must both be the same type
-error in file FileId(1) at 837..839: mismatched types for `<=`
-| note in file FileId(1) for 840..841: this is of type `char`
-| note in file FileId(1) for 835..836: this is of type `boolean`
-| error in file FileId(1) for 837..839: `boolean` cannot be compared to `char`
+error in file FileId(1) at 847..849: mismatched types for `<=`
+| note in file FileId(1) for 850..851: this is of type `char`
+| note in file FileId(1) for 845..846: this is of type `boolean`
+| error in file FileId(1) for 847..849: `boolean` cannot be compared to `char`
 | info: operands must both be the same type
-error in file FileId(1) at 858..860: mismatched types for `<=`
-| note in file FileId(1) for 861..865: this is of type `char(6)`
-| note in file FileId(1) for 856..857: this is of type `boolean`
-| error in file FileId(1) for 858..860: `boolean` cannot be compared to `char(6)`
+error in file FileId(1) at 868..870: mismatched types for `<=`
+| note in file FileId(1) for 871..875: this is of type `char(6)`
+| note in file FileId(1) for 866..867: this is of type `boolean`
+| error in file FileId(1) for 868..870: `boolean` cannot be compared to `char(6)`
 | info: operands must both be the same type
-error in file FileId(1) at 882..884: mismatched types for `<=`
-| note in file FileId(1) for 885..886: this is of type `string`
-| note in file FileId(1) for 880..881: this is of type `boolean`
-| error in file FileId(1) for 882..884: `boolean` cannot be compared to `string`
+error in file FileId(1) at 892..894: mismatched types for `<=`
+| note in file FileId(1) for 895..896: this is of type `string`
+| note in file FileId(1) for 890..891: this is of type `boolean`
+| error in file FileId(1) for 892..894: `boolean` cannot be compared to `string`
 | info: operands must both be the same type
-error in file FileId(1) at 903..905: mismatched types for `<=`
-| note in file FileId(1) for 906..910: this is of type `string(6)`
-| note in file FileId(1) for 901..902: this is of type `boolean`
-| error in file FileId(1) for 903..905: `boolean` cannot be compared to `string(6)`
+error in file FileId(1) at 913..915: mismatched types for `<=`
+| note in file FileId(1) for 916..920: this is of type `string(6)`
+| note in file FileId(1) for 911..912: this is of type `boolean`
+| error in file FileId(1) for 913..915: `boolean` cannot be compared to `string(6)`
 | info: operands must both be the same type
-error in file FileId(1) at 928..930: mismatched types for `<=`
-| note in file FileId(1) for 931..932: this is of type `real`
-| note in file FileId(1) for 926..927: this is of type `char`
-| error in file FileId(1) for 928..930: `char` cannot be compared to `real`
+error in file FileId(1) at 938..940: mismatched types for `<=`
+| note in file FileId(1) for 941..942: this is of type `real`
+| note in file FileId(1) for 936..937: this is of type `char`
+| error in file FileId(1) for 938..940: `char` cannot be compared to `real`
 | info: operands must both be the same type
-error in file FileId(1) at 949..951: mismatched types for `<=`
-| note in file FileId(1) for 952..953: this is of type `int`
-| note in file FileId(1) for 947..948: this is of type `char`
-| error in file FileId(1) for 949..951: `char` cannot be compared to `int`
+error in file FileId(1) at 959..961: mismatched types for `<=`
+| note in file FileId(1) for 962..963: this is of type `int`
+| note in file FileId(1) for 957..958: this is of type `char`
+| error in file FileId(1) for 959..961: `char` cannot be compared to `int`
 | info: operands must both be the same type
-error in file FileId(1) at 970..972: mismatched types for `<=`
-| note in file FileId(1) for 973..974: this is of type `nat`
-| note in file FileId(1) for 968..969: this is of type `char`
-| error in file FileId(1) for 970..972: `char` cannot be compared to `nat`
+error in file FileId(1) at 980..982: mismatched types for `<=`
+| note in file FileId(1) for 983..984: this is of type `nat`
+| note in file FileId(1) for 978..979: this is of type `char`
+| error in file FileId(1) for 980..982: `char` cannot be compared to `nat`
 | info: operands must both be the same type
-error in file FileId(1) at 991..993: mismatched types for `<=`
-| note in file FileId(1) for 994..995: this is of type `boolean`
-| note in file FileId(1) for 989..990: this is of type `char`
-| error in file FileId(1) for 991..993: `char` cannot be compared to `boolean`
+error in file FileId(1) at 1001..1003: mismatched types for `<=`
+| note in file FileId(1) for 1004..1005: this is of type `boolean`
+| note in file FileId(1) for 999..1000: this is of type `char`
+| error in file FileId(1) for 1001..1003: `char` cannot be compared to `boolean`
 | info: operands must both be the same type
-error in file FileId(1) at 1016..1018: mismatched types for `<=`
-| note in file FileId(1) for 1019..1020: this is of type `real`
-| note in file FileId(1) for 1011..1015: this is of type `char(6)`
-| error in file FileId(1) for 1016..1018: `char(6)` cannot be compared to `real`
+error in file FileId(1) at 1026..1028: mismatched types for `<=`
+| note in file FileId(1) for 1029..1030: this is of type `real`
+| note in file FileId(1) for 1021..1025: this is of type `char(6)`
+| error in file FileId(1) for 1026..1028: `char(6)` cannot be compared to `real`
 | info: operands must both be the same type
-error in file FileId(1) at 1040..1042: mismatched types for `<=`
-| note in file FileId(1) for 1043..1044: this is of type `int`
-| note in file FileId(1) for 1035..1039: this is of type `char(6)`
-| error in file FileId(1) for 1040..1042: `char(6)` cannot be compared to `int`
+error in file FileId(1) at 1050..1052: mismatched types for `<=`
+| note in file FileId(1) for 1053..1054: this is of type `int`
+| note in file FileId(1) for 1045..1049: this is of type `char(6)`
+| error in file FileId(1) for 1050..1052: `char(6)` cannot be compared to `int`
 | info: operands must both be the same type
-error in file FileId(1) at 1064..1066: mismatched types for `<=`
-| note in file FileId(1) for 1067..1068: this is of type `nat`
-| note in file FileId(1) for 1059..1063: this is of type `char(6)`
-| error in file FileId(1) for 1064..1066: `char(6)` cannot be compared to `nat`
+error in file FileId(1) at 1074..1076: mismatched types for `<=`
+| note in file FileId(1) for 1077..1078: this is of type `nat`
+| note in file FileId(1) for 1069..1073: this is of type `char(6)`
+| error in file FileId(1) for 1074..1076: `char(6)` cannot be compared to `nat`
 | info: operands must both be the same type
-error in file FileId(1) at 1088..1090: mismatched types for `<=`
-| note in file FileId(1) for 1091..1092: this is of type `boolean`
-| note in file FileId(1) for 1083..1087: this is of type `char(6)`
-| error in file FileId(1) for 1088..1090: `char(6)` cannot be compared to `boolean`
+error in file FileId(1) at 1098..1100: mismatched types for `<=`
+| note in file FileId(1) for 1101..1102: this is of type `boolean`
+| note in file FileId(1) for 1093..1097: this is of type `char(6)`
+| error in file FileId(1) for 1098..1100: `char(6)` cannot be compared to `boolean`
 | info: operands must both be the same type
-error in file FileId(1) at 1110..1112: mismatched types for `<=`
-| note in file FileId(1) for 1113..1114: this is of type `real`
-| note in file FileId(1) for 1108..1109: this is of type `string`
-| error in file FileId(1) for 1110..1112: `string` cannot be compared to `real`
+error in file FileId(1) at 1120..1122: mismatched types for `<=`
+| note in file FileId(1) for 1123..1124: this is of type `real`
+| note in file FileId(1) for 1118..1119: this is of type `string`
+| error in file FileId(1) for 1120..1122: `string` cannot be compared to `real`
 | info: operands must both be the same type
-error in file FileId(1) at 1131..1133: mismatched types for `<=`
-| note in file FileId(1) for 1134..1135: this is of type `int`
-| note in file FileId(1) for 1129..1130: this is of type `string`
-| error in file FileId(1) for 1131..1133: `string` cannot be compared to `int`
+error in file FileId(1) at 1141..1143: mismatched types for `<=`
+| note in file FileId(1) for 1144..1145: this is of type `int`
+| note in file FileId(1) for 1139..1140: this is of type `string`
+| error in file FileId(1) for 1141..1143: `string` cannot be compared to `int`
 | info: operands must both be the same type
-error in file FileId(1) at 1152..1154: mismatched types for `<=`
-| note in file FileId(1) for 1155..1156: this is of type `nat`
-| note in file FileId(1) for 1150..1151: this is of type `string`
-| error in file FileId(1) for 1152..1154: `string` cannot be compared to `nat`
+error in file FileId(1) at 1162..1164: mismatched types for `<=`
+| note in file FileId(1) for 1165..1166: this is of type `nat`
+| note in file FileId(1) for 1160..1161: this is of type `string`
+| error in file FileId(1) for 1162..1164: `string` cannot be compared to `nat`
 | info: operands must both be the same type
-error in file FileId(1) at 1173..1175: mismatched types for `<=`
-| note in file FileId(1) for 1176..1177: this is of type `boolean`
-| note in file FileId(1) for 1171..1172: this is of type `string`
-| error in file FileId(1) for 1173..1175: `string` cannot be compared to `boolean`
+error in file FileId(1) at 1183..1185: mismatched types for `<=`
+| note in file FileId(1) for 1186..1187: this is of type `boolean`
+| note in file FileId(1) for 1181..1182: this is of type `string`
+| error in file FileId(1) for 1183..1185: `string` cannot be compared to `boolean`
 | info: operands must both be the same type
-error in file FileId(1) at 1198..1200: mismatched types for `<=`
-| note in file FileId(1) for 1201..1202: this is of type `real`
-| note in file FileId(1) for 1193..1197: this is of type `string(6)`
-| error in file FileId(1) for 1198..1200: `string(6)` cannot be compared to `real`
+error in file FileId(1) at 1208..1210: mismatched types for `<=`
+| note in file FileId(1) for 1211..1212: this is of type `real`
+| note in file FileId(1) for 1203..1207: this is of type `string(6)`
+| error in file FileId(1) for 1208..1210: `string(6)` cannot be compared to `real`
 | info: operands must both be the same type
-error in file FileId(1) at 1222..1224: mismatched types for `<=`
-| note in file FileId(1) for 1225..1226: this is of type `int`
-| note in file FileId(1) for 1217..1221: this is of type `string(6)`
-| error in file FileId(1) for 1222..1224: `string(6)` cannot be compared to `int`
+error in file FileId(1) at 1232..1234: mismatched types for `<=`
+| note in file FileId(1) for 1235..1236: this is of type `int`
+| note in file FileId(1) for 1227..1231: this is of type `string(6)`
+| error in file FileId(1) for 1232..1234: `string(6)` cannot be compared to `int`
 | info: operands must both be the same type
-error in file FileId(1) at 1246..1248: mismatched types for `<=`
-| note in file FileId(1) for 1249..1250: this is of type `nat`
-| note in file FileId(1) for 1241..1245: this is of type `string(6)`
-| error in file FileId(1) for 1246..1248: `string(6)` cannot be compared to `nat`
+error in file FileId(1) at 1256..1258: mismatched types for `<=`
+| note in file FileId(1) for 1259..1260: this is of type `nat`
+| note in file FileId(1) for 1251..1255: this is of type `string(6)`
+| error in file FileId(1) for 1256..1258: `string(6)` cannot be compared to `nat`
 | info: operands must both be the same type
-error in file FileId(1) at 1270..1272: mismatched types for `<=`
-| note in file FileId(1) for 1273..1274: this is of type `boolean`
-| note in file FileId(1) for 1265..1269: this is of type `string(6)`
-| error in file FileId(1) for 1270..1272: `string(6)` cannot be compared to `boolean`
+error in file FileId(1) at 1280..1282: mismatched types for `<=`
+| note in file FileId(1) for 1283..1284: this is of type `boolean`
+| note in file FileId(1) for 1275..1279: this is of type `string(6)`
+| error in file FileId(1) for 1280..1282: `string(6)` cannot be compared to `boolean`
 | info: operands must both be the same type
-error in file FileId(1) at 1318..1320: mismatched types for `<=`
-| note in file FileId(1) for 1321..1324: this is of type `set s2 (of boolean)`
-| note in file FileId(1) for 1314..1317: this is of type `set s1 (of boolean)`
-| error in file FileId(1) for 1318..1320: `set s1 (of boolean)` cannot be compared to `set s2 (of boolean)`
+error in file FileId(1) at 1328..1330: mismatched types for `<=`
+| note in file FileId(1) for 1331..1334: this is of type `set s2 (of boolean)`
+| note in file FileId(1) for 1324..1327: this is of type `set s1 (of boolean)`
+| error in file FileId(1) for 1328..1330: `set s1 (of boolean)` cannot be compared to `set s2 (of boolean)`
 | info: operands must both be the same type
-error in file FileId(1) at 1368..1370: mismatched types for `<=`
-| note in file FileId(1) for 1371..1374: this is of type `set s1 (of boolean)`
-| note in file FileId(1) for 1364..1367: this is of type `set <anonymous> (of boolean)`
-| error in file FileId(1) for 1368..1370: `set <anonymous> (of boolean)` cannot be compared to `set s1 (of boolean)`
+error in file FileId(1) at 1353..1355: mismatched types for `<=`
+| note in file FileId(1) for 1356..1359: this is of type `set s1 (of boolean)`
+| note in file FileId(1) for 1349..1352: this is of type `set s2 (of boolean)`
+| error in file FileId(1) for 1353..1355: `set s2 (of boolean)` cannot be compared to `set s1 (of boolean)`
 | info: operands must both be the same type
-error in file FileId(1) at 1393..1395: mismatched types for `<=`
-| note in file FileId(1) for 1396..1399: this is of type `set <anonymous> (of boolean)`
-| note in file FileId(1) for 1389..1392: this is of type `set s1 (of boolean)`
-| error in file FileId(1) for 1393..1395: `set s1 (of boolean)` cannot be compared to `set <anonymous> (of boolean)`
+error in file FileId(1) at 1378..1380: mismatched types for `<=`
+| note in file FileId(1) for 1381..1384: this is of type `set s1 (of boolean)`
+| note in file FileId(1) for 1374..1377: this is of type `set <anonymous> (of boolean)`
+| error in file FileId(1) for 1378..1380: `set <anonymous> (of boolean)` cannot be compared to `set s1 (of boolean)`
+| info: operands must both be the same type
+error in file FileId(1) at 1403..1405: mismatched types for `<=`
+| note in file FileId(1) for 1406..1409: this is of type `set <anonymous> (of boolean)`
+| note in file FileId(1) for 1399..1402: this is of type `set s1 (of boolean)`
+| error in file FileId(1) for 1403..1405: `set s1 (of boolean)` cannot be compared to `set <anonymous> (of boolean)`
 | info: operands must both be the same type

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_not_equal.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_not_equal.snap
@@ -1,6 +1,6 @@
 ---
 source: compiler/toc_analysis/src/typeck/test.rs
-expression: "\n    % Numerics\n    var r : real\n    var i : int\n    var n : nat\n\n    % Other scalars\n    var b : boolean\n\n    % Sized charseqs\n    var c : char\n    var c_sz : char(6)\n    var s : string\n    var s_sz : string(6)\n\n    % Different sets\n    type s1 : set of boolean\n    type s2 : set of boolean\n    var as1 : s1\n    var bs2 : s2\n    var aas : set of boolean\n\n    % should all produce boolean anyway\n    var _v_res : boolean\n\n    _v_res := r not= b\n    _v_res := r not= c\n    _v_res := r not= c_sz\n    _v_res := r not= s\n    _v_res := r not= s_sz\n\n    _v_res := i not= b\n    _v_res := i not= c\n    _v_res := i not= c_sz\n    _v_res := i not= s\n    _v_res := i not= s_sz\n\n    _v_res := n not= b\n    _v_res := n not= c\n    _v_res := n not= c_sz\n    _v_res := n not= s\n    _v_res := n not= s_sz\n\n    _v_res := b not= r\n    _v_res := b not= i\n    _v_res := b not= n\n    _v_res := b not= c\n    _v_res := b not= c_sz\n    _v_res := b not= s\n    _v_res := b not= s_sz\n\n    _v_res := c not= r\n    _v_res := c not= i\n    _v_res := c not= n\n    _v_res := c not= b\n\n    _v_res := c_sz not= r\n    _v_res := c_sz not= i\n    _v_res := c_sz not= n\n    _v_res := c_sz not= b\n\n    _v_res := s not= r\n    _v_res := s not= i\n    _v_res := s not= n\n    _v_res := s not= b\n\n    _v_res := s_sz not= r\n    _v_res := s_sz not= i\n    _v_res := s_sz not= n\n    _v_res := s_sz not= b\n\n    % Incompatible sets\n    _v_res := as1 not= bs2\n    _v_res := bs1 not= as2\n    _v_res := aas not= as1\n    _v_res := as1 not= aas\n    "
+expression: "\n    % Numerics\n    var r : real\n    var i : int\n    var n : nat\n\n    % Other scalars\n    var b : boolean\n\n    % Sized charseqs\n    var c : char\n    var c_sz : char(6)\n    var s : string\n    var s_sz : string(6)\n\n    % Different sets\n    type s1 : set of boolean\n    type s2 : set of boolean\n    var as1, as2 : s1\n    var bs1, bs2 : s2\n    var aas : set of boolean\n\n    % should all produce boolean anyway\n    var _v_res : boolean\n\n    _v_res := r not= b\n    _v_res := r not= c\n    _v_res := r not= c_sz\n    _v_res := r not= s\n    _v_res := r not= s_sz\n\n    _v_res := i not= b\n    _v_res := i not= c\n    _v_res := i not= c_sz\n    _v_res := i not= s\n    _v_res := i not= s_sz\n\n    _v_res := n not= b\n    _v_res := n not= c\n    _v_res := n not= c_sz\n    _v_res := n not= s\n    _v_res := n not= s_sz\n\n    _v_res := b not= r\n    _v_res := b not= i\n    _v_res := b not= n\n    _v_res := b not= c\n    _v_res := b not= c_sz\n    _v_res := b not= s\n    _v_res := b not= s_sz\n\n    _v_res := c not= r\n    _v_res := c not= i\n    _v_res := c not= n\n    _v_res := c not= b\n\n    _v_res := c_sz not= r\n    _v_res := c_sz not= i\n    _v_res := c_sz not= n\n    _v_res := c_sz not= b\n\n    _v_res := s not= r\n    _v_res := s not= i\n    _v_res := s not= n\n    _v_res := s not= b\n\n    _v_res := s_sz not= r\n    _v_res := s_sz not= i\n    _v_res := s_sz not= n\n    _v_res := s_sz not= b\n\n    % Incompatible sets\n    _v_res := as1 not= bs2\n    _v_res := bs1 not= as2\n    _v_res := aas not= as1\n    _v_res := as1 not= aas\n    "
 ---
 "r"@(FileId(1), 24..25) [ConstVar(Var, No)]: real
 "i"@(FileId(1), 41..42) [ConstVar(Var, No)]: int
@@ -15,216 +15,221 @@ expression: "\n    % Numerics\n    var r : real\n    var i : int\n    var n : na
 "s2"@(FileId(1), 277..291) [Set]: <error>
 "s2"@(FileId(1), 272..274) [Type]: set[DefId(LibraryId(0), LocalDefId(10))] of boolean
 "as1"@(FileId(1), 300..303) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(8))] of boolean
-"bs2"@(FileId(1), 317..320) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(10))] of boolean
-"<anonymous>"@(FileId(1), 340..354) [Set]: <error>
-"aas"@(FileId(1), 334..337) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(14))] of boolean
-"_v_res"@(FileId(1), 404..410) [ConstVar(Var, No)]: boolean
-"bs1"@(FileId(1), 1417..1420) [Undeclared]: <error>
-"as2"@(FileId(1), 1426..1429) [Undeclared]: <error>
+"as2"@(FileId(1), 305..308) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(8))] of boolean
+"bs1"@(FileId(1), 322..325) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(10))] of boolean
+"bs2"@(FileId(1), 327..330) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(10))] of boolean
+"<anonymous>"@(FileId(1), 350..364) [Set]: <error>
+"aas"@(FileId(1), 344..347) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(16))] of boolean
+"_v_res"@(FileId(1), 414..420) [ConstVar(Var, No)]: boolean
 "<root>"@(dummy) [Module(No)]: <error>
 
-error in file FileId(1) at 438..442: mismatched types for `not =`
-| note in file FileId(1) for 443..444: this is of type `boolean`
-| note in file FileId(1) for 436..437: this is of type `real`
-| error in file FileId(1) for 438..442: `real` cannot be compared to `boolean`
+error in file FileId(1) at 448..452: mismatched types for `not =`
+| note in file FileId(1) for 453..454: this is of type `boolean`
+| note in file FileId(1) for 446..447: this is of type `real`
+| error in file FileId(1) for 448..452: `real` cannot be compared to `boolean`
 | info: operands must both be the same type
-error in file FileId(1) at 461..465: mismatched types for `not =`
-| note in file FileId(1) for 466..467: this is of type `char`
-| note in file FileId(1) for 459..460: this is of type `real`
-| error in file FileId(1) for 461..465: `real` cannot be compared to `char`
+error in file FileId(1) at 471..475: mismatched types for `not =`
+| note in file FileId(1) for 476..477: this is of type `char`
+| note in file FileId(1) for 469..470: this is of type `real`
+| error in file FileId(1) for 471..475: `real` cannot be compared to `char`
 | info: operands must both be the same type
-error in file FileId(1) at 484..488: mismatched types for `not =`
-| note in file FileId(1) for 489..493: this is of type `char(6)`
-| note in file FileId(1) for 482..483: this is of type `real`
-| error in file FileId(1) for 484..488: `real` cannot be compared to `char(6)`
+error in file FileId(1) at 494..498: mismatched types for `not =`
+| note in file FileId(1) for 499..503: this is of type `char(6)`
+| note in file FileId(1) for 492..493: this is of type `real`
+| error in file FileId(1) for 494..498: `real` cannot be compared to `char(6)`
 | info: operands must both be the same type
-error in file FileId(1) at 510..514: mismatched types for `not =`
-| note in file FileId(1) for 515..516: this is of type `string`
-| note in file FileId(1) for 508..509: this is of type `real`
-| error in file FileId(1) for 510..514: `real` cannot be compared to `string`
+error in file FileId(1) at 520..524: mismatched types for `not =`
+| note in file FileId(1) for 525..526: this is of type `string`
+| note in file FileId(1) for 518..519: this is of type `real`
+| error in file FileId(1) for 520..524: `real` cannot be compared to `string`
 | info: operands must both be the same type
-error in file FileId(1) at 533..537: mismatched types for `not =`
-| note in file FileId(1) for 538..542: this is of type `string(6)`
-| note in file FileId(1) for 531..532: this is of type `real`
-| error in file FileId(1) for 533..537: `real` cannot be compared to `string(6)`
+error in file FileId(1) at 543..547: mismatched types for `not =`
+| note in file FileId(1) for 548..552: this is of type `string(6)`
+| note in file FileId(1) for 541..542: this is of type `real`
+| error in file FileId(1) for 543..547: `real` cannot be compared to `string(6)`
 | info: operands must both be the same type
-error in file FileId(1) at 560..564: mismatched types for `not =`
-| note in file FileId(1) for 565..566: this is of type `boolean`
-| note in file FileId(1) for 558..559: this is of type `int`
-| error in file FileId(1) for 560..564: `int` cannot be compared to `boolean`
+error in file FileId(1) at 570..574: mismatched types for `not =`
+| note in file FileId(1) for 575..576: this is of type `boolean`
+| note in file FileId(1) for 568..569: this is of type `int`
+| error in file FileId(1) for 570..574: `int` cannot be compared to `boolean`
 | info: operands must both be the same type
-error in file FileId(1) at 583..587: mismatched types for `not =`
-| note in file FileId(1) for 588..589: this is of type `char`
-| note in file FileId(1) for 581..582: this is of type `int`
-| error in file FileId(1) for 583..587: `int` cannot be compared to `char`
+error in file FileId(1) at 593..597: mismatched types for `not =`
+| note in file FileId(1) for 598..599: this is of type `char`
+| note in file FileId(1) for 591..592: this is of type `int`
+| error in file FileId(1) for 593..597: `int` cannot be compared to `char`
 | info: operands must both be the same type
-error in file FileId(1) at 606..610: mismatched types for `not =`
-| note in file FileId(1) for 611..615: this is of type `char(6)`
-| note in file FileId(1) for 604..605: this is of type `int`
-| error in file FileId(1) for 606..610: `int` cannot be compared to `char(6)`
+error in file FileId(1) at 616..620: mismatched types for `not =`
+| note in file FileId(1) for 621..625: this is of type `char(6)`
+| note in file FileId(1) for 614..615: this is of type `int`
+| error in file FileId(1) for 616..620: `int` cannot be compared to `char(6)`
 | info: operands must both be the same type
-error in file FileId(1) at 632..636: mismatched types for `not =`
-| note in file FileId(1) for 637..638: this is of type `string`
-| note in file FileId(1) for 630..631: this is of type `int`
-| error in file FileId(1) for 632..636: `int` cannot be compared to `string`
+error in file FileId(1) at 642..646: mismatched types for `not =`
+| note in file FileId(1) for 647..648: this is of type `string`
+| note in file FileId(1) for 640..641: this is of type `int`
+| error in file FileId(1) for 642..646: `int` cannot be compared to `string`
 | info: operands must both be the same type
-error in file FileId(1) at 655..659: mismatched types for `not =`
-| note in file FileId(1) for 660..664: this is of type `string(6)`
-| note in file FileId(1) for 653..654: this is of type `int`
-| error in file FileId(1) for 655..659: `int` cannot be compared to `string(6)`
+error in file FileId(1) at 665..669: mismatched types for `not =`
+| note in file FileId(1) for 670..674: this is of type `string(6)`
+| note in file FileId(1) for 663..664: this is of type `int`
+| error in file FileId(1) for 665..669: `int` cannot be compared to `string(6)`
 | info: operands must both be the same type
-error in file FileId(1) at 682..686: mismatched types for `not =`
-| note in file FileId(1) for 687..688: this is of type `boolean`
-| note in file FileId(1) for 680..681: this is of type `nat`
-| error in file FileId(1) for 682..686: `nat` cannot be compared to `boolean`
+error in file FileId(1) at 692..696: mismatched types for `not =`
+| note in file FileId(1) for 697..698: this is of type `boolean`
+| note in file FileId(1) for 690..691: this is of type `nat`
+| error in file FileId(1) for 692..696: `nat` cannot be compared to `boolean`
 | info: operands must both be the same type
-error in file FileId(1) at 705..709: mismatched types for `not =`
-| note in file FileId(1) for 710..711: this is of type `char`
-| note in file FileId(1) for 703..704: this is of type `nat`
-| error in file FileId(1) for 705..709: `nat` cannot be compared to `char`
+error in file FileId(1) at 715..719: mismatched types for `not =`
+| note in file FileId(1) for 720..721: this is of type `char`
+| note in file FileId(1) for 713..714: this is of type `nat`
+| error in file FileId(1) for 715..719: `nat` cannot be compared to `char`
 | info: operands must both be the same type
-error in file FileId(1) at 728..732: mismatched types for `not =`
-| note in file FileId(1) for 733..737: this is of type `char(6)`
-| note in file FileId(1) for 726..727: this is of type `nat`
-| error in file FileId(1) for 728..732: `nat` cannot be compared to `char(6)`
+error in file FileId(1) at 738..742: mismatched types for `not =`
+| note in file FileId(1) for 743..747: this is of type `char(6)`
+| note in file FileId(1) for 736..737: this is of type `nat`
+| error in file FileId(1) for 738..742: `nat` cannot be compared to `char(6)`
 | info: operands must both be the same type
-error in file FileId(1) at 754..758: mismatched types for `not =`
-| note in file FileId(1) for 759..760: this is of type `string`
-| note in file FileId(1) for 752..753: this is of type `nat`
-| error in file FileId(1) for 754..758: `nat` cannot be compared to `string`
+error in file FileId(1) at 764..768: mismatched types for `not =`
+| note in file FileId(1) for 769..770: this is of type `string`
+| note in file FileId(1) for 762..763: this is of type `nat`
+| error in file FileId(1) for 764..768: `nat` cannot be compared to `string`
 | info: operands must both be the same type
-error in file FileId(1) at 777..781: mismatched types for `not =`
-| note in file FileId(1) for 782..786: this is of type `string(6)`
-| note in file FileId(1) for 775..776: this is of type `nat`
-| error in file FileId(1) for 777..781: `nat` cannot be compared to `string(6)`
+error in file FileId(1) at 787..791: mismatched types for `not =`
+| note in file FileId(1) for 792..796: this is of type `string(6)`
+| note in file FileId(1) for 785..786: this is of type `nat`
+| error in file FileId(1) for 787..791: `nat` cannot be compared to `string(6)`
 | info: operands must both be the same type
-error in file FileId(1) at 804..808: mismatched types for `not =`
-| note in file FileId(1) for 809..810: this is of type `real`
-| note in file FileId(1) for 802..803: this is of type `boolean`
-| error in file FileId(1) for 804..808: `boolean` cannot be compared to `real`
+error in file FileId(1) at 814..818: mismatched types for `not =`
+| note in file FileId(1) for 819..820: this is of type `real`
+| note in file FileId(1) for 812..813: this is of type `boolean`
+| error in file FileId(1) for 814..818: `boolean` cannot be compared to `real`
 | info: operands must both be the same type
-error in file FileId(1) at 827..831: mismatched types for `not =`
-| note in file FileId(1) for 832..833: this is of type `int`
-| note in file FileId(1) for 825..826: this is of type `boolean`
-| error in file FileId(1) for 827..831: `boolean` cannot be compared to `int`
+error in file FileId(1) at 837..841: mismatched types for `not =`
+| note in file FileId(1) for 842..843: this is of type `int`
+| note in file FileId(1) for 835..836: this is of type `boolean`
+| error in file FileId(1) for 837..841: `boolean` cannot be compared to `int`
 | info: operands must both be the same type
-error in file FileId(1) at 850..854: mismatched types for `not =`
-| note in file FileId(1) for 855..856: this is of type `nat`
-| note in file FileId(1) for 848..849: this is of type `boolean`
-| error in file FileId(1) for 850..854: `boolean` cannot be compared to `nat`
+error in file FileId(1) at 860..864: mismatched types for `not =`
+| note in file FileId(1) for 865..866: this is of type `nat`
+| note in file FileId(1) for 858..859: this is of type `boolean`
+| error in file FileId(1) for 860..864: `boolean` cannot be compared to `nat`
 | info: operands must both be the same type
-error in file FileId(1) at 873..877: mismatched types for `not =`
-| note in file FileId(1) for 878..879: this is of type `char`
-| note in file FileId(1) for 871..872: this is of type `boolean`
-| error in file FileId(1) for 873..877: `boolean` cannot be compared to `char`
+error in file FileId(1) at 883..887: mismatched types for `not =`
+| note in file FileId(1) for 888..889: this is of type `char`
+| note in file FileId(1) for 881..882: this is of type `boolean`
+| error in file FileId(1) for 883..887: `boolean` cannot be compared to `char`
 | info: operands must both be the same type
-error in file FileId(1) at 896..900: mismatched types for `not =`
-| note in file FileId(1) for 901..905: this is of type `char(6)`
-| note in file FileId(1) for 894..895: this is of type `boolean`
-| error in file FileId(1) for 896..900: `boolean` cannot be compared to `char(6)`
+error in file FileId(1) at 906..910: mismatched types for `not =`
+| note in file FileId(1) for 911..915: this is of type `char(6)`
+| note in file FileId(1) for 904..905: this is of type `boolean`
+| error in file FileId(1) for 906..910: `boolean` cannot be compared to `char(6)`
 | info: operands must both be the same type
-error in file FileId(1) at 922..926: mismatched types for `not =`
-| note in file FileId(1) for 927..928: this is of type `string`
-| note in file FileId(1) for 920..921: this is of type `boolean`
-| error in file FileId(1) for 922..926: `boolean` cannot be compared to `string`
+error in file FileId(1) at 932..936: mismatched types for `not =`
+| note in file FileId(1) for 937..938: this is of type `string`
+| note in file FileId(1) for 930..931: this is of type `boolean`
+| error in file FileId(1) for 932..936: `boolean` cannot be compared to `string`
 | info: operands must both be the same type
-error in file FileId(1) at 945..949: mismatched types for `not =`
-| note in file FileId(1) for 950..954: this is of type `string(6)`
-| note in file FileId(1) for 943..944: this is of type `boolean`
-| error in file FileId(1) for 945..949: `boolean` cannot be compared to `string(6)`
+error in file FileId(1) at 955..959: mismatched types for `not =`
+| note in file FileId(1) for 960..964: this is of type `string(6)`
+| note in file FileId(1) for 953..954: this is of type `boolean`
+| error in file FileId(1) for 955..959: `boolean` cannot be compared to `string(6)`
 | info: operands must both be the same type
-error in file FileId(1) at 972..976: mismatched types for `not =`
-| note in file FileId(1) for 977..978: this is of type `real`
-| note in file FileId(1) for 970..971: this is of type `char`
-| error in file FileId(1) for 972..976: `char` cannot be compared to `real`
+error in file FileId(1) at 982..986: mismatched types for `not =`
+| note in file FileId(1) for 987..988: this is of type `real`
+| note in file FileId(1) for 980..981: this is of type `char`
+| error in file FileId(1) for 982..986: `char` cannot be compared to `real`
 | info: operands must both be the same type
-error in file FileId(1) at 995..999: mismatched types for `not =`
-| note in file FileId(1) for 1000..1001: this is of type `int`
-| note in file FileId(1) for 993..994: this is of type `char`
-| error in file FileId(1) for 995..999: `char` cannot be compared to `int`
+error in file FileId(1) at 1005..1009: mismatched types for `not =`
+| note in file FileId(1) for 1010..1011: this is of type `int`
+| note in file FileId(1) for 1003..1004: this is of type `char`
+| error in file FileId(1) for 1005..1009: `char` cannot be compared to `int`
 | info: operands must both be the same type
-error in file FileId(1) at 1018..1022: mismatched types for `not =`
-| note in file FileId(1) for 1023..1024: this is of type `nat`
-| note in file FileId(1) for 1016..1017: this is of type `char`
-| error in file FileId(1) for 1018..1022: `char` cannot be compared to `nat`
+error in file FileId(1) at 1028..1032: mismatched types for `not =`
+| note in file FileId(1) for 1033..1034: this is of type `nat`
+| note in file FileId(1) for 1026..1027: this is of type `char`
+| error in file FileId(1) for 1028..1032: `char` cannot be compared to `nat`
 | info: operands must both be the same type
-error in file FileId(1) at 1041..1045: mismatched types for `not =`
-| note in file FileId(1) for 1046..1047: this is of type `boolean`
-| note in file FileId(1) for 1039..1040: this is of type `char`
-| error in file FileId(1) for 1041..1045: `char` cannot be compared to `boolean`
+error in file FileId(1) at 1051..1055: mismatched types for `not =`
+| note in file FileId(1) for 1056..1057: this is of type `boolean`
+| note in file FileId(1) for 1049..1050: this is of type `char`
+| error in file FileId(1) for 1051..1055: `char` cannot be compared to `boolean`
 | info: operands must both be the same type
-error in file FileId(1) at 1068..1072: mismatched types for `not =`
-| note in file FileId(1) for 1073..1074: this is of type `real`
-| note in file FileId(1) for 1063..1067: this is of type `char(6)`
-| error in file FileId(1) for 1068..1072: `char(6)` cannot be compared to `real`
+error in file FileId(1) at 1078..1082: mismatched types for `not =`
+| note in file FileId(1) for 1083..1084: this is of type `real`
+| note in file FileId(1) for 1073..1077: this is of type `char(6)`
+| error in file FileId(1) for 1078..1082: `char(6)` cannot be compared to `real`
 | info: operands must both be the same type
-error in file FileId(1) at 1094..1098: mismatched types for `not =`
-| note in file FileId(1) for 1099..1100: this is of type `int`
-| note in file FileId(1) for 1089..1093: this is of type `char(6)`
-| error in file FileId(1) for 1094..1098: `char(6)` cannot be compared to `int`
+error in file FileId(1) at 1104..1108: mismatched types for `not =`
+| note in file FileId(1) for 1109..1110: this is of type `int`
+| note in file FileId(1) for 1099..1103: this is of type `char(6)`
+| error in file FileId(1) for 1104..1108: `char(6)` cannot be compared to `int`
 | info: operands must both be the same type
-error in file FileId(1) at 1120..1124: mismatched types for `not =`
-| note in file FileId(1) for 1125..1126: this is of type `nat`
-| note in file FileId(1) for 1115..1119: this is of type `char(6)`
-| error in file FileId(1) for 1120..1124: `char(6)` cannot be compared to `nat`
+error in file FileId(1) at 1130..1134: mismatched types for `not =`
+| note in file FileId(1) for 1135..1136: this is of type `nat`
+| note in file FileId(1) for 1125..1129: this is of type `char(6)`
+| error in file FileId(1) for 1130..1134: `char(6)` cannot be compared to `nat`
 | info: operands must both be the same type
-error in file FileId(1) at 1146..1150: mismatched types for `not =`
-| note in file FileId(1) for 1151..1152: this is of type `boolean`
-| note in file FileId(1) for 1141..1145: this is of type `char(6)`
-| error in file FileId(1) for 1146..1150: `char(6)` cannot be compared to `boolean`
+error in file FileId(1) at 1156..1160: mismatched types for `not =`
+| note in file FileId(1) for 1161..1162: this is of type `boolean`
+| note in file FileId(1) for 1151..1155: this is of type `char(6)`
+| error in file FileId(1) for 1156..1160: `char(6)` cannot be compared to `boolean`
 | info: operands must both be the same type
-error in file FileId(1) at 1170..1174: mismatched types for `not =`
-| note in file FileId(1) for 1175..1176: this is of type `real`
-| note in file FileId(1) for 1168..1169: this is of type `string`
-| error in file FileId(1) for 1170..1174: `string` cannot be compared to `real`
+error in file FileId(1) at 1180..1184: mismatched types for `not =`
+| note in file FileId(1) for 1185..1186: this is of type `real`
+| note in file FileId(1) for 1178..1179: this is of type `string`
+| error in file FileId(1) for 1180..1184: `string` cannot be compared to `real`
 | info: operands must both be the same type
-error in file FileId(1) at 1193..1197: mismatched types for `not =`
-| note in file FileId(1) for 1198..1199: this is of type `int`
-| note in file FileId(1) for 1191..1192: this is of type `string`
-| error in file FileId(1) for 1193..1197: `string` cannot be compared to `int`
+error in file FileId(1) at 1203..1207: mismatched types for `not =`
+| note in file FileId(1) for 1208..1209: this is of type `int`
+| note in file FileId(1) for 1201..1202: this is of type `string`
+| error in file FileId(1) for 1203..1207: `string` cannot be compared to `int`
 | info: operands must both be the same type
-error in file FileId(1) at 1216..1220: mismatched types for `not =`
-| note in file FileId(1) for 1221..1222: this is of type `nat`
-| note in file FileId(1) for 1214..1215: this is of type `string`
-| error in file FileId(1) for 1216..1220: `string` cannot be compared to `nat`
+error in file FileId(1) at 1226..1230: mismatched types for `not =`
+| note in file FileId(1) for 1231..1232: this is of type `nat`
+| note in file FileId(1) for 1224..1225: this is of type `string`
+| error in file FileId(1) for 1226..1230: `string` cannot be compared to `nat`
 | info: operands must both be the same type
-error in file FileId(1) at 1239..1243: mismatched types for `not =`
-| note in file FileId(1) for 1244..1245: this is of type `boolean`
-| note in file FileId(1) for 1237..1238: this is of type `string`
-| error in file FileId(1) for 1239..1243: `string` cannot be compared to `boolean`
+error in file FileId(1) at 1249..1253: mismatched types for `not =`
+| note in file FileId(1) for 1254..1255: this is of type `boolean`
+| note in file FileId(1) for 1247..1248: this is of type `string`
+| error in file FileId(1) for 1249..1253: `string` cannot be compared to `boolean`
 | info: operands must both be the same type
-error in file FileId(1) at 1266..1270: mismatched types for `not =`
-| note in file FileId(1) for 1271..1272: this is of type `real`
-| note in file FileId(1) for 1261..1265: this is of type `string(6)`
-| error in file FileId(1) for 1266..1270: `string(6)` cannot be compared to `real`
+error in file FileId(1) at 1276..1280: mismatched types for `not =`
+| note in file FileId(1) for 1281..1282: this is of type `real`
+| note in file FileId(1) for 1271..1275: this is of type `string(6)`
+| error in file FileId(1) for 1276..1280: `string(6)` cannot be compared to `real`
 | info: operands must both be the same type
-error in file FileId(1) at 1292..1296: mismatched types for `not =`
-| note in file FileId(1) for 1297..1298: this is of type `int`
-| note in file FileId(1) for 1287..1291: this is of type `string(6)`
-| error in file FileId(1) for 1292..1296: `string(6)` cannot be compared to `int`
+error in file FileId(1) at 1302..1306: mismatched types for `not =`
+| note in file FileId(1) for 1307..1308: this is of type `int`
+| note in file FileId(1) for 1297..1301: this is of type `string(6)`
+| error in file FileId(1) for 1302..1306: `string(6)` cannot be compared to `int`
 | info: operands must both be the same type
-error in file FileId(1) at 1318..1322: mismatched types for `not =`
-| note in file FileId(1) for 1323..1324: this is of type `nat`
-| note in file FileId(1) for 1313..1317: this is of type `string(6)`
-| error in file FileId(1) for 1318..1322: `string(6)` cannot be compared to `nat`
+error in file FileId(1) at 1328..1332: mismatched types for `not =`
+| note in file FileId(1) for 1333..1334: this is of type `nat`
+| note in file FileId(1) for 1323..1327: this is of type `string(6)`
+| error in file FileId(1) for 1328..1332: `string(6)` cannot be compared to `nat`
 | info: operands must both be the same type
-error in file FileId(1) at 1344..1348: mismatched types for `not =`
-| note in file FileId(1) for 1349..1350: this is of type `boolean`
-| note in file FileId(1) for 1339..1343: this is of type `string(6)`
-| error in file FileId(1) for 1344..1348: `string(6)` cannot be compared to `boolean`
+error in file FileId(1) at 1354..1358: mismatched types for `not =`
+| note in file FileId(1) for 1359..1360: this is of type `boolean`
+| note in file FileId(1) for 1349..1353: this is of type `string(6)`
+| error in file FileId(1) for 1354..1358: `string(6)` cannot be compared to `boolean`
 | info: operands must both be the same type
-error in file FileId(1) at 1394..1398: mismatched types for `not =`
-| note in file FileId(1) for 1399..1402: this is of type `set s2 (of boolean)`
-| note in file FileId(1) for 1390..1393: this is of type `set s1 (of boolean)`
-| error in file FileId(1) for 1394..1398: `set s1 (of boolean)` cannot be compared to `set s2 (of boolean)`
+error in file FileId(1) at 1404..1408: mismatched types for `not =`
+| note in file FileId(1) for 1409..1412: this is of type `set s2 (of boolean)`
+| note in file FileId(1) for 1400..1403: this is of type `set s1 (of boolean)`
+| error in file FileId(1) for 1404..1408: `set s1 (of boolean)` cannot be compared to `set s2 (of boolean)`
 | info: operands must both be the same type
-error in file FileId(1) at 1448..1452: mismatched types for `not =`
-| note in file FileId(1) for 1453..1456: this is of type `set s1 (of boolean)`
-| note in file FileId(1) for 1444..1447: this is of type `set <anonymous> (of boolean)`
-| error in file FileId(1) for 1448..1452: `set <anonymous> (of boolean)` cannot be compared to `set s1 (of boolean)`
+error in file FileId(1) at 1431..1435: mismatched types for `not =`
+| note in file FileId(1) for 1436..1439: this is of type `set s1 (of boolean)`
+| note in file FileId(1) for 1427..1430: this is of type `set s2 (of boolean)`
+| error in file FileId(1) for 1431..1435: `set s2 (of boolean)` cannot be compared to `set s1 (of boolean)`
 | info: operands must both be the same type
-error in file FileId(1) at 1475..1479: mismatched types for `not =`
-| note in file FileId(1) for 1480..1483: this is of type `set <anonymous> (of boolean)`
-| note in file FileId(1) for 1471..1474: this is of type `set s1 (of boolean)`
-| error in file FileId(1) for 1475..1479: `set s1 (of boolean)` cannot be compared to `set <anonymous> (of boolean)`
+error in file FileId(1) at 1458..1462: mismatched types for `not =`
+| note in file FileId(1) for 1463..1466: this is of type `set s1 (of boolean)`
+| note in file FileId(1) for 1454..1457: this is of type `set <anonymous> (of boolean)`
+| error in file FileId(1) for 1458..1462: `set <anonymous> (of boolean)` cannot be compared to `set s1 (of boolean)`
+| info: operands must both be the same type
+error in file FileId(1) at 1485..1489: mismatched types for `not =`
+| note in file FileId(1) for 1490..1493: this is of type `set <anonymous> (of boolean)`
+| note in file FileId(1) for 1481..1484: this is of type `set s1 (of boolean)`
+| error in file FileId(1) for 1485..1489: `set s1 (of boolean)` cannot be compared to `set <anonymous> (of boolean)`
 | info: operands must both be the same type

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__resolve_defs_on_undecl_field_lookup.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__resolve_defs_on_undecl_field_lookup.snap
@@ -1,0 +1,11 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+expression: "module base\n    export ~. tail\nend base\n\nmodule target\n    import tail\n    tail.truce\nend target\n"
+---
+"base"@(FileId(1), 7..11) [Module(No)]: <error>
+"target"@(FileId(1), 48..54) [Module(No)]: <error>
+"tail"@(FileId(1), 66..70) [Import]: <error>
+"<root>"@(dummy) [Module(No)]: <error>
+
+error in file FileId(1) at 80..85: no field named `truce` in expression
+| error in file FileId(1) for 80..85: no field named `truce` in here

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__resolve_defs_on_undecl_value_produced.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__resolve_defs_on_undecl_value_produced.snap
@@ -1,0 +1,9 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+expression: "module _\n    import undecl\n    begin\n        bind a to undecl\n    end\nend _\n"
+---
+"_"@(FileId(1), 7..8) [Module(No)]: <error>
+"undecl"@(FileId(1), 20..26) [Import]: <error>
+"a"@(FileId(1), 50..51) [Binding(Const, No)]: <error>
+"<root>"@(dummy) [Module(No)]: <error>
+

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_cons_call_all_err_extra_arg_end_range.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_cons_call_all_err_extra_arg_end_range.snap
@@ -4,7 +4,6 @@ expression: "type s : set of boolean\nvar _ := s(*, all, b .. * - b)\n"
 ---
 "s"@(FileId(1), 9..23) [Set]: <error>
 "s"@(FileId(1), 5..6) [Type]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
-"b"@(FileId(1), 43..44) [Undeclared]: <error>
 "_"@(FileId(1), 28..29) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
 "<root>"@(dummy) [Module(No)]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_on_undecl.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_on_undecl.snap
@@ -2,6 +2,5 @@
 source: compiler/toc_analysis/src/typeck/test.rs
 expression: "% pass through, since we can't say anything about this\nno_compile"
 ---
-"no_compile"@(FileId(1), 55..65) [Undeclared]: <error>
 "<root>"@(dummy) [Module(No)]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_type_alias_from_unresolved_def.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_type_alias_from_unresolved_def.snap
@@ -1,0 +1,9 @@
+---
+source: compiler/toc_analysis/src/typeck/test.rs
+expression: "module _\n    import tail\n    type _t : tail\nend _\n"
+---
+"_"@(FileId(1), 7..8) [Module(No)]: <error>
+"tail"@(FileId(1), 20..24) [Import]: <error>
+"_t"@(FileId(1), 34..36) [Type]: alias[DefId(LibraryId(0), LocalDefId(2))] of <error>
+"<root>"@(dummy) [Module(No)]: <error>
+

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_undecl_def_in_lvalue.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_undecl_def_in_lvalue.snap
@@ -2,6 +2,5 @@
 source: compiler/toc_analysis/src/typeck/test.rs
 expression: "undecl := 1"
 ---
-"undecl"@(FileId(1), 0..6) [Undeclared]: <error>
 "<root>"@(dummy) [Module(No)]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_undecl_def_in_rvalue.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_undecl_def_in_rvalue.snap
@@ -2,7 +2,6 @@
 source: compiler/toc_analysis/src/typeck/test.rs
 expression: "var lvalue := undecl"
 ---
-"undecl"@(FileId(1), 14..20) [Undeclared]: <error>
 "lvalue"@(FileId(1), 4..10) [ConstVar(Var, No)]: <error>
 "<root>"@(dummy) [Module(No)]: <error>
 

--- a/compiler/toc_analysis/src/typeck/test.rs
+++ b/compiler/toc_analysis/src/typeck/test.rs
@@ -603,8 +603,8 @@ test_for_each_op! { comparison_op_wrong_types,
     % Different sets
     type s1 : set of boolean
     type s2 : set of boolean
-    var as1 : s1
-    var bs2 : s2
+    var as1, as2 : s1
+    var bs1, bs2 : s2
     var aas : set of boolean
 
     % should all produce boolean anyway
@@ -676,17 +676,19 @@ test_for_each_op! { comparison_op_wrong_types_enums,
     % Different enums
     type e1 : enum(v)
     type e2 : enum(v)
-    var ae1 : e1
-    var be2 : e2
-    var aas : enum(v)
+    var ae : e1
+    var be : e2
+    var aA : enum(v)
+    var bA : enum(v)
 
     % should all produce boolean anyway
     var _v_res : boolean
 
-    _v_res := ae1 {0} be2
-    _v_res := be1 {0} ae2
-    _v_res := aes {0} ae1
-    _v_res := ae1 {0} aes
+    _v_res := ae {0} be
+    _v_res := be {0} ae
+    _v_res := aA {0} ae
+    _v_res := ae {0} aA
+    _v_res := aA {0} bA
     "#
 }
 

--- a/compiler/toc_analysis/src/typeck/test.rs
+++ b/compiler/toc_analysis/src/typeck/test.rs
@@ -2185,6 +2185,12 @@ test_named_group! { typeck_type_alias,
         type e : enum(v)
         var a : e.v
         ",
+        from_unresolved_def => "
+        module _
+            import tail
+            type _t : tail
+        end _
+        ",
     ]
 }
 
@@ -3171,6 +3177,24 @@ test_named_group! { resolve_defs,
 
         put n.o
         var c : n.p
+        ",
+        on_undecl_field_lookup => "
+        module base
+            export ~. tail
+        end base
+
+        module target
+            import tail
+            tail.truce
+        end target
+        ",
+        on_undecl_value_produced => "
+        module _
+            import undecl
+            begin
+                bind a to undecl
+            end
+        end _
         ",
     ]
 }

--- a/compiler/toc_hir/src/builder.rs
+++ b/compiler/toc_hir/src/builder.rs
@@ -79,15 +79,20 @@ impl LibraryBuilder {
         &mut self.defs[def_id.into()]
     }
 
-    pub fn finish(
-        self,
-        root_items: Vec<(FileId, item::ItemId)>,
-        resolve_map: symbol::ResolutionMap,
-    ) -> library::Library {
+    pub fn freeze_root_items(self, root_items: Vec<(FileId, item::ItemId)>) -> Self {
+        Self {
+            library: library::Library {
+                // Convert from vec of tuples to an index map
+                root_items: root_items.into_iter().collect(),
+                ..self.library
+            },
+        }
+    }
+
+    pub fn finish(self, resolve_map: symbol::ResolutionMap) -> library::Library {
         let Self { library } = self;
 
         library::Library {
-            root_items: root_items.into_iter().collect(),
             resolve_map,
             ..library
         }

--- a/compiler/toc_hir/src/builder.rs
+++ b/compiler/toc_hir/src/builder.rs
@@ -42,11 +42,13 @@ impl LibraryBuilder {
         name: Symbol,
         span: SpanId,
         kind: Option<symbol::SymbolKind>,
+        pervasive: symbol::IsPervasive,
     ) -> symbol::LocalDefId {
         let def = symbol::DefInfo {
             name,
             def_at: span,
             kind,
+            pervasive,
         };
         let index = self.defs.alloc(def);
         symbol::LocalDefId(index)

--- a/compiler/toc_hir/src/builder.rs
+++ b/compiler/toc_hir/src/builder.rs
@@ -31,7 +31,7 @@ impl LibraryBuilder {
     /// ## Parameters
     /// - `name`: The name of the symbol to define
     /// - `span`: The text span of the definition
-    /// - `kind`: The kind of symbol to define
+    /// - `kind`: The kind of symbol to define, or None if it's undeclared
     ///
     /// ## Returns
     /// The [`LocalDefId`] associated with the definition
@@ -42,13 +42,11 @@ impl LibraryBuilder {
         name: Symbol,
         span: SpanId,
         kind: Option<symbol::SymbolKind>,
-        declare_kind: symbol::DeclareKind,
     ) -> symbol::LocalDefId {
         let def = symbol::DefInfo {
             name,
             def_at: span,
             kind,
-            declare_kind,
         };
         let index = self.defs.alloc(def);
         symbol::LocalDefId(index)
@@ -79,11 +77,16 @@ impl LibraryBuilder {
         &mut self.defs[def_id.into()]
     }
 
-    pub fn finish(self, root_items: Vec<(FileId, item::ItemId)>) -> library::Library {
+    pub fn finish(
+        self,
+        root_items: Vec<(FileId, item::ItemId)>,
+        resolve_map: symbol::ResolutionMap,
+    ) -> library::Library {
         let Self { library } = self;
 
         library::Library {
             root_items: root_items.into_iter().collect(),
+            resolve_map,
             ..library
         }
     }
@@ -99,6 +102,7 @@ impl Default for LibraryBuilder {
                 bodies: Default::default(),
                 type_map: Default::default(),
                 span_map: Default::default(),
+                resolve_map: Default::default(),
             },
         }
     }

--- a/compiler/toc_hir/src/expr.rs
+++ b/compiler/toc_hir/src/expr.rs
@@ -167,9 +167,9 @@ pub enum UnaryOp {
 #[derive(Debug, PartialEq, Eq)]
 pub enum Name {
     /// Normal identifier reference
-    Name(symbol::LocalDefId),
+    Name(Spanned<symbol::Symbol>),
     /// Reference to `self`
-    // TODO: Link a use-id to the appropriate class DefId
+    // FIXME: Resolve to the appropriate class DefId
     Self_,
 }
 

--- a/compiler/toc_hir/src/ids.rs
+++ b/compiler/toc_hir/src/ids.rs
@@ -31,6 +31,16 @@ impl LocalDefId {
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub struct DefId(pub LibraryId, pub LocalDefId);
 
+impl DefId {
+    pub fn library(self) -> LibraryId {
+        self.0
+    }
+
+    pub fn local(self) -> LocalDefId {
+        self.1
+    }
+}
+
 impl fmt::Debug for DefId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let Self(lib_id, local_def) = self;

--- a/compiler/toc_hir/src/ids.rs
+++ b/compiler/toc_hir/src/ids.rs
@@ -117,6 +117,14 @@ impl BodyStmt {
     pub fn with_stmt(self, stmt: StmtId) -> Self {
         BodyStmt(self.0, stmt)
     }
+
+    pub fn body(self) -> BodyId {
+        self.0
+    }
+
+    pub fn stmt(self) -> StmtId {
+        self.1
+    }
 }
 
 /// Uniquely identifies an expression within a library
@@ -127,17 +135,25 @@ impl BodyExpr {
     pub fn with_expr(self, expr: ExprId) -> Self {
         BodyExpr(self.0, expr)
     }
+
+    pub fn body(self) -> BodyId {
+        self.0
+    }
+
+    pub fn expr(self) -> ExprId {
+        self.1
+    }
 }
 
 impl ExprId {
-    pub fn in_body(self, body: BodyId) -> BodyExpr {
-        BodyExpr(body, self)
+    pub fn in_body(self, body_id: BodyId) -> BodyExpr {
+        BodyExpr(body_id, self)
     }
 }
 
 impl StmtId {
-    pub fn in_body(self, body: body::BodyId) -> BodyStmt {
-        BodyStmt(body, self)
+    pub fn in_body(self, body_id: body::BodyId) -> BodyStmt {
+        BodyStmt(body_id, self)
     }
 }
 

--- a/compiler/toc_hir/src/item.rs
+++ b/compiler/toc_hir/src/item.rs
@@ -205,6 +205,8 @@ pub struct Module {
     pub def_id: symbol::LocalDefId,
     pub declares: Vec<ItemId>,
     pub imports: Vec<ItemId>,
+    /// What this module exports.
+    /// There are no [`ExportItem`]s which share the same [`Symbol`].
     pub exports: Vec<ExportItem>,
     pub body: body::BodyId,
 }

--- a/compiler/toc_hir/src/library.rs
+++ b/compiler/toc_hir/src/library.rs
@@ -99,12 +99,20 @@ impl Library {
         self.type_map.lookup_type(type_id)
     }
 
-    pub fn lookup_resolve(&self, binding: Spanned<symbol::Symbol>) -> symbol::Resolve {
+    pub fn binding_resolve(&self, binding: Spanned<symbol::Symbol>) -> symbol::Resolve {
         self.resolve_map
-            .resolves
+            .binding_resolves
             .get(&binding)
             .copied()
             .unwrap_or(symbol::Resolve::Err)
+    }
+
+    pub fn def_resolve(&self, local_def: symbol::LocalDefId) -> symbol::DefResolve {
+        self.resolve_map
+            .def_resolves
+            .get(local_def)
+            .copied()
+            .unwrap_or(symbol::DefResolve::None)
     }
 
     pub fn local_defs(&self) -> impl Iterator<Item = symbol::LocalDefId> + '_ {

--- a/compiler/toc_hir/src/library.rs
+++ b/compiler/toc_hir/src/library.rs
@@ -120,7 +120,7 @@ impl Library {
             .def_resolves
             .get(local_def)
             .copied()
-            .unwrap_or(symbol::DefResolve::None)
+            .unwrap_or(symbol::DefResolve::Canonical)
     }
 
     pub fn local_defs(&self) -> impl Iterator<Item = symbol::LocalDefId> + '_ {

--- a/compiler/toc_hir/src/library.rs
+++ b/compiler/toc_hir/src/library.rs
@@ -99,8 +99,12 @@ impl Library {
         self.type_map.lookup_type(type_id)
     }
 
-    pub fn lookup_resolve(&self, binding: Spanned<symbol::Symbol>) -> Option<symbol::Resolve> {
-        self.resolve_map.resolves.get(&binding).copied()
+    pub fn lookup_resolve(&self, binding: Spanned<symbol::Symbol>) -> symbol::Resolve {
+        self.resolve_map
+            .resolves
+            .get(&binding)
+            .copied()
+            .unwrap_or(symbol::Resolve::Err)
     }
 
     pub fn local_defs(&self) -> impl Iterator<Item = symbol::LocalDefId> + '_ {

--- a/compiler/toc_hir/src/library.rs
+++ b/compiler/toc_hir/src/library.rs
@@ -4,9 +4,13 @@ use std::sync::Arc;
 
 use indexmap::IndexMap;
 use la_arena::Arena;
-use toc_span::{FileId, HasSpanTable, SpanTable};
+use toc_span::{FileId, HasSpanTable, SpanTable, Spanned};
 
-use crate::{body, item, symbol, ty};
+use crate::{
+    body, item,
+    symbol::{self, ResolutionMap},
+    ty,
+};
 
 pub use crate::ids::LibraryId;
 
@@ -60,6 +64,7 @@ pub struct Library {
     pub(crate) items: Arena<item::Item>,
     pub(crate) defs: Arena<symbol::DefInfo>,
     pub(crate) bodies: Arena<body::Body>,
+    pub(crate) resolve_map: ResolutionMap,
 }
 
 impl std::fmt::Debug for Library {
@@ -92,6 +97,10 @@ impl Library {
 
     pub fn lookup_type(&self, type_id: ty::TypeId) -> &ty::Type {
         self.type_map.lookup_type(type_id)
+    }
+
+    pub fn lookup_resolve(&self, binding: Spanned<symbol::Symbol>) -> Option<symbol::Resolve> {
+        self.resolve_map.resolves.get(&binding).copied()
     }
 
     pub fn local_defs(&self) -> impl Iterator<Item = symbol::LocalDefId> + '_ {

--- a/compiler/toc_hir/src/library.rs
+++ b/compiler/toc_hir/src/library.rs
@@ -22,6 +22,14 @@ impl<T> InLibrary<T> {
     pub fn map<U>(self, f: impl FnOnce(T) -> U) -> InLibrary<U> {
         InLibrary(self.0, f(self.1))
     }
+
+    pub fn library(self) -> LibraryId {
+        self.0
+    }
+
+    pub fn item(self) -> T {
+        self.1
+    }
 }
 
 pub trait WrapInLibrary: Copy {

--- a/compiler/toc_hir/src/stmt.rs
+++ b/compiler/toc_hir/src/stmt.rs
@@ -175,7 +175,24 @@ pub struct If {
     /// True branch, executed if the condition is true
     pub true_branch: StmtId,
     /// Optional false branch
-    pub false_branch: Option<StmtId>,
+    pub false_branch: FalseBranch,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FalseBranch {
+    ElseIf(StmtId),
+    Else(StmtId),
+    None,
+}
+
+impl FalseBranch {
+    /// Extracts the [`StmtId`], if there is one.
+    pub fn stmt(self) -> Option<StmtId> {
+        match self {
+            FalseBranch::ElseIf(id) | FalseBranch::Else(id) => Some(id),
+            FalseBranch::None => None,
+        }
+    }
 }
 
 #[derive(Debug, PartialEq, Eq)]

--- a/compiler/toc_hir/src/symbol.rs
+++ b/compiler/toc_hir/src/symbol.rs
@@ -68,6 +68,10 @@ pub struct DefInfo {
     /// What kind of declaration this definition refers to,
     /// or `None` if it's from an undeclared definition.
     pub kind: Option<SymbolKind>,
+
+    /// Whether or not this def is automatically imported through
+    /// child import boundaries.
+    pub pervasive: IsPervasive,
 }
 
 /// What kind of item this symbol references.
@@ -213,6 +217,10 @@ impl std::fmt::Display for SymbolKind {
 
         f.write_str(name)
     }
+}
+
+crate::make_named_bool! {
+    pub enum IsPervasive;
 }
 
 crate::make_named_bool! {

--- a/compiler/toc_hir/src/symbol.rs
+++ b/compiler/toc_hir/src/symbol.rs
@@ -316,6 +316,22 @@ pub enum Resolve {
     Err,
 }
 
+impl Resolve {
+    /// Asserts that this is a [`Resolve::Def`], and extracts the associated
+    /// [`LocalDefId`].
+    ///
+    /// ## Panics
+    ///
+    /// Panics if it's not a [`Resolve::Def`] (e.g. [`Resolve::Err`])
+    #[track_caller]
+    pub fn unwrap_def(self) -> LocalDefId {
+        match self {
+            Resolve::Def(local_def) => local_def,
+            Resolve::Err => panic!("called `Resolve::unwrap_def` on a `Resolve::Err` value"),
+        }
+    }
+}
+
 /// What a def might resolve to
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DefResolve {

--- a/compiler/toc_hir/src/symbol.rs
+++ b/compiler/toc_hir/src/symbol.rs
@@ -68,9 +68,6 @@ pub struct DefInfo {
     /// What kind of declaration this definition refers to,
     /// or `None` if it's from an undeclared definition.
     pub kind: Option<SymbolKind>,
-    // How this definition was declared
-    // ???: Can we punt this to only be during construction?
-    // pub declare_kind: DeclareKind,
 }
 
 /// What kind of item this symbol references.
@@ -224,49 +221,6 @@ crate::make_named_bool! {
 
 crate::make_named_bool! {
     pub enum IsMonitor;
-}
-
-/// How a symbol is brought into scope
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum DeclareKind {
-    /// The symbol is undeclared at the point of definition.
-    Undeclared,
-    /// The symbol is a normal declaration at the point of definition.
-    Declared,
-    /// The symbol is declared, but is only usable in certain contexts
-    LimitedDeclared(LimitedKind),
-    /// The symbol is a forward reference to a later declaration,
-    /// with a [`LocalDefId`] pointing to the resolving definition.
-    Forward(ForwardKind, Option<LocalDefId>),
-    /// The symbol is a resolution of a forward declaration.
-    Resolved(ForwardKind),
-
-    // TODO: We only care about where it's exported from, attrs can come later (library local export table?)
-    /// The symbol is from an export of an item, with a [`LocalDefId`]
-    /// pointing to the original item.
-    ItemExport(LocalDefId),
-
-    // TODO: Shunt this info into a libray local import table/resolution map?
-    /// The symbol is of an imported item, optionally with a [`LocalDefId`]
-    /// pointing to the original item, or `None` if there isn't one.
-    ItemImport(Option<LocalDefId>),
-}
-
-/// Disambiguates between different forward declaration kinds
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ForwardKind {
-    /// `type` forward declaration
-    Type,
-    /// `procedure` forward declaration
-    // Only constructed in tests right now
-    _Procedure,
-}
-
-/// Specificity on why a symbol is limited in visibility
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum LimitedKind {
-    /// Only usable in post-condition statements
-    PostCondition,
 }
 
 /// Any HIR node that contains a definition

--- a/compiler/toc_hir/src/symbol.rs
+++ b/compiler/toc_hir/src/symbol.rs
@@ -301,10 +301,11 @@ pub enum DefResolve {
     Local(LocalDefId),
     /// Resolves to an external def
     External(DefId),
-    /// Doesn't resolve to any def, as there wasn't any def that
-    /// was applicable for being the import's target, or this is
-    /// the canonical def
-    None,
+    /// No resolution was applicable, e.g. there wasn't any def that
+    /// was applicable for being the import's target
+    Err,
+    /// This is already the canonical def.
+    Canonical,
 }
 
 /// Library-local map of bindings to their corresponding [`Resolve`]

--- a/compiler/toc_hir/src/symbol.rs
+++ b/compiler/toc_hir/src/symbol.rs
@@ -316,10 +316,24 @@ pub enum Resolve {
     Err,
 }
 
+/// What a def might resolve to
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DefResolve {
+    /// Resolves to another local def
+    Local(LocalDefId),
+    /// Resolves to an external def
+    External(DefId),
+    /// Doesn't resolve to any def, as there wasn't any def that
+    /// was applicable for being the import's target, or this is
+    /// the canonical def
+    None,
+}
+
 /// Library-local map of bindings to their corresponding [`Resolve`]
 #[derive(Debug, PartialEq, Eq, Default)]
 pub struct ResolutionMap {
-    pub resolves: IndexMap<Spanned<Symbol>, Resolve>,
+    pub binding_resolves: IndexMap<Spanned<Symbol>, Resolve>,
+    pub def_resolves: DefMap<DefResolve>,
 }
 
 /// Mapping between a [`LocalDefId`] and the corresponding [`DefOwner`]

--- a/compiler/toc_hir/src/ty.rs
+++ b/compiler/toc_hir/src/ty.rs
@@ -102,8 +102,8 @@ pub enum SeqLength {
 
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub struct Alias {
-    /// [`LocalDefId`](symbol::LocalDefId) to start working through
-    pub base_def: Spanned<symbol::LocalDefId>,
+    /// [`Symbol`] to start walking through
+    pub base_def: Spanned<Symbol>,
     /// Names of each segment to lookup
     pub segments: Vec<Spanned<Symbol>>,
 }

--- a/compiler/toc_hir/src/visitor.rs
+++ b/compiler/toc_hir/src/visitor.rs
@@ -492,7 +492,7 @@ impl<'hir> Walker<'hir> {
     fn walk_if(&mut self, in_body: body::BodyId, node: &stmt::If) {
         self.enter_expr(in_body, node.condition);
         self.enter_stmt(in_body, node.true_branch);
-        if let Some(false_branch) = node.false_branch {
+        if let Some(false_branch) = node.false_branch.stmt() {
             self.enter_stmt(in_body, false_branch);
         }
     }

--- a/compiler/toc_hir_db/src/db.rs
+++ b/compiler/toc_hir_db/src/db.rs
@@ -89,9 +89,9 @@ pub trait HirDatabase: toc_hir_lowering::LoweringDb {
     fn bodies_of(&self, library: LibraryId) -> Arc<Vec<body::BodyId>>;
 
     /// Resolved the given `def_id` to the canonical definition (i.e. beyond any exports),
-    /// or itself if it is one.
+    /// or the last def before an undeclared was encountered.
     #[salsa::invoke(query::resolve_def)]
-    fn resolve_def(&self, def_id: DefId) -> DefId;
+    fn resolve_def(&self, def_id: DefId) -> Result<DefId, DefId>;
 
     /// Gets the [`SymbolKind`] of the given `def_id`, or [`None`] if it's an undeclared definition.
     ///

--- a/compiler/toc_hir_lowering/src/lib.rs
+++ b/compiler/toc_hir_lowering/src/lib.rs
@@ -18,7 +18,7 @@
 // Other DBs will deal with what they map to (e.g. a separate DB managing all of the CSTs)
 
 mod lower;
-mod scopes;
+mod resolver;
 
 use toc_hir::{library::LoweredLibrary, library_graph::LibraryGraph};
 use toc_reporting::CompileResult;

--- a/compiler/toc_hir_lowering/src/lower.rs
+++ b/compiler/toc_hir_lowering/src/lower.rs
@@ -20,7 +20,6 @@
 // - so lower_expr_body and lower_stmt_body needs to be in BodyLowering
 
 mod expr;
-mod resolver;
 mod stmt;
 mod ty;
 
@@ -41,7 +40,7 @@ use toc_reporting::{CompileResult, MessageBundle, MessageSink};
 use toc_span::{FileId, HasSpanTable, Span, SpanId, TextRange};
 use toc_syntax::ast::{self, AstNode};
 
-use crate::scopes::PervasiveTracker;
+use crate::resolver::PervasiveTracker;
 use crate::{LoweredLibrary, LoweringDb};
 
 // Implement for anything that can provide an AST source.
@@ -80,9 +79,8 @@ where
             messages = messages.combine(msgs);
         }
 
-        // TODO: Map name exprs to defs
         let (resolve_map, resolve_msgs) =
-            resolver::resolve_defs(&root_items, &library, pervasive_tracker).take();
+            crate::resolver::resolve_defs(&root_items, &library, pervasive_tracker).take();
         messages = messages.combine(resolve_msgs);
 
         let lib = library.finish(root_items, resolve_map);

--- a/compiler/toc_hir_lowering/src/lower.rs
+++ b/compiler/toc_hir_lowering/src/lower.rs
@@ -20,13 +20,14 @@
 // - so lower_expr_body and lower_stmt_body needs to be in BodyLowering
 
 mod expr;
+mod resolver;
 mod stmt;
 mod ty;
 
 use std::sync::Arc;
 
 use toc_ast_db::db::SourceParser;
-use toc_hir::symbol::{syms, DeclareKind, IsMonitor, Symbol, SymbolKind};
+use toc_hir::symbol::{syms, IsMonitor, SymbolKind};
 use toc_hir::{
     body,
     builder::{self, BodyBuilder},
@@ -34,13 +35,14 @@ use toc_hir::{
     item,
     library_graph::{GraphBuilder, LibraryGraph},
     stmt::{Stmt, StmtId, StmtKind},
-    symbol::{self, LocalDefId},
+    symbol::LocalDefId,
 };
 use toc_reporting::{CompileResult, MessageBundle, MessageSink};
 use toc_span::{FileId, HasSpanTable, Span, SpanId, TextRange};
 use toc_syntax::ast::{self, AstNode};
 
-use crate::{scopes, LoweredLibrary, LoweringDb};
+use crate::scopes::PervasiveTracker;
+use crate::{LoweredLibrary, LoweringDb};
 
 // Implement for anything that can provide an AST source.
 impl<T> LoweringDb for T
@@ -66,18 +68,24 @@ where
         }
 
         let reachable_files: Vec<_> = self.depend_graph(library_root).unit_sources().collect();
-
-        // Lower all files reachable from the library root
         let mut root_items = vec![];
         let mut library = builder::LibraryBuilder::default();
+        let mut pervasive_tracker = PervasiveTracker::default();
 
+        // Lower all files reachable from the library root
         for file in reachable_files {
-            let (item, msgs) = FileLowering::lower_file(db, &mut library, file).take();
+            let (item, msgs) =
+                FileLowering::lower_file(db, file, &mut library, &mut pervasive_tracker).take();
             root_items.push((file, item));
             messages = messages.combine(msgs);
         }
 
-        let lib = library.finish(root_items);
+        // TODO: Map name exprs to defs
+        let (resolve_map, resolve_msgs) =
+            resolver::resolve_defs(&root_items, &library, pervasive_tracker).take();
+        messages = messages.combine(resolve_msgs);
+
+        let lib = library.finish(root_items, resolve_map);
 
         CompileResult::new(Arc::new(lib), messages)
     }
@@ -99,31 +107,38 @@ where
 struct FileLowering<'ctx> {
     file: FileId,
     library: &'ctx mut builder::LibraryBuilder,
-    scopes: scopes::ScopeTracker,
+    pervasive_tracker: &'ctx mut PervasiveTracker,
+    // scopes: scopes::ScopeTracker,
     messages: MessageSink,
 }
 
 impl<'ctx> FileLowering<'ctx> {
-    fn new(file: FileId, library: &'ctx mut builder::LibraryBuilder) -> Self {
+    fn new(
+        file: FileId,
+        library: &'ctx mut builder::LibraryBuilder,
+        pervasive_tracker: &'ctx mut PervasiveTracker,
+    ) -> Self {
         Self {
             file,
             library,
+            pervasive_tracker,
             messages: MessageSink::new(),
-            scopes: scopes::ScopeTracker::new(),
+            // scopes: scopes::ScopeTracker::new(),
         }
     }
 
     fn lower_file(
         db: &dyn LoweringDb,
-        library: &'ctx mut builder::LibraryBuilder,
         file: FileId,
+        library: &'ctx mut builder::LibraryBuilder,
+        pervasive_tracker: &'ctx mut PervasiveTracker,
     ) -> CompileResult<item::ItemId> {
         // Parse & validate file
         let parse_res = db.parse_file(file);
         let validate_res = db.validate_file(file);
 
         // Enter the actual lowering
-        let mut ctx = Self::new(file, library);
+        let mut ctx = Self::new(file, library, pervasive_tracker);
         let root = ast::Source::cast(parse_res.result().syntax()).unwrap();
         let root_item = ctx.lower_root(root);
 
@@ -151,22 +166,15 @@ impl<'ctx> FileLowering<'ctx> {
             );
         }
 
-        // FIXME: Handle external imports
-        // This is where we'd inject external definitions
+        // FIXME: Handle external imports at somepoint
+        // They'll get resolved to the final target later
 
-        let (body, declared_items) = self.lower_stmt_body(
-            scopes::ScopeKind::Block,
-            root.stmt_list().unwrap(),
-            vec![],
-            None,
-            &[],
-        );
+        let (body, declared_items) = self.lower_stmt_body(root.stmt_list().unwrap(), vec![], None);
 
         let module_def = self.library.add_def(
             *syms::Root,
             self.library.span_table().dummy_span(),
             Some(SymbolKind::Module(IsMonitor::No)),
-            DeclareKind::Declared,
         );
         let module_span = self.intern_range(root.syntax().text_range());
         let module = item::Module {
@@ -187,42 +195,15 @@ impl<'ctx> FileLowering<'ctx> {
 
     fn lower_stmt_body(
         &mut self,
-        scope_kind: scopes::ScopeKind,
         stmt_list: ast::StmtList,
         param_defs: Vec<LocalDefId>,
         result_name: Option<LocalDefId>,
-        imports: &[LocalDefId],
     ) -> (body::BodyId, Vec<item::ItemId>) {
         // Lower stmts
         let span = stmt_list.syntax().text_range();
         let mut body = builder::BodyBuilder::default();
         let body_stmts = {
-            self.scopes.push_scope(scope_kind);
-
-            // Reintroduce the names
-            for &def_id in param_defs.iter().chain(&result_name) {
-                let def_info = self.library.local_def(def_id);
-
-                self.scopes
-                    .def_sym(def_info.name, def_id, def_info.declare_kind, false);
-            }
-
-            // Introduce imported defs
-            for &def_id in imports {
-                let def_info = self.library.local_def(def_id);
-
-                if let DeclareKind::ItemImport(imported_def) = def_info.declare_kind {
-                    // Carry the pervasiveness through
-                    // We're essentially redeclaring over the pervasive definition, so we still want to
-                    // preserve the pervasive property
-                    self.introduce_def(def_id, self.scopes.is_pervasive(imported_def));
-                } else {
-                    unreachable!("not an importing def")
-                };
-            }
-
             let body_stmts = BodyLowering::new(self, &mut body).lower_stmt_list(stmt_list);
-            self.scopes.pop_scope();
 
             body_stmts
         };
@@ -282,174 +263,6 @@ impl<'ctx> FileLowering<'ctx> {
     fn intern_range(&mut self, range: toc_span::TextRange) -> SpanId {
         let span = self.mk_span(range);
         self.library.intern_span(span)
-    }
-
-    // Helper for using a symbol, handling undeclared reporting
-    fn use_sym(&mut self, name: Symbol, span: Span) -> LocalDefId {
-        self.scopes.use_sym(name, || {
-            // make an undeclared
-            self.messages.error(
-                format!("`{name}` is undeclared"),
-                format!("no definitions of `{name}` are in scope"),
-                span,
-            );
-
-            let span = self.library.intern_span(span);
-            self.library
-                .add_def(name, span, None, DeclareKind::Undeclared)
-        })
-    }
-
-    /// Introduces a definition into the current scope, handling redecleration with any existing defs
-    fn introduce_def(&mut self, def_id: symbol::LocalDefId, is_pervasive: bool) {
-        let def_info = self.library.local_def(def_id);
-        let name = def_info.name;
-        let span = def_info.def_at;
-        let kind = def_info.declare_kind;
-
-        // Bring into scope
-        let old_def = self.scopes.def_sym(name, def_id, kind, is_pervasive);
-
-        // Resolve any associated forward decls
-        if let DeclareKind::Resolved(resolve_kind) = kind {
-            let forward_list = self.scopes.take_resolved_forwards(name, resolve_kind);
-
-            if let Some(forward_list) = forward_list {
-                // Point all of these local defs to this one
-                for forward_def in forward_list {
-                    let def_info = self.library.local_def_mut(forward_def);
-
-                    match &mut def_info.declare_kind {
-                        DeclareKind::Forward(_, resolve_to) => *resolve_to = Some(def_id),
-                        _ => unreachable!("not a forward def"),
-                    }
-                }
-            }
-        }
-
-        if let Some(old_def) = old_def {
-            // Report redeclares, specializing based on what kind of declaration it is
-            let old_def_info = self.library.local_def(old_def);
-
-            let old_span = old_def_info.def_at.lookup_in(&self.library);
-            let new_span = span.lookup_in(&self.library);
-
-            // Just use the name from the old def for both, since by definition they are the same
-            let name = old_def_info.name;
-
-            match (old_def_info.declare_kind, kind) {
-                (DeclareKind::Undeclared, _) | (_, DeclareKind::Undeclared) => {
-                    // Always ok to declare over undeclared symbols
-                }
-                (DeclareKind::Forward(other_kind, _), DeclareKind::Forward(this_kind, _))
-                    if other_kind == this_kind =>
-                {
-                    // Duplicate forward declare
-                    self.messages
-                        .error_detailed(
-                            format!("`{name}` is already a forward declaration"),
-                            new_span,
-                        )
-                        .with_note("previous forward declaration here", old_span)
-                        .with_error("new one here", new_span)
-                        .finish();
-                }
-                (
-                    DeclareKind::Forward(other_kind, resolve_to),
-                    DeclareKind::Resolved(this_kind),
-                ) if other_kind == this_kind => {
-                    // resolve_to: none -> didn't change
-                    // resolve_to: some(== def_id) -> did change, this resolved it
-                    // resolve_to: some(!= def_id) -> didn't change, this didn't resolve it (ok to note as redeclare)
-
-                    if resolve_to.is_none() {
-                        // Forwards must be resolved to the same scope
-                        // This declaration didn't resolve it, which only happens if they're not in the same scope
-                        self.messages
-                            .error_detailed(
-                                format!("`{name}` must be resolved in the same scope"),
-                                new_span,
-                            )
-                            .with_note(format!("forward declaration of `{name}` here"), old_span)
-                            .with_error(
-                                format!("resolution of `{name}` is not in the same scope"),
-                                new_span,
-                            )
-                            .finish();
-                    } else {
-                        // This shouldn't ever fail, since if a symbol is moving from
-                        // forward to resolved, this is the declaration that should've
-                        // done it.
-                        assert_eq!(
-                            resolve_to,
-                            Some(def_id),
-                            "encountered a forward not resolved by this definition"
-                        );
-                    }
-                }
-                (_, DeclareKind::ItemExport(exported_from)) => {
-                    // From an unqualified export in a local module
-                    // Use the originating item as the top-level error span
-                    let from_item_span = self
-                        .library
-                        .local_def(exported_from)
-                        .def_at
-                        .lookup_in(&self.library);
-
-                    self.messages
-                        .error_detailed(
-                            format!("`{name}` is already declared in the parent scope"),
-                            from_item_span,
-                        )
-                        .with_note(format!("`{name}` previously declared here"), old_span)
-                        .with_error(format!("`{name}` exported from here"), new_span)
-                        .finish();
-                }
-                (_, DeclareKind::ItemImport(_)) => {
-                    // Import is declaring over something that's already visible.
-                    //
-                    // This isn't limited to pervasive defs, and can be because defs were introduced
-                    // before the import (e.g. module's name, param decls)
-                    let is_old_pervasive = self.scopes.is_pervasive(old_def);
-
-                    if is_old_pervasive {
-                        // Visible because old def was pervasive
-                        self.messages
-                            .error_detailed(
-                                format!("`{name}` is already imported in this scope"),
-                                new_span,
-                            )
-                            .with_note(format!("`{name}` declared pervasive here"), old_span)
-                            .with_error(format!("`{name}` re-imported here"), new_span)
-                            .with_info(format!(
-                                "`{name}` was declared pervasively, so it's already imported"
-                            ))
-                            .finish();
-                    } else {
-                        // Declared for another reason
-                        self.messages
-                            .error_detailed(
-                                format!("`{name}` is already declared in this scope"),
-                                new_span,
-                            )
-                            .with_note(format!("`{name}` previously declared here"), old_span)
-                            .with_error(format!("`{name}` imported here"), new_span)
-                            .finish();
-                    }
-                }
-                _ => {
-                    // From a new declaration
-                    self.messages
-                        .error_detailed(
-                            format!("`{name}` is already declared in this scope"),
-                            new_span,
-                        )
-                        .with_note(format!("`{name}` previously declared here"), old_span)
-                        .with_error(format!("`{name}` redeclared here"), new_span)
-                        .finish();
-                }
-            }
-        }
     }
 }
 

--- a/compiler/toc_hir_lowering/src/lower/resolver.rs
+++ b/compiler/toc_hir_lowering/src/lower/resolver.rs
@@ -1,0 +1,679 @@
+//! Resolution of name nodes to specific local defs
+
+use toc_hir::{
+    body::{BodyId, BodyKind},
+    expr::{BodyExpr, ExprId, ExprKind, Name, RangeBound},
+    item::{DefinedType, ItemId, ItemKind, QualifyAs, SubprogramExtra},
+    library::Library,
+    stmt::{BodyStmt, CaseSelector, FalseBranch, ForBounds, GetWidth, Skippable, StmtId, StmtKind},
+    symbol::{DeclareKind, ForwardKind, LimitedKind, LocalDefId, ResolutionMap, Resolve, Symbol},
+    ty::{ConstrainedEnd, Primitive, SeqLength, TypeId, TypeKind},
+};
+use toc_reporting::{CompileResult, MessageSink};
+use toc_span::{FileId, SpanId};
+
+use crate::scopes::{PervasiveTracker, ScopeKind, ScopeTracker};
+
+/// Resolves bindings in a library, producing a [`ResolutionMap`]
+pub(crate) fn resolve_defs(
+    root_items: &[(FileId, ItemId)],
+    library: &Library,
+    pervasive_tracker: PervasiveTracker,
+) -> CompileResult<ResolutionMap> {
+    let mut ctx = ResolveCtx {
+        library,
+        resolves: Default::default(),
+        scopes: ScopeTracker::new(pervasive_tracker),
+        messages: Default::default(),
+    };
+
+    for (_, root_item) in root_items {
+        ctx.resolve_item(*root_item);
+    }
+
+    CompileResult::new(ctx.resolves, ctx.messages.finish())
+}
+
+struct ResolveCtx<'lib> {
+    library: &'lib Library,
+    resolves: ResolutionMap,
+    scopes: ScopeTracker,
+    messages: MessageSink,
+}
+
+impl<'a> ResolveCtx<'a> {
+    // Helper for using a symbol, handling undeclared & use reporting reporting
+    fn use_sym(&mut self, name: Symbol, span: SpanId) -> Resolve {
+        let resolve = match self.scopes.use_sym(name) {
+            Some(def) => Resolve::Def(def),
+            None => {
+                if self.scopes.is_first_undecl_use(name) {
+                    self.messages.error(
+                        format!("`{name}` is undeclared"),
+                        format!("no definitions of `{name}` are in scope"),
+                        span.lookup_in(&self.library),
+                    );
+                }
+
+                Resolve::Err
+            }
+        };
+
+        if let Resolve::Def(def) = resolve {
+            if let DeclareKind::LimitedDeclared(limited) = self.scopes.declare_kind(def) {
+                match limited {
+                    LimitedKind::PostCondition => {
+                        // FIXME: If we're in a post condition, don't report this error
+                        self.messages.error(
+                            format!("`cannot use {name}` here"),
+                            format!("`{name}` can only be used in a `post` statement"),
+                            span.lookup_in(&self.library),
+                        );
+                    }
+                }
+            }
+        }
+
+        resolve
+    }
+
+    /// Introduces a definition into the current scope, handling redecleration with any existing defs
+    fn introduce_def(&mut self, def_id: LocalDefId, kind: DeclareKind) {
+        // Don't bother introducing unnamed defs, since they're not meant to be real
+        if self.is_unnamed(def_id) {
+            return;
+        }
+
+        let def_info = self.library.local_def(def_id);
+        let name = def_info.name;
+        let span = def_info.def_at;
+
+        // Bring into scope
+        let old_def = self.scopes.def_sym(name, def_id, kind);
+
+        // Resolve any associated forward decls
+        if let DeclareKind::Resolved(resolve_kind) = kind {
+            let forward_list = self.scopes.take_resolved_forwards(name, resolve_kind);
+
+            if let Some(forward_list) = forward_list {
+                // Point all of these local defs to this one
+                for forward_def in forward_list {
+                    let kind = self.scopes.declare_kind_mut(forward_def).unwrap();
+
+                    match kind {
+                        DeclareKind::Forward(_, resolve_to) => *resolve_to = Some(def_id),
+                        _ => unreachable!("not a forward def"),
+                    }
+                }
+            }
+        }
+
+        if let Some(old_def) = old_def {
+            // Report redeclares, specializing based on what kind of declaration it is
+            let old_def_info = self.library.local_def(old_def);
+            let old_declare_kind = self.scopes.declare_kind(old_def);
+
+            let old_span = old_def_info.def_at.lookup_in(&self.library);
+            let new_span = span.lookup_in(&self.library);
+
+            // Just use the name from the old def for both, since by definition they are the same
+            let name = old_def_info.name;
+
+            match (old_declare_kind, kind) {
+                (DeclareKind::Undeclared, _) | (_, DeclareKind::Undeclared) => {
+                    // Always ok to declare over undeclared symbols
+                }
+                (DeclareKind::Forward(other_kind, _), DeclareKind::Forward(this_kind, _))
+                    if other_kind == this_kind =>
+                {
+                    // Duplicate forward declare
+                    self.messages
+                        .error_detailed(
+                            format!("`{name}` is already a forward declaration"),
+                            new_span,
+                        )
+                        .with_note("previous forward declaration here", old_span)
+                        .with_error("new one here", new_span)
+                        .finish();
+                }
+                (
+                    DeclareKind::Forward(other_kind, resolve_to),
+                    DeclareKind::Resolved(this_kind),
+                ) if other_kind == this_kind => {
+                    // resolve_to: none -> didn't change
+                    // resolve_to: some(== def_id) -> did change, this resolved it
+                    // resolve_to: some(!= def_id) -> didn't change, this didn't resolve it (ok to note as redeclare)
+
+                    if resolve_to.is_none() {
+                        // Forwards must be resolved to the same scope
+                        // This declaration didn't resolve it, which only happens if they're not in the same scope
+                        self.messages
+                            .error_detailed(
+                                format!("`{name}` must be resolved in the same scope"),
+                                new_span,
+                            )
+                            .with_note(format!("forward declaration of `{name}` here"), old_span)
+                            .with_error(
+                                format!("resolution of `{name}` is not in the same scope"),
+                                new_span,
+                            )
+                            .finish();
+                    } else {
+                        // This shouldn't ever fail, since if a symbol is moving from
+                        // forward to resolved, this is the declaration that should've
+                        // done it.
+                        assert_eq!(
+                            resolve_to,
+                            Some(def_id),
+                            "encountered a forward not resolved by this definition"
+                        );
+                    }
+                }
+                (_, DeclareKind::ItemExport(exported_from)) => {
+                    // From an unqualified export in a local module
+                    // Use the originating item as the top-level error span
+                    let from_item_span = self
+                        .library
+                        .local_def(exported_from)
+                        .def_at
+                        .lookup_in(&self.library);
+
+                    self.messages
+                        .error_detailed(
+                            format!("`{name}` is already declared in the parent scope"),
+                            from_item_span,
+                        )
+                        .with_note(format!("`{name}` previously declared here"), old_span)
+                        .with_error(format!("`{name}` exported from here"), new_span)
+                        .finish();
+                }
+                (_, DeclareKind::ItemImport(_)) => {
+                    // Import is declaring over something that's already visible.
+                    //
+                    // This isn't limited to pervasive defs, and can be because defs were introduced
+                    // before the import (e.g. module's name, param decls)
+                    let is_old_pervasive = self.scopes.is_pervasive(old_def);
+
+                    if is_old_pervasive {
+                        // Visible because old def was pervasive
+                        self.messages
+                            .error_detailed(
+                                format!("`{name}` is already imported in this scope"),
+                                new_span,
+                            )
+                            .with_note(format!("`{name}` declared pervasive here"), old_span)
+                            .with_error(format!("`{name}` re-imported here"), new_span)
+                            .with_info(format!(
+                                "`{name}` was declared pervasively, so it's already imported"
+                            ))
+                            .finish();
+                    } else {
+                        // Declared for another reason
+                        self.messages
+                            .error_detailed(
+                                format!("`{name}` is already declared in this scope"),
+                                new_span,
+                            )
+                            .with_note(format!("`{name}` previously declared here"), old_span)
+                            .with_error(format!("`{name}` imported here"), new_span)
+                            .finish();
+                    }
+                }
+                _ => {
+                    // From a new declaration
+                    self.messages
+                        .error_detailed(
+                            format!("`{name}` is already declared in this scope"),
+                            new_span,
+                        )
+                        .with_note(format!("`{name}` previously declared here"), old_span)
+                        .with_error(format!("`{name}` redeclared here"), new_span)
+                        .finish();
+                }
+            }
+        }
+    }
+
+    fn is_unnamed(&self, def_id: LocalDefId) -> bool {
+        self.library.local_def(def_id).kind.is_none()
+    }
+
+    fn with_scope<R>(&mut self, kind: ScopeKind, f: impl FnOnce(&mut Self) -> R) -> R {
+        self.scopes.push_scope(kind);
+        let res = f(self);
+        self.scopes.pop_scope();
+
+        res
+    }
+}
+
+// Items //
+impl<'a> ResolveCtx<'a> {
+    fn resolve_item(&mut self, item_id: ItemId) {
+        // Consistency with `with_scope`
+        let this = self;
+
+        match &this.library.item(item_id).kind {
+            ItemKind::ConstVar(item) => {
+                if let Some(type_id) = item.type_spec {
+                    this.resolve_type(type_id);
+                }
+                if let Some(body_id) = item.init_expr {
+                    this.resolve_body(body_id);
+                }
+
+                // Declare names after uses to prevent def-use cycles
+                this.introduce_def(item.def_id, DeclareKind::Declared);
+            }
+            ItemKind::Type(item) => {
+                // DeclareKind is based on how this type is defined
+                let decl_kind = match item.type_def {
+                    DefinedType::Alias(type_id) => {
+                        this.resolve_type(type_id);
+                        DeclareKind::Resolved(ForwardKind::Type)
+                    }
+                    DefinedType::Forward(_) => DeclareKind::Forward(ForwardKind::Type, None),
+                };
+
+                // Declare name after type to prevent def-use cycles
+                // ???: Do we still want to do introduce it here?
+                // We can still create cycles by just introducing a forward def.
+                // Plus, we plan to have an occurrence check as part of type infer,
+                // making this useless.
+                this.introduce_def(item.def_id, decl_kind);
+            }
+            ItemKind::Binding(item) => {
+                this.resolve_body(item.bind_to);
+
+                // Declare names after uses to prevent def-use cycles
+                this.introduce_def(item.def_id, DeclareKind::Declared);
+            }
+            ItemKind::Subprogram(item) => {
+                this.introduce_def(item.def_id, DeclareKind::Declared);
+
+                if let Some(param_list) = &item.param_list {
+                    // Make sure there aren't any duplicate names
+                    this.with_scope(ScopeKind::SubprogramHeader, |this| {
+                        for param_def in &param_list.names {
+                            this.introduce_def(*param_def, DeclareKind::Declared);
+                        }
+                    });
+
+                    for param in &param_list.tys {
+                        this.resolve_type(param.param_ty);
+                    }
+                }
+
+                this.resolve_type(item.result.ty);
+
+                match item.extra {
+                    SubprogramExtra::DeviceSpec(body_id) | SubprogramExtra::StackSize(body_id) => {
+                        this.resolve_body(body_id);
+                    }
+                    _ => {}
+                }
+
+                this.with_scope(ScopeKind::Subprogram, |this| {
+                    this.with_scope(ScopeKind::Block, |this| {
+                        // Introduce params
+                        if let Some(param_list) = &item.param_list {
+                            for &param_def in &param_list.names {
+                                let name = this.library.local_def(param_def).name;
+                                this.scopes.def_sym(name, param_def, DeclareKind::Declared);
+                            }
+                        }
+
+                        // Optionally result type
+                        if let Some(result_name) = item.result.name {
+                            this.introduce_def(
+                                result_name,
+                                DeclareKind::LimitedDeclared(LimitedKind::PostCondition),
+                            );
+                        }
+
+                        // And any remaining imports
+                        for &item_id in &item.body.imports {
+                            this.resolve_item(item_id);
+                        }
+
+                        this.resolve_body(item.body.body);
+                    });
+                })
+            }
+            ItemKind::Module(item) => {
+                // Always introduce it before so that it's visible to import lookup
+                this.introduce_def(item.def_id, DeclareKind::Declared);
+
+                this.with_scope(ScopeKind::Module, |this| {
+                    // Make visible in the inner scope, but only if it isn't pervasive
+                    // (it being pervasive would mean it's already visible)
+                    if !this.scopes.is_pervasive(item.def_id) {
+                        this.introduce_def(item.def_id, DeclareKind::Declared);
+                    }
+
+                    this.with_scope(ScopeKind::Block, |this| {
+                        // Introduce applicable imports
+                        for &item_id in &item.imports {
+                            this.resolve_item(item_id);
+                        }
+
+                        this.resolve_body(item.body);
+                    });
+                });
+
+                // Introduce the unqualified exports too
+                for export in item.exports.iter().filter(|item| {
+                    matches!(
+                        item.qualify_as,
+                        QualifyAs::Unqualified | QualifyAs::PervasiveUnqualified
+                    )
+                }) {
+                    let exported_def = this.library.item(export.item_id).def_id;
+                    this.introduce_def(export.def_id, DeclareKind::ItemExport(exported_def));
+                }
+            }
+            ItemKind::Import(item) => {
+                // resolve it right now
+                let name = this.library.local_def(item.def_id).name;
+
+                let imported_def = if let Some(def_id) = this.scopes.import_sym(name) {
+                    Some(def_id)
+                } else {
+                    let def_at = this
+                        .library
+                        .local_def(item.def_id)
+                        .def_at
+                        .lookup_in(&this.library);
+
+                    this.messages.error(
+                        format!("`{name}` could not be imported"),
+                        format!("no definitions of `{name}` found in the surrounding scope"),
+                        def_at,
+                    );
+
+                    None
+                };
+
+                this.introduce_def(item.def_id, DeclareKind::ItemImport(imported_def));
+            }
+        }
+    }
+}
+
+impl<'a> ResolveCtx<'a> {
+    fn resolve_body(&mut self, body_id: BodyId) {
+        // Consistency with `with_scope`
+        let this = self;
+
+        match &this.library.body(body_id).kind {
+            BodyKind::Stmts(stmts, _, _) => {
+                this.resolve_stmts(stmts, body_id);
+            }
+            BodyKind::Exprs(expr) => {
+                this.resolve_expr(expr.in_body(body_id));
+            }
+        }
+    }
+}
+
+// Stmts //
+impl<'a> ResolveCtx<'a> {
+    fn resolve_stmts(&mut self, stmts: &[StmtId], body_id: BodyId) {
+        // Consistency with `with_scope`
+        let this = self;
+
+        for stmt_id in stmts {
+            this.resolve_stmt(stmt_id.in_body(body_id));
+        }
+    }
+
+    fn resolve_stmt(&mut self, node_id: BodyStmt) {
+        // Consistency with `with_scope`
+        let this = self;
+        let body_id = node_id.body();
+
+        match &this.library.body(node_id.body()).stmt(node_id.stmt()).kind {
+            StmtKind::Item(item_id) => this.resolve_item(*item_id),
+            StmtKind::Assign(stmt) => {
+                this.resolve_expr(stmt.lhs.in_body(body_id));
+                this.resolve_expr(stmt.rhs.in_body(body_id));
+            }
+            StmtKind::Put(stmt) => {
+                if let Some(expr) = stmt.stream_num {
+                    this.resolve_expr(expr.in_body(body_id))
+                }
+
+                for item in &stmt.items {
+                    let put_item = match item {
+                        Skippable::Skip => continue,
+                        Skippable::Item(put_item) => put_item,
+                    };
+
+                    this.resolve_expr(put_item.expr.in_body(body_id));
+                    this.try_resolve_expr(put_item.opts.width(), body_id);
+                    this.try_resolve_expr(put_item.opts.precision(), body_id);
+                    this.try_resolve_expr(put_item.opts.exponent_width(), body_id);
+                }
+            }
+            StmtKind::Get(stmt) => {
+                if let Some(expr) = stmt.stream_num {
+                    this.resolve_expr(expr.in_body(body_id))
+                }
+
+                for item in &stmt.items {
+                    let get_item = match item {
+                        Skippable::Skip => continue,
+                        Skippable::Item(get_item) => get_item,
+                    };
+
+                    this.resolve_expr(get_item.expr.in_body(body_id));
+
+                    if let GetWidth::Chars(expr) = get_item.width {
+                        this.resolve_expr(expr.in_body(body_id))
+                    }
+                }
+            }
+            StmtKind::For(stmt) => {
+                match stmt.bounds {
+                    ForBounds::Implicit(expr) => this.resolve_expr(expr.in_body(body_id)),
+                    ForBounds::Full(start, end) => {
+                        this.resolve_expr(start.in_body(body_id));
+                        this.resolve_expr(end.in_body(body_id));
+                    }
+                }
+
+                this.try_resolve_expr(stmt.step_by, body_id);
+
+                this.with_scope(ScopeKind::Loop, |this| {
+                    // counter is only available inside of the loop body
+                    if let Some(def_id) = stmt.counter_def {
+                        this.introduce_def(def_id, DeclareKind::Declared);
+                    }
+
+                    this.resolve_stmts(&stmt.stmts, body_id);
+                })
+            }
+            StmtKind::Loop(stmt) => this.with_scope(ScopeKind::Loop, |this| {
+                this.resolve_stmts(&stmt.stmts, body_id);
+            }),
+            StmtKind::Exit(stmt) => {
+                this.try_resolve_expr(stmt.when_condition, body_id);
+            }
+            StmtKind::If(stmt) => {
+                this.resolve_expr(stmt.condition.in_body(body_id));
+
+                // Each branch gets its own scope
+                this.with_scope(ScopeKind::Block, |this| {
+                    this.resolve_stmt(stmt.true_branch.in_body(body_id));
+                });
+
+                match stmt.false_branch {
+                    // `else-if` doesn't get a block scope, since it's at the same scoping
+                    // as the current `if`
+                    FalseBranch::ElseIf(stmt_id) => this.resolve_stmt(stmt_id.in_body(body_id)),
+                    // `else` however does, since it's self-contained
+                    FalseBranch::Else(stmt_id) => this.with_scope(ScopeKind::Block, |this| {
+                        this.resolve_stmt(stmt_id.in_body(body_id))
+                    }),
+                    FalseBranch::None => {}
+                }
+            }
+            StmtKind::Case(stmt) => {
+                this.resolve_expr(stmt.discriminant.in_body(body_id));
+
+                for arm in &stmt.arms {
+                    if let CaseSelector::Exprs(exprs) = &arm.selectors {
+                        for selector in exprs {
+                            this.resolve_expr(selector.in_body(body_id));
+                        }
+                    }
+
+                    this.with_scope(ScopeKind::Block, |this| {
+                        this.resolve_stmts(&arm.stmts, body_id)
+                    })
+                }
+            }
+            StmtKind::Block(stmt) => this.with_scope(ScopeKind::Block, |this| {
+                this.resolve_stmts(&stmt.stmts, body_id);
+            }),
+            StmtKind::Call(stmt) => {
+                this.resolve_expr(stmt.lhs.in_body(body_id));
+
+                if let Some(args) = &stmt.arguments {
+                    for arg in args {
+                        this.resolve_expr(arg.in_body(body_id));
+                    }
+                }
+            }
+            StmtKind::Return(_) => {}
+            StmtKind::Result(stmt) => {
+                this.resolve_expr(stmt.expr.in_body(body_id));
+            }
+        }
+    }
+}
+
+// Exprs //
+impl<'a> ResolveCtx<'a> {
+    /// Like [`Self::resolve_expr`] + [`Option::map`]
+    fn try_resolve_expr(&mut self, expr_id: Option<ExprId>, body_id: BodyId) {
+        if let Some(expr) = expr_id {
+            self.resolve_expr(expr.in_body(body_id));
+        }
+    }
+
+    fn resolve_expr(&mut self, node_id: BodyExpr) {
+        // Consistency with `with_scope`
+        let this = self;
+        let body_id = node_id.body();
+
+        match &this.library.body(body_id).expr(node_id.expr()).kind {
+            ExprKind::Missing => {}
+            ExprKind::Literal(_) => {}
+            ExprKind::Init(expr) => {
+                for body_id in &expr.exprs {
+                    this.resolve_body(*body_id);
+                }
+            }
+            ExprKind::Binary(expr) => {
+                this.resolve_expr(expr.lhs.in_body(body_id));
+                this.resolve_expr(expr.rhs.in_body(body_id));
+            }
+            ExprKind::Unary(expr) => {
+                this.resolve_expr(expr.rhs.in_body(body_id));
+            }
+            ExprKind::All => {}
+            ExprKind::Range(expr) => {
+                let resolve_range_bound = |this: &mut Self, range| match range {
+                    RangeBound::FromStart(expr) | RangeBound::FromEnd(expr) => {
+                        this.resolve_expr(expr.in_body(body_id))
+                    }
+                    RangeBound::AtEnd(_) => {}
+                };
+
+                resolve_range_bound(this, expr.start);
+                if let Some(end) = expr.end {
+                    resolve_range_bound(this, end);
+                }
+            }
+            ExprKind::Name(expr) => match expr {
+                Name::Name(binding) => {
+                    let resolve = this.use_sym(*binding.item(), binding.span());
+                    this.resolves.resolves.insert(*binding, resolve);
+                }
+                Name::Self_ => unimplemented!(),
+            },
+            ExprKind::Field(expr) => {
+                this.resolve_expr(expr.lhs.in_body(body_id));
+            }
+            ExprKind::Deref(expr) => {
+                this.resolve_expr(expr.rhs.in_body(body_id));
+            }
+            ExprKind::Call(expr) => {
+                this.resolve_expr(expr.lhs.in_body(body_id));
+
+                for arg in &expr.arguments {
+                    this.resolve_expr(arg.in_body(body_id));
+                }
+            }
+        }
+    }
+}
+
+// Types //
+impl<'a> ResolveCtx<'a> {
+    fn resolve_type(&mut self, type_id: TypeId) {
+        // Consistency with `with_scope`
+        let this = self;
+
+        match &this.library.lookup_type(type_id).kind {
+            TypeKind::Missing => {}
+            TypeKind::Primitive(ty) => match ty {
+                Primitive::SizedChar(SeqLength::Expr(body_id))
+                | Primitive::SizedString(SeqLength::Expr(body_id)) => {
+                    this.resolve_body(*body_id);
+                }
+                _ => {}
+            },
+            TypeKind::Alias(ty) => {
+                let binding = ty.base_def;
+                let resolve = this.use_sym(*binding.item(), binding.span());
+                this.resolves.resolves.insert(binding, resolve);
+            }
+            TypeKind::Constrained(ty) => {
+                this.resolve_body(ty.start);
+
+                if let ConstrainedEnd::Expr(body_id) = ty.end {
+                    this.resolve_body(body_id);
+                }
+            }
+            TypeKind::Enum(_ty) => {
+                // FIXME: Add resolve visits when size specs are lowered
+            }
+            TypeKind::Array(ty) => {
+                for &range in &ty.ranges {
+                    this.resolve_type(range);
+                }
+
+                this.resolve_type(ty.elem_ty);
+            }
+            TypeKind::Set(ty) => {
+                this.resolve_type(ty.elem_ty);
+                // FIXME: Add body resolve visit when size specs are lowered
+            }
+            TypeKind::Pointer(ty) => {
+                this.resolve_type(ty.ty);
+            }
+            TypeKind::Subprogram(ty) => {
+                if let Some(param_list) = &ty.param_list {
+                    for param in param_list {
+                        this.resolve_type(param.param_ty);
+                    }
+                }
+
+                this.resolve_type(ty.result_ty);
+            }
+            TypeKind::Void => {}
+        }
+    }
+}

--- a/compiler/toc_hir_lowering/src/lower/ty.rs
+++ b/compiler/toc_hir_lowering/src/lower/ty.rs
@@ -1,5 +1,5 @@
 //! Lowering into `Type` HIR nodes
-use toc_hir::symbol::{syms, SymbolKind};
+use toc_hir::symbol::{syms, IsPervasive, SymbolKind};
 use toc_hir::{symbol, ty};
 use toc_span::{HasSpanTable, Span, Spanned};
 use toc_syntax::ast::{self, AstNode};
@@ -278,18 +278,22 @@ impl super::BodyLowering<'_, '_> {
             .filter_map(|name| {
                 let span = self.ctx.intern_range(name.syntax().text_range());
                 let name = name.identifier_token()?.text().into();
-                let def_id = self
-                    .ctx
-                    .library
-                    .add_def(name, span, Some(SymbolKind::EnumVariant));
+                let def_id = self.ctx.library.add_def(
+                    name,
+                    span,
+                    Some(SymbolKind::EnumVariant),
+                    IsPervasive::No,
+                );
 
                 Some(def_id)
             })
             .collect();
-        let def_id = self
-            .ctx
-            .library
-            .add_def(type_decl_name(ty), span, Some(SymbolKind::Enum));
+        let def_id = self.ctx.library.add_def(
+            type_decl_name(ty),
+            span,
+            Some(SymbolKind::Enum),
+            IsPervasive::No,
+        );
 
         Some(ty::TypeKind::Enum(ty::Enum { def_id, variants }))
     }
@@ -408,10 +412,12 @@ impl super::BodyLowering<'_, '_> {
     fn lower_set_type(&mut self, ty: ast::SetType) -> Option<ty::TypeKind> {
         let span = self.ctx.intern_range(ty.syntax().text_range());
         let elem = self.lower_required_type(ty.elem_ty());
-        let def_id = self
-            .ctx
-            .library
-            .add_def(type_decl_name(ty), span, Some(SymbolKind::Set));
+        let def_id = self.ctx.library.add_def(
+            type_decl_name(ty),
+            span,
+            Some(SymbolKind::Set),
+            IsPervasive::No,
+        );
 
         Some(ty::TypeKind::Set(ty::Set {
             def_id,

--- a/compiler/toc_hir_lowering/src/lower/ty.rs
+++ b/compiler/toc_hir_lowering/src/lower/ty.rs
@@ -1,5 +1,5 @@
 //! Lowering into `Type` HIR nodes
-use toc_hir::symbol::{syms, DeclareKind, SymbolKind};
+use toc_hir::symbol::{syms, SymbolKind};
 use toc_hir::{symbol, ty};
 use toc_span::{HasSpanTable, Span, Spanned};
 use toc_syntax::ast::{self, AstNode};
@@ -103,11 +103,10 @@ impl super::BodyLowering<'_, '_> {
 
                     // at a simple alias
                     let name = expr.name()?.identifier_token()?;
-                    let span = self.ctx.mk_span(name.text_range());
-                    let def_id = self.ctx.use_sym(name.text().into(), span);
+                    let span = self.ctx.intern_range(name.text_range());
 
                     break Some(ty::TypeKind::Alias(ty::Alias {
-                        base_def: Spanned::new(def_id, self.ctx.intern_range(name.text_range())),
+                        base_def: Spanned::new(name.text().into(), span),
                         segments,
                     }));
                 }
@@ -279,22 +278,18 @@ impl super::BodyLowering<'_, '_> {
             .filter_map(|name| {
                 let span = self.ctx.intern_range(name.syntax().text_range());
                 let name = name.identifier_token()?.text().into();
-                let def_id = self.ctx.library.add_def(
-                    name,
-                    span,
-                    Some(SymbolKind::EnumVariant),
-                    DeclareKind::Declared,
-                );
+                let def_id = self
+                    .ctx
+                    .library
+                    .add_def(name, span, Some(SymbolKind::EnumVariant));
 
                 Some(def_id)
             })
             .collect();
-        let def_id = self.ctx.library.add_def(
-            type_decl_name(ty),
-            span,
-            Some(SymbolKind::Enum),
-            DeclareKind::Declared,
-        );
+        let def_id = self
+            .ctx
+            .library
+            .add_def(type_decl_name(ty), span, Some(SymbolKind::Enum));
 
         Some(ty::TypeKind::Enum(ty::Enum { def_id, variants }))
     }
@@ -413,12 +408,10 @@ impl super::BodyLowering<'_, '_> {
     fn lower_set_type(&mut self, ty: ast::SetType) -> Option<ty::TypeKind> {
         let span = self.ctx.intern_range(ty.syntax().text_range());
         let elem = self.lower_required_type(ty.elem_ty());
-        let def_id = self.ctx.library.add_def(
-            type_decl_name(ty),
-            span,
-            Some(SymbolKind::Set),
-            DeclareKind::Declared,
-        );
+        let def_id = self
+            .ctx
+            .library
+            .add_def(type_decl_name(ty), span, Some(SymbolKind::Set));
 
         Some(ty::TypeKind::Set(ty::Set {
             def_id,

--- a/compiler/toc_hir_lowering/src/resolver/scopes.rs
+++ b/compiler/toc_hir_lowering/src/resolver/scopes.rs
@@ -35,6 +35,8 @@ pub(crate) enum DeclareKind {
     /// pointing to the original item, or `None` if there isn't one.
     ItemImport(Option<LocalDefId>),
 
+    /// The symbol an unqualified export from an import.
+    /// [`LocalDefId`]s point to `(original_import, original_export)`
     UnqualifiedImport(LocalDefId, LocalDefId),
 }
 

--- a/compiler/toc_hir_lowering/src/resolver/scopes.rs
+++ b/compiler/toc_hir_lowering/src/resolver/scopes.rs
@@ -34,6 +34,8 @@ pub(crate) enum DeclareKind {
     /// The symbol is of an imported item, optionally with a [`LocalDefId`]
     /// pointing to the original item, or `None` if there isn't one.
     ItemImport(Option<LocalDefId>),
+
+    UnqualifiedImport(LocalDefId, LocalDefId),
 }
 
 /// Disambiguates between different forward declaration kinds

--- a/compiler/toc_hir_lowering/src/resolver/scopes/test.rs
+++ b/compiler/toc_hir_lowering/src/resolver/scopes/test.rs
@@ -1,9 +1,7 @@
 //! Scope testing
-use toc_hir::symbol::{DeclareKind, ForwardKind, LocalDefId};
+use toc_hir::symbol::LocalDefId;
 
-use crate::scopes::ScopeKind;
-
-use super::{PervasiveTracker, ScopeTracker};
+use super::{DeclareKind, ForwardKind, PervasiveTracker, ScopeKind, ScopeTracker};
 
 #[derive(Default)]
 struct LocalDefAlloc {

--- a/compiler/toc_hir_lowering/src/resolver/scopes/test.rs
+++ b/compiler/toc_hir_lowering/src/resolver/scopes/test.rs
@@ -1,7 +1,7 @@
 //! Scope testing
 use toc_hir::symbol::LocalDefId;
 
-use super::{DeclareKind, ForwardKind, PervasiveTracker, ScopeKind, ScopeTracker};
+use super::{DeclareKind, ForwardKind, ScopeKind, ScopeTracker};
 
 #[derive(Default)]
 struct LocalDefAlloc {
@@ -19,11 +19,11 @@ impl LocalDefAlloc {
 #[test]
 fn test_ident_declare_use() {
     // declare | usage
-    let mut scopes = ScopeTracker::new(Default::default());
+    let mut scopes = ScopeTracker::new();
     let mut defs = LocalDefAlloc::default();
 
     let def_id = defs.next();
-    scopes.def_sym("a".into(), def_id, DeclareKind::Declared);
+    scopes.def_sym("a".into(), def_id, DeclareKind::Declared, false);
     let lookup_id = scopes.use_sym("a".into()).unwrap();
 
     assert_eq!(def_id, lookup_id);
@@ -31,17 +31,17 @@ fn test_ident_declare_use() {
 
 #[test]
 fn test_ident_redeclare() {
-    let mut scopes = ScopeTracker::new(Default::default());
+    let mut scopes = ScopeTracker::new();
     let mut defs = LocalDefAlloc::default();
 
     // First decl, pass
     let initial_id = defs.next();
-    let old_def = scopes.def_sym("a".into(), initial_id, DeclareKind::Declared);
+    let old_def = scopes.def_sym("a".into(), initial_id, DeclareKind::Declared, false);
     assert_eq!(old_def, None);
 
     // Redecl, have different ids
     let redeclare_id = defs.next();
-    let old_def = scopes.def_sym("a".into(), redeclare_id, DeclareKind::Declared);
+    let old_def = scopes.def_sym("a".into(), redeclare_id, DeclareKind::Declared, false);
 
     assert_ne!(initial_id, redeclare_id);
     // Should be the initial id
@@ -51,18 +51,18 @@ fn test_ident_redeclare() {
 #[test]
 fn test_ident_declare_shadow() {
     // Identifier shadowing is not allow within inner scopes, but is detected later on
-    let mut scopes = ScopeTracker::new(Default::default());
+    let mut scopes = ScopeTracker::new();
     let mut defs = LocalDefAlloc::default();
 
     // Outer declare
     let outer_def = defs.next();
-    let old_def = scopes.def_sym("a".into(), outer_def, DeclareKind::Declared);
+    let old_def = scopes.def_sym("a".into(), outer_def, DeclareKind::Declared, false);
     assert_eq!(old_def, None);
 
     // Inner declare
     scopes.with_scope(false, |scopes| {
         let shadow_def = defs.next();
-        let old_def = scopes.def_sym("a".into(), shadow_def, DeclareKind::Declared);
+        let old_def = scopes.def_sym("a".into(), shadow_def, DeclareKind::Declared, false);
 
         // Identifiers should be different
         assert_ne!(shadow_def, outer_def);
@@ -79,13 +79,13 @@ fn test_ident_declare_shadow() {
 #[test]
 fn test_ident_declare_no_shadow() {
     // Declaring outer after inner scopes should not cause issues
-    let mut scopes = ScopeTracker::new(Default::default());
+    let mut scopes = ScopeTracker::new();
     let mut defs = LocalDefAlloc::default();
 
     // Inner declare
     let (shadow_def, shadow_use) = scopes.with_scope(false, |scopes| {
         let shadow_def = defs.next();
-        let old_def = scopes.def_sym("a".into(), shadow_def, DeclareKind::Declared);
+        let old_def = scopes.def_sym("a".into(), shadow_def, DeclareKind::Declared, false);
         let shadow_use = scopes.use_sym("a".into()).unwrap();
 
         assert!(old_def.is_none());
@@ -95,7 +95,7 @@ fn test_ident_declare_no_shadow() {
 
     // Outer declare
     let outer_def = defs.next();
-    let old_def = scopes.def_sym("a".into(), outer_def, DeclareKind::Declared);
+    let old_def = scopes.def_sym("a".into(), outer_def, DeclareKind::Declared, false);
     let outer_use = scopes.use_sym("a".into()).unwrap();
 
     // No shadowing should be done, outer_use should match outer_def,
@@ -109,7 +109,7 @@ fn test_ident_declare_no_shadow() {
 
 #[test]
 fn test_use_undefined() {
-    let mut scopes = ScopeTracker::new(Default::default());
+    let mut scopes = ScopeTracker::new();
 
     let def_id = scopes.use_sym("a".into());
 
@@ -120,7 +120,7 @@ fn test_use_undefined() {
 #[test]
 fn test_use_shared_undefined() {
     // Undeclared syms should be hoisted to the top-most import boundary
-    let mut scopes = ScopeTracker::new(Default::default());
+    let mut scopes = ScopeTracker::new();
 
     // Don't contaminate root scope
     scopes.with_scope(true, |scopes| {
@@ -152,12 +152,12 @@ fn test_use_shared_undefined() {
 #[test]
 fn test_use_import() {
     // External identifiers should be imported into the current scope (i.e share the same LocalDefId)
-    let mut scopes = ScopeTracker::new(Default::default());
+    let mut scopes = ScopeTracker::new();
     let mut defs = LocalDefAlloc::default();
 
     // Root declare
     let declare_id = defs.next();
-    scopes.def_sym("a".into(), declare_id, DeclareKind::Declared);
+    scopes.def_sym("a".into(), declare_id, DeclareKind::Declared, false);
 
     // Inner use
     scopes.with_scope(false, |scopes| {
@@ -170,18 +170,20 @@ fn test_use_import() {
 
 #[test]
 fn test_import_boundaries() {
-    let mut pv_tracker = PervasiveTracker::default();
     let mut defs = LocalDefAlloc::default();
 
     let non_pervasive = defs.next();
     let pervasive = defs.next();
 
-    pv_tracker.mark_pervasive(pervasive);
-
     // Declare some external identifiers
-    let mut scopes = ScopeTracker::new(pv_tracker);
-    scopes.def_sym("non_pervasive".into(), non_pervasive, DeclareKind::Declared);
-    scopes.def_sym("pervasive".into(), pervasive, DeclareKind::Declared);
+    let mut scopes = ScopeTracker::new();
+    scopes.def_sym(
+        "non_pervasive".into(),
+        non_pervasive,
+        DeclareKind::Declared,
+        false,
+    );
+    scopes.def_sym("pervasive".into(), pervasive, DeclareKind::Declared, true);
 
     // Make an inner block
     scopes.with_scope(false, |scopes| {
@@ -215,7 +217,7 @@ fn test_import_boundaries() {
 
 #[test]
 fn test_forward_declare() {
-    let mut scopes = ScopeTracker::new(Default::default());
+    let mut scopes = ScopeTracker::new();
     let mut defs = LocalDefAlloc::default();
 
     let forward_def = defs.next();
@@ -223,12 +225,14 @@ fn test_forward_declare() {
         "fwd".into(),
         forward_def,
         DeclareKind::Forward(ForwardKind::Type, None),
+        false,
     );
     let resolve_def = defs.next();
     scopes.def_sym(
         "fwd".into(),
         resolve_def,
         DeclareKind::Resolved(ForwardKind::Type),
+        false,
     );
 
     assert_eq!(scopes.use_sym("fwd".into()).unwrap(), resolve_def);
@@ -242,7 +246,7 @@ fn test_forward_declare() {
 fn test_forward_declare_double() {
     // Forward declares in the same scope should be captured
     // when resolving them
-    let mut scopes = ScopeTracker::new(Default::default());
+    let mut scopes = ScopeTracker::new();
     let mut defs = LocalDefAlloc::default();
 
     let forward_def0 = defs.next();
@@ -250,12 +254,14 @@ fn test_forward_declare_double() {
         "fwd".into(),
         forward_def0,
         DeclareKind::Forward(ForwardKind::Type, None),
+        false,
     );
     let forward_def1 = defs.next();
     scopes.def_sym(
         "fwd".into(),
         forward_def1,
         DeclareKind::Forward(ForwardKind::Type, None),
+        false,
     );
 
     let resolve_def = defs.next();
@@ -263,6 +269,7 @@ fn test_forward_declare_double() {
         "fwd".into(),
         resolve_def,
         DeclareKind::Resolved(ForwardKind::Type),
+        false,
     );
 
     assert_eq!(scopes.use_sym("fwd".into()).unwrap(), resolve_def);
@@ -275,7 +282,7 @@ fn test_forward_declare_double() {
 #[test]
 fn test_forward_declare_overwritten() {
     // Later forward declares of different types should replace old forward lists
-    let mut scopes = ScopeTracker::new(Default::default());
+    let mut scopes = ScopeTracker::new();
     let mut defs = LocalDefAlloc::default();
 
     let forward_type = defs.next();
@@ -286,17 +293,20 @@ fn test_forward_declare_overwritten() {
         "fwd".into(),
         forward_type,
         DeclareKind::Forward(ForwardKind::Type, None),
+        false,
     );
     scopes.def_sym(
         "fwd".into(),
         forward_proc,
         DeclareKind::Forward(ForwardKind::_Procedure, None),
+        false,
     );
 
     scopes.def_sym(
         "fwd".into(),
         resolve_def,
         DeclareKind::Resolved(ForwardKind::Type),
+        false,
     );
 
     assert_eq!(scopes.use_sym("fwd".into()).unwrap(), resolve_def);
@@ -309,7 +319,7 @@ fn test_forward_declare_overwritten() {
 #[test]
 fn test_forward_declare_overwritten_normal() {
     // Normal declarations should overwrite forward lists
-    let mut scopes = ScopeTracker::new(Default::default());
+    let mut scopes = ScopeTracker::new();
     let mut defs = LocalDefAlloc::default();
 
     let forward_type = defs.next();
@@ -320,13 +330,15 @@ fn test_forward_declare_overwritten_normal() {
         "fwd".into(),
         forward_type,
         DeclareKind::Forward(ForwardKind::Type, None),
+        false,
     );
-    scopes.def_sym("fwd".into(), normal_def, DeclareKind::Declared);
+    scopes.def_sym("fwd".into(), normal_def, DeclareKind::Declared, false);
 
     scopes.def_sym(
         "fwd".into(),
         resolve_def,
         DeclareKind::Resolved(ForwardKind::Type),
+        false,
     );
 
     assert_eq!(scopes.use_sym("fwd".into()), Some(resolve_def));
@@ -341,22 +353,20 @@ fn test_forward_resolve_only_same_scope() {
     // Forward declares are only resolved in the same scope,
     // doesn't matter if it's an import boundary,
     // doesn't matter if the identifier is pervasive or not
-    let mut pv_tracker = PervasiveTracker::default();
     let mut defs = LocalDefAlloc::default();
 
     let forward_def = defs.next();
     let inner_def = defs.next();
     let resolve_def = defs.next();
 
-    pv_tracker.mark_pervasive(forward_def);
-
-    let mut scopes = ScopeTracker::new(pv_tracker);
+    let mut scopes = ScopeTracker::new();
 
     // def scope def
     scopes.def_sym(
         "fwd".into(),
         forward_def,
         DeclareKind::Forward(ForwardKind::Type, None),
+        true,
     );
 
     // Not import boundary
@@ -365,6 +375,7 @@ fn test_forward_resolve_only_same_scope() {
             "fwd".into(),
             inner_def,
             DeclareKind::Forward(ForwardKind::Type, None),
+            false,
         );
 
         assert_eq!(
@@ -379,6 +390,7 @@ fn test_forward_resolve_only_same_scope() {
             "fwd".into(),
             inner_def,
             DeclareKind::Forward(ForwardKind::Type, None),
+            false,
         );
 
         assert_eq!(
@@ -391,6 +403,7 @@ fn test_forward_resolve_only_same_scope() {
         "fwd".into(),
         resolve_def,
         DeclareKind::Resolved(ForwardKind::Type),
+        false,
     );
 
     assert_eq!(scopes.use_sym("fwd".into()), Some(resolve_def));
@@ -403,17 +416,14 @@ fn test_forward_resolve_only_same_scope() {
 #[test]
 fn test_import_def_no_boundary() {
     // import ---
-    let mut pv_tracker = PervasiveTracker::default();
     let mut defs = LocalDefAlloc::default();
 
     // shouldn't be peeked at from SurroundingScope
     // should be peeked at from CurrentScope
     let a_def = defs.next();
 
-    pv_tracker.mark_pervasive(a_def);
-
-    let mut scopes = ScopeTracker::new(pv_tracker);
-    scopes.def_sym("a".into(), a_def, DeclareKind::Declared);
+    let mut scopes = ScopeTracker::new();
+    scopes.def_sym("a".into(), a_def, DeclareKind::Declared, true);
 
     assert_eq!(scopes.import_sym("a".into()), None);
 }
@@ -421,7 +431,6 @@ fn test_import_def_no_boundary() {
 #[test]
 fn test_import_def_between_boundaries() {
     // import --- import -*- import
-    let mut pv_tracker = PervasiveTracker::default();
     let mut defs = LocalDefAlloc::default();
 
     let outer_pv = defs.next();
@@ -429,19 +438,17 @@ fn test_import_def_between_boundaries() {
     let middle = defs.next();
     let inner = defs.next();
 
-    pv_tracker.mark_pervasive(outer_pv);
-
-    let mut scopes = ScopeTracker::new(pv_tracker);
-    scopes.def_sym("outer_pv".into(), outer_pv, DeclareKind::Declared);
-    scopes.def_sym("outer".into(), outer, DeclareKind::Declared);
+    let mut scopes = ScopeTracker::new();
+    scopes.def_sym("outer_pv".into(), outer_pv, DeclareKind::Declared, true);
+    scopes.def_sym("outer".into(), outer, DeclareKind::Declared, false);
 
     scopes.push_scope(ScopeKind::Module);
     {
-        scopes.def_sym("middle".into(), middle, DeclareKind::Declared);
+        scopes.def_sym("middle".into(), middle, DeclareKind::Declared, false);
 
         scopes.push_scope(ScopeKind::Module);
         {
-            scopes.def_sym("inner".into(), inner, DeclareKind::Declared);
+            scopes.def_sym("inner".into(), inner, DeclareKind::Declared, false);
 
             // outer_pv visible
             assert_eq!(scopes.import_sym("outer_pv".into()), Some(outer_pv));
@@ -464,7 +471,6 @@ fn test_import_def_implicit_boundary() {
     // --- explicit -*- implicit
     // --- implicit -*- implicit (never encountered, would do scope hopping)
     // --- implicit -*- explicit
-    let mut pv_tracker = PervasiveTracker::default();
     let mut defs = LocalDefAlloc::default();
 
     let outer_pv = defs.next();
@@ -472,19 +478,17 @@ fn test_import_def_implicit_boundary() {
     let middle = defs.next();
     let inner = defs.next();
 
-    pv_tracker.mark_pervasive(outer_pv);
-
-    let mut scopes = ScopeTracker::new(pv_tracker);
-    scopes.def_sym("outer_pv".into(), outer_pv, DeclareKind::Declared);
-    scopes.def_sym("outer".into(), outer, DeclareKind::Declared);
+    let mut scopes = ScopeTracker::new();
+    scopes.def_sym("outer_pv".into(), outer_pv, DeclareKind::Declared, true);
+    scopes.def_sym("outer".into(), outer, DeclareKind::Declared, false);
 
     scopes.push_scope(ScopeKind::Module);
     {
-        scopes.def_sym("middle".into(), middle, DeclareKind::Declared);
+        scopes.def_sym("middle".into(), middle, DeclareKind::Declared, false);
 
         scopes.push_scope(ScopeKind::Subprogram);
         {
-            scopes.def_sym("inner".into(), inner, DeclareKind::Declared);
+            scopes.def_sym("inner".into(), inner, DeclareKind::Declared, false);
 
             // outer_pv visible
             assert_eq!(scopes.import_sym("outer_pv".into()), Some(outer_pv));

--- a/compiler/toc_hir_lowering/tests/lowering.rs
+++ b/compiler/toc_hir_lowering/tests/lowering.rs
@@ -1709,3 +1709,161 @@ fn intro_import_defs_subprogram() {
     end _",
     );
 }
+
+#[test]
+fn intro_assoc_unqualifieds_module() {
+    // Making sure that it works
+    assert_lower(
+        "
+module _
+    export ~. waw
+    module waw
+        export ~. var sus
+        var sus : int
+    end waw
+end _
+
+module target
+    import waw
+    sus := 1
+end target
+    ",
+    );
+
+    // Making sure that we give good error reporting against
+    // - over previous import
+    assert_lower(
+        "
+module wrap
+    export ~. unquali
+    module unquali
+        export ~. uwu
+        var uwu : int
+    end unquali
+end wrap
+
+var uwu : int
+module target
+    import uwu, unquali
+end target
+    ",
+    );
+
+    // - over previous unqualified import
+    assert_lower(
+        "
+module wrapA
+    export ~.a
+    module a
+        export ~. var uwu
+        var uwu : int
+    end a
+end wrapA
+
+module wrapB
+    export ~.b
+    module b
+        export ~. var uwu
+        var uwu : int
+    end b
+end wrapB
+
+module target
+    import a, b
+end target
+    ",
+    );
+
+    // - over pervasive
+    assert_lower(
+        "
+module wrap
+    export ~. unquali
+    module unquali
+        export ~. uwu
+        var uwu : int
+    end unquali
+end wrap
+
+var * uwu : int
+module target
+    import unquali
+end target
+    ",
+    );
+
+    // - over previously declared
+    assert_lower(
+        "
+module wrap
+    export ~. unquali
+    module unquali
+        export ~. uwu
+        var uwu : int
+    end unquali
+end wrap
+
+module uwu
+    import unquali
+end uwu
+    ",
+    );
+
+    // In the same import
+    assert_lower(
+        "
+module wrap
+    export ~. uwu
+    module uwu
+        export ~. uwu
+        var uwu : int
+    end uwu
+end wrap
+
+module target
+    import uwu
+end target
+    ",
+    );
+
+    // being declared over by the same import
+    assert_lower(
+        "
+module wrap
+    export ~. unquali
+    module unquali
+        export ~. uwu
+        var uwu : int
+    end unquali
+end wrap
+
+module target
+    import unquali
+
+    var uwu : int
+end target
+    ",
+    );
+
+    // being declared over by a new unqualified
+    assert_lower(
+        "
+module wrap
+    export ~. unquali
+    module unquali
+        export ~. uwu
+        var uwu : int
+    end unquali
+end wrap
+
+module target
+    import unquali
+
+    module wa
+        export ~. uwu
+        var uwu : int
+    end wa
+end target
+    ",
+    );
+}

--- a/compiler/toc_hir_lowering/tests/lowering.rs
+++ b/compiler/toc_hir_lowering/tests/lowering.rs
@@ -921,6 +921,9 @@ fn lower_procedure_def() {
 
     // Missing both names
     assert_lower("proc end");
+
+    // Make sure extra is resolved
+    assert_lower("var lmao : int proc uwu : lmao end uwu");
 }
 
 #[test]
@@ -1065,6 +1068,9 @@ fn lower_process_def() {
 
     // Missing both names
     assert_lower("process end");
+
+    // Make sure extra is resolved
+    assert_lower("var lmao : int process uwu : lmao end uwu");
 }
 
 #[test]

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__intro_assoc_unqualifieds_module-2.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__intro_assoc_unqualifieds_module-2.snap
@@ -1,0 +1,30 @@
+---
+source: compiler/toc_hir_lowering/tests/lowering.rs
+expression: "\nmodule wrap\n    export ~. unquali\n    module unquali\n        export ~. uwu\n        var uwu : int\n    end unquali\nend wrap\n\nvar uwu : int\nmodule target\n    import uwu, unquali\nend target\n    "
+---
+Library@(dummy)
+  Root@(dummy): FileId(1) -> ItemId(7)
+    Module@(FileId(1), 0..191): "<root>"@(dummy)
+      StmtBody@(FileId(1), 1..186): []
+        StmtItem@(FileId(1), 1..122): ItemId(2)
+          Module@(FileId(1), 1..122): "wrap"@(FileId(1), 8..12), exports [Const Unqualified local("unquali"@(FileId(1), 46..53))]
+            StmtBody@(FileId(1), 39..113): []
+              StmtItem@(FileId(1), 39..113): ItemId(1)
+                Module@(FileId(1), 39..113): "unquali"@(FileId(1), 46..53), exports [Const Unqualified local("uwu"@(FileId(1), 88..91))]
+                  StmtBody@(FileId(1), 84..97): []
+                    StmtItem@(FileId(1), 84..97): ItemId(0)
+                      ConstVar@(FileId(1), 84..97): var "uwu"@(FileId(1), 88..91)
+                        Primitive@(FileId(1), 94..97): Int
+        StmtItem@(FileId(1), 124..137): ItemId(3)
+          ConstVar@(FileId(1), 124..137): var "uwu"@(FileId(1), 128..131)
+            Primitive@(FileId(1), 134..137): Int
+        StmtItem@(FileId(1), 138..186): ItemId(6)
+          Module@(FileId(1), 138..186): "target"@(FileId(1), 145..151)
+            Import@(FileId(1), 163..166): SameAsItem local("uwu"@(FileId(1), 128..131))
+            Import@(FileId(1), 168..175): SameAsItem local("unquali"@(FileId(1), 27..34))
+            StmtBody@(FileId(1), 176..176): []
+error in file FileId(1) at 168..175: `uwu` is already declared in this scope
+| note in file FileId(1) for 163..166: `uwu` previously imported here
+| error in file FileId(1) for 168..175: `uwu` is an unqualified export of `unquali`
+| info: importing a class or module also imports its unqualified exports
+

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__intro_assoc_unqualifieds_module-3.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__intro_assoc_unqualifieds_module-3.snap
@@ -1,0 +1,36 @@
+---
+source: compiler/toc_hir_lowering/tests/lowering.rs
+expression: "\nmodule wrapA\n    export ~.a\n    module a\n        export ~. var uwu\n        var uwu : int\n    end a\nend wrapA\n\nmodule wrapB\n    export ~.b\n    module b\n        export ~. var uwu\n        var uwu : int\n    end b\nend wrapB\n\nmodule target\n    import a, b\nend target\n    "
+---
+Library@(dummy)
+  Root@(dummy): FileId(1) -> ItemId(9)
+    Module@(FileId(1), 0..266): "<root>"@(dummy)
+      StmtBody@(FileId(1), 1..261): []
+        StmtItem@(FileId(1), 1..109): ItemId(2)
+          Module@(FileId(1), 1..109): "wrapA"@(FileId(1), 8..13), exports [Const Unqualified local("a"@(FileId(1), 40..41))]
+            StmtBody@(FileId(1), 33..99): []
+              StmtItem@(FileId(1), 33..99): ItemId(1)
+                Module@(FileId(1), 33..99): "a"@(FileId(1), 40..41), exports [Var Unqualified local("uwu"@(FileId(1), 80..83))]
+                  StmtBody@(FileId(1), 76..89): []
+                    StmtItem@(FileId(1), 76..89): ItemId(0)
+                      ConstVar@(FileId(1), 76..89): var "uwu"@(FileId(1), 80..83)
+                        Primitive@(FileId(1), 86..89): Int
+        StmtItem@(FileId(1), 111..219): ItemId(5)
+          Module@(FileId(1), 111..219): "wrapB"@(FileId(1), 118..123), exports [Const Unqualified local("b"@(FileId(1), 150..151))]
+            StmtBody@(FileId(1), 143..209): []
+              StmtItem@(FileId(1), 143..209): ItemId(4)
+                Module@(FileId(1), 143..209): "b"@(FileId(1), 150..151), exports [Var Unqualified local("uwu"@(FileId(1), 190..193))]
+                  StmtBody@(FileId(1), 186..199): []
+                    StmtItem@(FileId(1), 186..199): ItemId(3)
+                      ConstVar@(FileId(1), 186..199): var "uwu"@(FileId(1), 190..193)
+                        Primitive@(FileId(1), 196..199): Int
+        StmtItem@(FileId(1), 221..261): ItemId(8)
+          Module@(FileId(1), 221..261): "target"@(FileId(1), 228..234)
+            Import@(FileId(1), 246..247): SameAsItem local("a"@(FileId(1), 27..28))
+            Import@(FileId(1), 249..250): SameAsItem local("b"@(FileId(1), 137..138))
+            StmtBody@(FileId(1), 251..251): []
+error in file FileId(1) at 246..247: `uwu` is already declared in this scope
+| note in file FileId(1) for 246..247: `a` has an unqualified export named `uwu`
+| error in file FileId(1) for 249..250: `b` also has an unqualified export named `uwu`
+| info: importing a class or module also imports its unqualified exports
+

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__intro_assoc_unqualifieds_module-4.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__intro_assoc_unqualifieds_module-4.snap
@@ -1,0 +1,29 @@
+---
+source: compiler/toc_hir_lowering/tests/lowering.rs
+expression: "\nmodule wrap\n    export ~. unquali\n    module unquali\n        export ~. uwu\n        var uwu : int\n    end unquali\nend wrap\n\nvar * uwu : int\nmodule target\n    import unquali\nend target\n    "
+---
+Library@(dummy)
+  Root@(dummy): FileId(1) -> ItemId(6)
+    Module@(FileId(1), 0..188): "<root>"@(dummy)
+      StmtBody@(FileId(1), 1..183): []
+        StmtItem@(FileId(1), 1..122): ItemId(2)
+          Module@(FileId(1), 1..122): "wrap"@(FileId(1), 8..12), exports [Const Unqualified local("unquali"@(FileId(1), 46..53))]
+            StmtBody@(FileId(1), 39..113): []
+              StmtItem@(FileId(1), 39..113): ItemId(1)
+                Module@(FileId(1), 39..113): "unquali"@(FileId(1), 46..53), exports [Const Unqualified local("uwu"@(FileId(1), 88..91))]
+                  StmtBody@(FileId(1), 84..97): []
+                    StmtItem@(FileId(1), 84..97): ItemId(0)
+                      ConstVar@(FileId(1), 84..97): var "uwu"@(FileId(1), 88..91)
+                        Primitive@(FileId(1), 94..97): Int
+        StmtItem@(FileId(1), 124..139): ItemId(3)
+          ConstVar@(FileId(1), 124..139): var "uwu"@(FileId(1), 130..133)
+            Primitive@(FileId(1), 136..139): Int
+        StmtItem@(FileId(1), 140..183): ItemId(5)
+          Module@(FileId(1), 140..183): "target"@(FileId(1), 147..153)
+            Import@(FileId(1), 165..172): SameAsItem local("unquali"@(FileId(1), 27..34))
+            StmtBody@(FileId(1), 173..173): []
+error in file FileId(1) at 165..172: `uwu` is already declared in this scope
+| note in file FileId(1) for 130..133: `uwu` previously declared here
+| error in file FileId(1) for 165..172: `uwu` is an unqualified export of `unquali`
+| info: importing a class or module also imports its unqualified exports
+

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__intro_assoc_unqualifieds_module-5.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__intro_assoc_unqualifieds_module-5.snap
@@ -1,0 +1,26 @@
+---
+source: compiler/toc_hir_lowering/tests/lowering.rs
+expression: "\nmodule wrap\n    export ~. unquali\n    module unquali\n        export ~. uwu\n        var uwu : int\n    end unquali\nend wrap\n\nmodule uwu\n    import unquali\nend uwu\n    "
+---
+Library@(dummy)
+  Root@(dummy): FileId(1) -> ItemId(5)
+    Module@(FileId(1), 0..166): "<root>"@(dummy)
+      StmtBody@(FileId(1), 1..161): []
+        StmtItem@(FileId(1), 1..122): ItemId(2)
+          Module@(FileId(1), 1..122): "wrap"@(FileId(1), 8..12), exports [Const Unqualified local("unquali"@(FileId(1), 46..53))]
+            StmtBody@(FileId(1), 39..113): []
+              StmtItem@(FileId(1), 39..113): ItemId(1)
+                Module@(FileId(1), 39..113): "unquali"@(FileId(1), 46..53), exports [Const Unqualified local("uwu"@(FileId(1), 88..91))]
+                  StmtBody@(FileId(1), 84..97): []
+                    StmtItem@(FileId(1), 84..97): ItemId(0)
+                      ConstVar@(FileId(1), 84..97): var "uwu"@(FileId(1), 88..91)
+                        Primitive@(FileId(1), 94..97): Int
+        StmtItem@(FileId(1), 124..161): ItemId(4)
+          Module@(FileId(1), 124..161): "uwu"@(FileId(1), 131..134)
+            Import@(FileId(1), 146..153): SameAsItem local("unquali"@(FileId(1), 27..34))
+            StmtBody@(FileId(1), 154..154): []
+error in file FileId(1) at 146..153: `uwu` is already declared in this scope
+| note in file FileId(1) for 131..134: `uwu` previously declared here
+| error in file FileId(1) for 146..153: `uwu` is an unqualified export of `unquali`
+| info: importing a class or module also imports its unqualified exports
+

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__intro_assoc_unqualifieds_module-6.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__intro_assoc_unqualifieds_module-6.snap
@@ -1,0 +1,30 @@
+---
+source: compiler/toc_hir_lowering/tests/lowering.rs
+expression: "\nmodule wrap\n    export ~. uwu\n    module uwu\n        export ~. uwu\n        var uwu : int\n    end uwu\nend wrap\n\nmodule target\n    import uwu\nend target\n    "
+---
+Library@(dummy)
+  Root@(dummy): FileId(1) -> ItemId(5)
+    Module@(FileId(1), 0..156): "<root>"@(dummy)
+      StmtBody@(FileId(1), 1..151): []
+        StmtItem@(FileId(1), 1..110): ItemId(2)
+          Module@(FileId(1), 1..110): "wrap"@(FileId(1), 8..12), exports [Const Unqualified local("uwu"@(FileId(1), 42..45))]
+            StmtBody@(FileId(1), 35..101): []
+              StmtItem@(FileId(1), 35..101): ItemId(1)
+                Module@(FileId(1), 35..101): "uwu"@(FileId(1), 42..45), exports [Const Unqualified local("uwu"@(FileId(1), 80..83))]
+                  StmtBody@(FileId(1), 76..89): []
+                    StmtItem@(FileId(1), 76..89): ItemId(0)
+                      ConstVar@(FileId(1), 76..89): var "uwu"@(FileId(1), 80..83)
+                        Primitive@(FileId(1), 86..89): Int
+        StmtItem@(FileId(1), 112..151): ItemId(4)
+          Module@(FileId(1), 112..151): "target"@(FileId(1), 119..125)
+            Import@(FileId(1), 137..140): SameAsItem local("uwu"@(FileId(1), 27..30))
+            StmtBody@(FileId(1), 141..141): []
+error in file FileId(1) at 80..83: `uwu` is already declared in this scope
+| note in file FileId(1) for 42..45: `uwu` previously declared here
+| error in file FileId(1) for 80..83: `uwu` redeclared here
+error in file FileId(1) at 80..83: `uwu` is already declared in the parent scope
+| note in file FileId(1) for 42..45: `uwu` previously declared here
+| error in file FileId(1) for 64..67: `uwu` exported unqualified from here
+error in file FileId(1) at 137..140: `uwu` is already declared in this import
+| error in file FileId(1) for 137..140: `uwu` is imported here, and it has an unqualified export of the same name
+

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__intro_assoc_unqualifieds_module-7.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__intro_assoc_unqualifieds_module-7.snap
@@ -1,0 +1,29 @@
+---
+source: compiler/toc_hir_lowering/tests/lowering.rs
+expression: "\nmodule wrap\n    export ~. unquali\n    module unquali\n        export ~. uwu\n        var uwu : int\n    end unquali\nend wrap\n\nmodule target\n    import unquali\n\n    var uwu : int\nend target\n    "
+---
+Library@(dummy)
+  Root@(dummy): FileId(1) -> ItemId(6)
+    Module@(FileId(1), 0..191): "<root>"@(dummy)
+      StmtBody@(FileId(1), 1..186): []
+        StmtItem@(FileId(1), 1..122): ItemId(2)
+          Module@(FileId(1), 1..122): "wrap"@(FileId(1), 8..12), exports [Const Unqualified local("unquali"@(FileId(1), 46..53))]
+            StmtBody@(FileId(1), 39..113): []
+              StmtItem@(FileId(1), 39..113): ItemId(1)
+                Module@(FileId(1), 39..113): "unquali"@(FileId(1), 46..53), exports [Const Unqualified local("uwu"@(FileId(1), 88..91))]
+                  StmtBody@(FileId(1), 84..97): []
+                    StmtItem@(FileId(1), 84..97): ItemId(0)
+                      ConstVar@(FileId(1), 84..97): var "uwu"@(FileId(1), 88..91)
+                        Primitive@(FileId(1), 94..97): Int
+        StmtItem@(FileId(1), 124..186): ItemId(5)
+          Module@(FileId(1), 124..186): "target"@(FileId(1), 131..137)
+            Import@(FileId(1), 149..156): SameAsItem local("unquali"@(FileId(1), 27..34))
+            StmtBody@(FileId(1), 162..175): []
+              StmtItem@(FileId(1), 162..175): ItemId(4)
+                ConstVar@(FileId(1), 162..175): var "uwu"@(FileId(1), 166..169)
+                  Primitive@(FileId(1), 172..175): Int
+error in file FileId(1) at 166..169: `uwu` is already declared in this scope
+| note in file FileId(1) for 149..156: `uwu` is an unqualified import from `unquali`
+| error in file FileId(1) for 166..169: `uwu` redeclared here
+| info: importing a class or module also imports its unqualified exports
+

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__intro_assoc_unqualifieds_module-8.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__intro_assoc_unqualifieds_module-8.snap
@@ -1,0 +1,32 @@
+---
+source: compiler/toc_hir_lowering/tests/lowering.rs
+expression: "\nmodule wrap\n    export ~. unquali\n    module unquali\n        export ~. uwu\n        var uwu : int\n    end unquali\nend wrap\n\nmodule target\n    import unquali\n\n    module wa\n        export ~. uwu\n        var uwu : int\n    end wa\nend target\n    "
+---
+Library@(dummy)
+  Root@(dummy): FileId(1) -> ItemId(7)
+    Module@(FileId(1), 0..242): "<root>"@(dummy)
+      StmtBody@(FileId(1), 1..237): []
+        StmtItem@(FileId(1), 1..122): ItemId(2)
+          Module@(FileId(1), 1..122): "wrap"@(FileId(1), 8..12), exports [Const Unqualified local("unquali"@(FileId(1), 46..53))]
+            StmtBody@(FileId(1), 39..113): []
+              StmtItem@(FileId(1), 39..113): ItemId(1)
+                Module@(FileId(1), 39..113): "unquali"@(FileId(1), 46..53), exports [Const Unqualified local("uwu"@(FileId(1), 88..91))]
+                  StmtBody@(FileId(1), 84..97): []
+                    StmtItem@(FileId(1), 84..97): ItemId(0)
+                      ConstVar@(FileId(1), 84..97): var "uwu"@(FileId(1), 88..91)
+                        Primitive@(FileId(1), 94..97): Int
+        StmtItem@(FileId(1), 124..237): ItemId(6)
+          Module@(FileId(1), 124..237): "target"@(FileId(1), 131..137)
+            Import@(FileId(1), 149..156): SameAsItem local("unquali"@(FileId(1), 27..34))
+            StmtBody@(FileId(1), 162..226): []
+              StmtItem@(FileId(1), 162..226): ItemId(5)
+                Module@(FileId(1), 162..226): "wa"@(FileId(1), 169..171), exports [Const Unqualified local("uwu"@(FileId(1), 206..209))]
+                  StmtBody@(FileId(1), 202..215): []
+                    StmtItem@(FileId(1), 202..215): ItemId(4)
+                      ConstVar@(FileId(1), 202..215): var "uwu"@(FileId(1), 206..209)
+                        Primitive@(FileId(1), 212..215): Int
+error in file FileId(1) at 206..209: `uwu` is already declared in the parent scope
+| note in file FileId(1) for 149..156: `uwu` is an unqualified import from `unquali`
+| error in file FileId(1) for 190..193: `uwu` exported unqualified from here
+| info: importing a class or module also imports its unqualified exports
+

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__intro_assoc_unqualifieds_module.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__intro_assoc_unqualifieds_module.snap
@@ -1,0 +1,25 @@
+---
+source: compiler/toc_hir_lowering/tests/lowering.rs
+expression: "\nmodule _\n    export ~. waw\n    module waw\n        export ~. var sus\n        var sus : int\n    end waw\nend _\n\nmodule target\n    import waw\n    sus := 1\nend target\n    "
+---
+Library@(dummy)
+  Root@(dummy): FileId(1) -> ItemId(5)
+    Module@(FileId(1), 0..167): "<root>"@(dummy)
+      StmtBody@(FileId(1), 1..162): []
+        StmtItem@(FileId(1), 1..108): ItemId(2)
+          Module@(FileId(1), 1..108): "_"@(FileId(1), 8..9), exports [Const Unqualified local("waw"@(FileId(1), 39..42))]
+            StmtBody@(FileId(1), 32..102): []
+              StmtItem@(FileId(1), 32..102): ItemId(1)
+                Module@(FileId(1), 32..102): "waw"@(FileId(1), 39..42), exports [Var Unqualified local("sus"@(FileId(1), 81..84))]
+                  StmtBody@(FileId(1), 77..90): []
+                    StmtItem@(FileId(1), 77..90): ItemId(0)
+                      ConstVar@(FileId(1), 77..90): var "sus"@(FileId(1), 81..84)
+                        Primitive@(FileId(1), 87..90): Int
+        StmtItem@(FileId(1), 110..162): ItemId(4)
+          Module@(FileId(1), 110..162): "target"@(FileId(1), 117..123)
+            Import@(FileId(1), 135..138): SameAsItem local("waw"@(FileId(1), 24..27))
+            StmtBody@(FileId(1), 143..151): []
+              Assign@(FileId(1), 143..151)
+                Name@(FileId(1), 143..146): "sus"@(FileId(1), 65..68)
+                Literal@(FileId(1), 150..151): Integer(1)
+

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__intro_import_defs_module-2.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__intro_import_defs_module-2.snap
@@ -11,6 +11,6 @@ Library@(dummy)
             Primitive@(FileId(1), 17..20): Int
         StmtItem@(FileId(1), 25..64): ItemId(2)
           Module@(FileId(1), 25..64): "_"@(FileId(1), 32..33)
-            Import@(FileId(1), 49..54): SameAsItem "a_def"@(FileId(1), 49..54)
+            Import@(FileId(1), 49..54): SameAsItem local("a_def"@(FileId(1), 9..14))
             StmtBody@(FileId(1), 59..59): []
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__intro_import_defs_module-3.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__intro_import_defs_module-3.snap
@@ -11,7 +11,7 @@ Library@(dummy)
             Primitive@(FileId(1), 18..21): Int
         StmtItem@(FileId(1), 26..65): ItemId(2)
           Module@(FileId(1), 26..65): "_"@(FileId(1), 33..34)
-            Import@(FileId(1), 50..55): SameAsItem "p_def"@(FileId(1), 50..55)
+            Import@(FileId(1), 50..55): SameAsItem local("p_def"@(FileId(1), 10..15))
             StmtBody@(FileId(1), 60..60): []
 error in file FileId(1) at 50..55: `p_def` is already imported in this scope
 | note in file FileId(1) for 10..15: `p_def` declared pervasive here

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__intro_import_defs_module.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__intro_import_defs_module.snap
@@ -8,7 +8,7 @@ Library@(dummy)
       StmtBody@(FileId(1), 5..46): []
         StmtItem@(FileId(1), 5..46): ItemId(1)
           Module@(FileId(1), 5..46): "_"@(FileId(1), 12..13)
-            Import@(FileId(1), 29..36): SameAsItem "nothing"@(FileId(1), 29..36)
+            Import@(FileId(1), 29..36): SameAsItem unresolved
             StmtBody@(FileId(1), 41..41): []
 error in file FileId(1) at 29..36: `nothing` could not be imported
 | error in file FileId(1) for 29..36: no definitions of `nothing` found in the surrounding scope

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__intro_import_defs_subprogram-2.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__intro_import_defs_subprogram-2.snap
@@ -12,6 +12,6 @@ Library@(dummy)
         StmtItem@(FileId(1), 25..62): ItemId(2)
           Subprogram@(FileId(1), 25..62): "_"@(FileId(1), 30..31)
             Void@(FileId(1), 25..31)
-            Import@(FileId(1), 47..52): SameAsItem "a_def"@(FileId(1), 47..52)
+            Import@(FileId(1), 47..52): SameAsItem local("a_def"@(FileId(1), 9..14))
             StmtBody@(FileId(1), 57..57): []
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__intro_import_defs_subprogram-3.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__intro_import_defs_subprogram-3.snap
@@ -12,7 +12,7 @@ Library@(dummy)
         StmtItem@(FileId(1), 26..63): ItemId(2)
           Subprogram@(FileId(1), 26..63): "_"@(FileId(1), 31..32)
             Void@(FileId(1), 26..32)
-            Import@(FileId(1), 48..53): SameAsItem "p_def"@(FileId(1), 48..53)
+            Import@(FileId(1), 48..53): SameAsItem local("p_def"@(FileId(1), 10..15))
             StmtBody@(FileId(1), 58..58): []
 error in file FileId(1) at 48..53: `p_def` is already imported in this scope
 | note in file FileId(1) for 10..15: `p_def` declared pervasive here

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__intro_import_defs_subprogram.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__intro_import_defs_subprogram.snap
@@ -9,7 +9,7 @@ Library@(dummy)
         StmtItem@(FileId(1), 5..44): ItemId(1)
           Subprogram@(FileId(1), 5..44): "_"@(FileId(1), 10..11)
             Void@(FileId(1), 5..11)
-            Import@(FileId(1), 27..34): SameAsItem "nothing"@(FileId(1), 27..34)
+            Import@(FileId(1), 27..34): SameAsItem unresolved
             StmtBody@(FileId(1), 39..39): []
 error in file FileId(1) at 27..34: `nothing` could not be imported
 | error in file FileId(1) for 27..34: no definitions of `nothing` found in the surrounding scope

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_case_stmt-4.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_case_stmt-4.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler/toc_hir_lowering/tests/lowering.rs
 expression: "\n    case s of\n    label 1:\n        var a := a + 1\n    label 2, 3:\n        var a := a + 2\n    label 4:\n        var a := a + 3\n    end case\n    "
-
 ---
 Library@(dummy)
   Root@(dummy): FileId(1) -> ItemId(3)
@@ -22,14 +21,14 @@ Library@(dummy)
             ConstVar@(FileId(1), 75..89): var "a"@(FileId(1), 79..80)
               ExprBody@(FileId(1), 84..89)
                 Binary@(FileId(1), 84..89): Add
-                  Name@(FileId(1), 84..85): "a"@(FileId(1), 45..46), undeclared
+                  Name@(FileId(1), 84..85): "a"@(FileId(1), 84..85), undeclared
                   Literal@(FileId(1), 88..89): Integer(2)
           Literal@(FileId(1), 100..101): Integer(4)
           StmtItem@(FileId(1), 111..125): ItemId(2)
             ConstVar@(FileId(1), 111..125): var "a"@(FileId(1), 115..116)
               ExprBody@(FileId(1), 120..125)
                 Binary@(FileId(1), 120..125): Add
-                  Name@(FileId(1), 120..121): "a"@(FileId(1), 45..46), undeclared
+                  Name@(FileId(1), 120..121): "a"@(FileId(1), 120..121), undeclared
                   Literal@(FileId(1), 124..125): Integer(3)
 error in file FileId(1) at 10..11: `s` is undeclared
 | error in file FileId(1) for 10..11: no definitions of `s` are in scope

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_case_stmt-5.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_case_stmt-5.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler/toc_hir_lowering/tests/lowering.rs
 expression: "\n    case s of\n    label 1:\n        var a := a + 1\n    label 2, 3:\n        var a := a + 2\n    label 4:\n        var a := a + 3\n    label :\n        var a := a + 4\n    end case\n    "
-
 ---
 Library@(dummy)
   Root@(dummy): FileId(1) -> ItemId(4)
@@ -22,20 +21,20 @@ Library@(dummy)
             ConstVar@(FileId(1), 75..89): var "a"@(FileId(1), 79..80)
               ExprBody@(FileId(1), 84..89)
                 Binary@(FileId(1), 84..89): Add
-                  Name@(FileId(1), 84..85): "a"@(FileId(1), 45..46), undeclared
+                  Name@(FileId(1), 84..85): "a"@(FileId(1), 84..85), undeclared
                   Literal@(FileId(1), 88..89): Integer(2)
           Literal@(FileId(1), 100..101): Integer(4)
           StmtItem@(FileId(1), 111..125): ItemId(2)
             ConstVar@(FileId(1), 111..125): var "a"@(FileId(1), 115..116)
               ExprBody@(FileId(1), 120..125)
                 Binary@(FileId(1), 120..125): Add
-                  Name@(FileId(1), 120..121): "a"@(FileId(1), 45..46), undeclared
+                  Name@(FileId(1), 120..121): "a"@(FileId(1), 120..121), undeclared
                   Literal@(FileId(1), 124..125): Integer(3)
           StmtItem@(FileId(1), 146..160): ItemId(3)
             ConstVar@(FileId(1), 146..160): var "a"@(FileId(1), 150..151)
               ExprBody@(FileId(1), 155..160)
                 Binary@(FileId(1), 155..160): Add
-                  Name@(FileId(1), 155..156): "a"@(FileId(1), 45..46), undeclared
+                  Name@(FileId(1), 155..156): "a"@(FileId(1), 155..156), undeclared
                   Literal@(FileId(1), 159..160): Integer(4)
 error in file FileId(1) at 10..11: `s` is undeclared
 | error in file FileId(1) for 10..11: no definitions of `s` are in scope

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_case_stmt-6.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_case_stmt-6.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler/toc_hir_lowering/tests/lowering.rs
 expression: "\n    case s of\n    label 1:\n        var a := a + 1\n    label 2, 3:\n        var a := a + 2\n    label 4:\n        var a := a + 3\n    label :\n        var a := a + 4\n    label :\n        var a := a + 5\n    end case\n    "
-
 ---
 Library@(dummy)
   Root@(dummy): FileId(1) -> ItemId(5)
@@ -22,26 +21,26 @@ Library@(dummy)
             ConstVar@(FileId(1), 75..89): var "a"@(FileId(1), 79..80)
               ExprBody@(FileId(1), 84..89)
                 Binary@(FileId(1), 84..89): Add
-                  Name@(FileId(1), 84..85): "a"@(FileId(1), 45..46), undeclared
+                  Name@(FileId(1), 84..85): "a"@(FileId(1), 84..85), undeclared
                   Literal@(FileId(1), 88..89): Integer(2)
           Literal@(FileId(1), 100..101): Integer(4)
           StmtItem@(FileId(1), 111..125): ItemId(2)
             ConstVar@(FileId(1), 111..125): var "a"@(FileId(1), 115..116)
               ExprBody@(FileId(1), 120..125)
                 Binary@(FileId(1), 120..125): Add
-                  Name@(FileId(1), 120..121): "a"@(FileId(1), 45..46), undeclared
+                  Name@(FileId(1), 120..121): "a"@(FileId(1), 120..121), undeclared
                   Literal@(FileId(1), 124..125): Integer(3)
           StmtItem@(FileId(1), 146..160): ItemId(3)
             ConstVar@(FileId(1), 146..160): var "a"@(FileId(1), 150..151)
               ExprBody@(FileId(1), 155..160)
                 Binary@(FileId(1), 155..160): Add
-                  Name@(FileId(1), 155..156): "a"@(FileId(1), 45..46), undeclared
+                  Name@(FileId(1), 155..156): "a"@(FileId(1), 155..156), undeclared
                   Literal@(FileId(1), 159..160): Integer(4)
           StmtItem@(FileId(1), 181..195): ItemId(4)
             ConstVar@(FileId(1), 181..195): var "a"@(FileId(1), 185..186)
               ExprBody@(FileId(1), 190..195)
                 Binary@(FileId(1), 190..195): Add
-                  Name@(FileId(1), 190..191): "a"@(FileId(1), 45..46), undeclared
+                  Name@(FileId(1), 190..191): "a"@(FileId(1), 190..191), undeclared
                   Literal@(FileId(1), 194..195): Integer(5)
 error in file FileId(1) at 10..11: `s` is undeclared
 | error in file FileId(1) for 10..11: no definitions of `s` are in scope

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_case_stmt-7.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_case_stmt-7.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler/toc_hir_lowering/tests/lowering.rs
 expression: "\n    case s of\n    label 1:\n        var a := a + 1\n    label 2, 3:\n        var a := a + 2\n    label 4:\n        var a := a + 3\n    label :\n        var a := a + 4\n    label 5:\n        var a := a + 5\n    label 6:\n        var a := a + 6\n    end case\n    "
-
 ---
 Library@(dummy)
   Root@(dummy): FileId(1) -> ItemId(6)
@@ -22,34 +21,34 @@ Library@(dummy)
             ConstVar@(FileId(1), 75..89): var "a"@(FileId(1), 79..80)
               ExprBody@(FileId(1), 84..89)
                 Binary@(FileId(1), 84..89): Add
-                  Name@(FileId(1), 84..85): "a"@(FileId(1), 45..46), undeclared
+                  Name@(FileId(1), 84..85): "a"@(FileId(1), 84..85), undeclared
                   Literal@(FileId(1), 88..89): Integer(2)
           Literal@(FileId(1), 100..101): Integer(4)
           StmtItem@(FileId(1), 111..125): ItemId(2)
             ConstVar@(FileId(1), 111..125): var "a"@(FileId(1), 115..116)
               ExprBody@(FileId(1), 120..125)
                 Binary@(FileId(1), 120..125): Add
-                  Name@(FileId(1), 120..121): "a"@(FileId(1), 45..46), undeclared
+                  Name@(FileId(1), 120..121): "a"@(FileId(1), 120..121), undeclared
                   Literal@(FileId(1), 124..125): Integer(3)
           StmtItem@(FileId(1), 146..160): ItemId(3)
             ConstVar@(FileId(1), 146..160): var "a"@(FileId(1), 150..151)
               ExprBody@(FileId(1), 155..160)
                 Binary@(FileId(1), 155..160): Add
-                  Name@(FileId(1), 155..156): "a"@(FileId(1), 45..46), undeclared
+                  Name@(FileId(1), 155..156): "a"@(FileId(1), 155..156), undeclared
                   Literal@(FileId(1), 159..160): Integer(4)
           Literal@(FileId(1), 171..172): Integer(5)
           StmtItem@(FileId(1), 182..196): ItemId(4)
             ConstVar@(FileId(1), 182..196): var "a"@(FileId(1), 186..187)
               ExprBody@(FileId(1), 191..196)
                 Binary@(FileId(1), 191..196): Add
-                  Name@(FileId(1), 191..192): "a"@(FileId(1), 45..46), undeclared
+                  Name@(FileId(1), 191..192): "a"@(FileId(1), 191..192), undeclared
                   Literal@(FileId(1), 195..196): Integer(5)
           Literal@(FileId(1), 207..208): Integer(6)
           StmtItem@(FileId(1), 218..232): ItemId(5)
             ConstVar@(FileId(1), 218..232): var "a"@(FileId(1), 222..223)
               ExprBody@(FileId(1), 227..232)
                 Binary@(FileId(1), 227..232): Add
-                  Name@(FileId(1), 227..228): "a"@(FileId(1), 45..46), undeclared
+                  Name@(FileId(1), 227..228): "a"@(FileId(1), 227..228), undeclared
                   Literal@(FileId(1), 231..232): Integer(6)
 error in file FileId(1) at 10..11: `s` is undeclared
 | error in file FileId(1) for 10..11: no definitions of `s` are in scope

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_formals_use_name.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_formals_use_name.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler/toc_hir_lowering/tests/lowering.rs
-assertion_line: 59
 expression: "type i : int proc u (j : i) end u"
-
 ---
 Library@(dummy)
   Root@(dummy): FileId(1) -> ItemId(2)
@@ -13,7 +11,7 @@ Library@(dummy)
             Primitive@(FileId(1), 9..12): Int
         StmtItem@(FileId(1), 13..33): ItemId(1)
           Subprogram@(FileId(1), 13..33): "u"@(FileId(1), 18..19) ["j"@(FileId(1), 21..22)]
-            Alias@(FileId(1), 25..26): "i"@(FileId(1), 5..6), resolved(Type)
+            Alias@(FileId(1), 25..26): "i"@(FileId(1), 5..6)
             Void@(FileId(1), 13..27)
             StmtBody@(FileId(1), 28..28): ["j"@(FileId(1), 21..22)]
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_get_stmt-4.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_get_stmt-4.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler/toc_hir_lowering/tests/lowering.rs
 expression: get a*a
-
 ---
 Library@(dummy)
   Root@(dummy): FileId(1) -> ItemId(0)
@@ -10,7 +9,7 @@ Library@(dummy)
         Get@(FileId(1), 0..7)
           Binary@(FileId(1), 4..7): Mul
             Name@(FileId(1), 4..5): "a"@(FileId(1), 4..5), undeclared
-            Name@(FileId(1), 6..7): "a"@(FileId(1), 4..5), undeclared
+            Name@(FileId(1), 6..7): "a"@(FileId(1), 6..7), undeclared
 error in file FileId(1) at 4..5: `a` is undeclared
 | error in file FileId(1) for 4..5: no definitions of `a` are in scope
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_get_stmt-5.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_get_stmt-5.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler/toc_hir_lowering/tests/lowering.rs
 expression: "get a : a*a"
-
 ---
 Library@(dummy)
   Root@(dummy): FileId(1) -> ItemId(0)
@@ -10,8 +9,8 @@ Library@(dummy)
         Get@(FileId(1), 0..11)
           Name@(FileId(1), 4..5): "a"@(FileId(1), 4..5), undeclared
           Binary@(FileId(1), 8..11): Mul
-            Name@(FileId(1), 8..9): "a"@(FileId(1), 4..5), undeclared
-            Name@(FileId(1), 10..11): "a"@(FileId(1), 4..5), undeclared
+            Name@(FileId(1), 8..9): "a"@(FileId(1), 8..9), undeclared
+            Name@(FileId(1), 10..11): "a"@(FileId(1), 10..11), undeclared
 error in file FileId(1) at 4..5: `a` is undeclared
 | error in file FileId(1) for 4..5: no definitions of `a` are in scope
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_import_stmt-10.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_import_stmt-10.snap
@@ -8,7 +8,7 @@ Library@(dummy)
       StmtBody@(FileId(1), 5..41): []
         StmtItem@(FileId(1), 5..41): ItemId(1)
           Module@(FileId(1), 5..41): "_"@(FileId(1), 13..14)
-            Import@(FileId(1), 30..31): SameAsItem "_"@(FileId(1), 30..31)
+            Import@(FileId(1), 30..31): SameAsItem local("_"@(FileId(1), 13..14))
             StmtBody@(FileId(1), 36..36): []
 error in file FileId(1) at 30..31: `_` is already imported in this scope
 | note in file FileId(1) for 13..14: `_` declared pervasive here

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_import_stmt-2.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_import_stmt-2.snap
@@ -11,7 +11,7 @@ Library@(dummy)
             Primitive@(FileId(1), 13..16): Int
         StmtItem@(FileId(1), 21..66): ItemId(2)
           Module@(FileId(1), 21..66): "_"@(FileId(1), 28..29)
-            Import@(FileId(1), 45..56): SameAsItem "a"@(FileId(1), 55..56)
+            Import@(FileId(1), 45..56): SameAsItem local("a"@(FileId(1), 9..10))
             StmtBody@(FileId(1), 61..61): []
 error in file FileId(1) at 51..54: cannot use `const` and `var` on the same import
 | error in file FileId(1) for 45..50: first conflicting `const`

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_import_stmt-3.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_import_stmt-3.snap
@@ -11,7 +11,7 @@ Library@(dummy)
             Primitive@(FileId(1), 13..16): Int
         StmtItem@(FileId(1), 21..64): ItemId(2)
           Module@(FileId(1), 21..64): "_"@(FileId(1), 28..29)
-            Import@(FileId(1), 45..54): SameAsItem "a"@(FileId(1), 53..54)
+            Import@(FileId(1), 45..54): SameAsItem local("a"@(FileId(1), 9..10))
             StmtBody@(FileId(1), 59..59): []
 error in file FileId(1) at 45..52: unsupported import attribute
 | error in file FileId(1) for 45..52: `forward` imports are not supported yet

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_import_stmt-4.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_import_stmt-4.snap
@@ -18,8 +18,8 @@ Library@(dummy)
         StmtItem@(FileId(1), 27..76): ItemId(6)
           Subprogram@(FileId(1), 27..76): "_"@(FileId(1), 32..33)
             Void@(FileId(1), 27..33)
-            Import@(FileId(1), 49..50): SameAsItem "a"@(FileId(1), 49..50)
-            Import@(FileId(1), 52..57): Explicit(Var, SpanId(11)) "b"@(FileId(1), 56..57)
-            Import@(FileId(1), 59..66): Explicit(Const, SpanId(14)) "c"@(FileId(1), 65..66)
+            Import@(FileId(1), 49..50): SameAsItem local("a"@(FileId(1), 9..10))
+            Import@(FileId(1), 52..57): Explicit(Var, SpanId(11)) local("b"@(FileId(1), 12..13))
+            Import@(FileId(1), 59..66): Explicit(Const, SpanId(14)) local("c"@(FileId(1), 15..16))
             StmtBody@(FileId(1), 71..71): []
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_import_stmt-5.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_import_stmt-5.snap
@@ -12,7 +12,7 @@ Library@(dummy)
         StmtItem@(FileId(1), 21..64): ItemId(2)
           Subprogram@(FileId(1), 21..64): "_"@(FileId(1), 26..27)
             Void@(FileId(1), 21..27)
-            Import@(FileId(1), 43..54): SameAsItem "a"@(FileId(1), 53..54)
+            Import@(FileId(1), 43..54): SameAsItem local("a"@(FileId(1), 9..10))
             StmtBody@(FileId(1), 59..59): []
 error in file FileId(1) at 49..52: cannot use `const` and `var` on the same import
 | error in file FileId(1) for 43..48: first conflicting `const`

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_import_stmt-6.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_import_stmt-6.snap
@@ -12,7 +12,7 @@ Library@(dummy)
         StmtItem@(FileId(1), 21..62): ItemId(2)
           Subprogram@(FileId(1), 21..62): "_"@(FileId(1), 26..27)
             Void@(FileId(1), 21..27)
-            Import@(FileId(1), 43..52): SameAsItem "a"@(FileId(1), 51..52)
+            Import@(FileId(1), 43..52): SameAsItem local("a"@(FileId(1), 9..10))
             StmtBody@(FileId(1), 57..57): []
 error in file FileId(1) at 43..50: unsupported import attribute
 | error in file FileId(1) for 43..50: `forward` imports are not supported yet

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_import_stmt-7.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_import_stmt-7.snap
@@ -12,7 +12,7 @@ Library@(dummy)
         StmtItem@(FileId(1), 21..57): ItemId(2)
           Subprogram@(FileId(1), 21..57): "_"@(FileId(1), 26..27)
             Void@(FileId(1), 21..27)
-            Import@(FileId(1), 43..44): SameAsItem "a"@(FileId(1), 43..44)
+            Import@(FileId(1), 43..44): SameAsItem local("a"@(FileId(1), 9..10))
             StmtBody@(FileId(1), 52..52): []
 error in file FileId(1) at 46..47: import item is ignored
 | error in file FileId(1) for 46..47: `a` is already imported...

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_import_stmt-8.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_import_stmt-8.snap
@@ -12,7 +12,7 @@ Library@(dummy)
         StmtItem@(FileId(1), 21..57): ItemId(2)
           Subprogram@(FileId(1), 21..57): "_"@(FileId(1), 26..27)
             Void@(FileId(1), 21..27)
-            Import@(FileId(1), 43..44): SameAsItem "a"@(FileId(1), 43..44)
+            Import@(FileId(1), 43..44): SameAsItem local("a"@(FileId(1), 9..10))
             StmtBody@(FileId(1), 52..52): []
 error in file FileId(1) at 46..47: import item is ignored
 | error in file FileId(1) for 46..47: `a` is already imported...

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_import_stmt-9.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_import_stmt-9.snap
@@ -8,7 +8,7 @@ Library@(dummy)
       StmtBody@(FileId(1), 5..40): []
         StmtItem@(FileId(1), 5..40): ItemId(1)
           Module@(FileId(1), 5..40): "_"@(FileId(1), 12..13)
-            Import@(FileId(1), 29..30): SameAsItem "_"@(FileId(1), 29..30)
+            Import@(FileId(1), 29..30): SameAsItem local("_"@(FileId(1), 12..13))
             StmtBody@(FileId(1), 35..35): []
 error in file FileId(1) at 29..30: `_` is already declared in this scope
 | note in file FileId(1) for 12..13: `_` previously declared here

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_import_stmt.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_import_stmt.snap
@@ -17,8 +17,8 @@ Library@(dummy)
             Primitive@(FileId(1), 19..22): Int
         StmtItem@(FileId(1), 27..78): ItemId(6)
           Module@(FileId(1), 27..78): "_"@(FileId(1), 34..35)
-            Import@(FileId(1), 51..52): SameAsItem "a"@(FileId(1), 51..52)
-            Import@(FileId(1), 54..59): Explicit(Var, SpanId(10)) "b"@(FileId(1), 58..59)
-            Import@(FileId(1), 61..68): Explicit(Const, SpanId(13)) "c"@(FileId(1), 67..68)
+            Import@(FileId(1), 51..52): SameAsItem local("a"@(FileId(1), 9..10))
+            Import@(FileId(1), 54..59): Explicit(Var, SpanId(10)) local("b"@(FileId(1), 12..13))
+            Import@(FileId(1), 61..68): Explicit(Const, SpanId(13)) local("c"@(FileId(1), 15..16))
             StmtBody@(FileId(1), 73..73): []
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_module_def-4.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_module_def-4.snap
@@ -1,15 +1,13 @@
 ---
 source: compiler/toc_hir_lowering/tests/lowering.rs
-assertion_line: 61
 expression: "\n        module z\n            export ~.a, ~.b\n            var a, b : int\n        end z\n        module y\n            export ~.*all\n            var c, d : int\n        end y\n\n        % non pervasive\n        var i : int\n        i := a\n        i := b\n\n        % pervasive\n        module x\n            var i : int\n            i := c\n            i := d\n        end x\n        "
-
 ---
 Library@(dummy)
   Root@(dummy): FileId(1) -> ItemId(9)
     Module@(FileId(1), 0..368): "<root>"@(dummy)
       StmtBody@(FileId(1), 9..359): []
         StmtItem@(FileId(1), 9..86): ItemId(2)
-          Module@(FileId(1), 9..86): "z"@(FileId(1), 16..17), exports [Const Unqualified "a"@(FileId(1), 62..63), Const Unqualified "b"@(FileId(1), 65..66)]
+          Module@(FileId(1), 9..86): "z"@(FileId(1), 16..17), exports [Const Unqualified local("a"@(FileId(1), 62..63)), Const Unqualified local("b"@(FileId(1), 65..66))]
             StmtBody@(FileId(1), 58..72): []
               StmtItem@(FileId(1), 58..72): ItemId(0)
                 ConstVar@(FileId(1), 58..72): var "a"@(FileId(1), 62..63)
@@ -18,7 +16,7 @@ Library@(dummy)
                 ConstVar@(FileId(1), 58..72): var "b"@(FileId(1), 65..66)
                   Primitive@(FileId(1), 69..72): Int
         StmtItem@(FileId(1), 95..170): ItemId(5)
-          Module@(FileId(1), 95..170): "y"@(FileId(1), 102..103), exports [Const PervasiveUnqualified "c"@(FileId(1), 146..147), Const PervasiveUnqualified "d"@(FileId(1), 149..150)]
+          Module@(FileId(1), 95..170): "y"@(FileId(1), 102..103), exports [Const PervasiveUnqualified local("c"@(FileId(1), 146..147)), Const PervasiveUnqualified local("d"@(FileId(1), 149..150))]
             StmtBody@(FileId(1), 142..156): []
               StmtItem@(FileId(1), 142..156): ItemId(3)
                 ConstVar@(FileId(1), 142..156): var "c"@(FileId(1), 146..147)

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_module_def-5.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_module_def-5.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler/toc_hir_lowering/tests/lowering.rs
-assertion_line: 61
 expression: "\n        var u, w, U : int\n        module a\n            export ~.all\n            var u, w, U : int\n        end a\n        "
-
 ---
 Library@(dummy)
   Root@(dummy): FileId(1) -> ItemId(7)
@@ -18,7 +16,7 @@ Library@(dummy)
           ConstVar@(FileId(1), 9..26): var "U"@(FileId(1), 19..20)
             Primitive@(FileId(1), 23..26): Int
         StmtItem@(FileId(1), 35..112): ItemId(6)
-          Module@(FileId(1), 35..112): "a"@(FileId(1), 42..43), exports [Const Unqualified "u"@(FileId(1), 85..86), Const Unqualified "w"@(FileId(1), 88..89), Const Unqualified "U"@(FileId(1), 91..92)]
+          Module@(FileId(1), 35..112): "a"@(FileId(1), 42..43), exports [Const Unqualified local("u"@(FileId(1), 85..86)), Const Unqualified local("w"@(FileId(1), 88..89)), Const Unqualified local("U"@(FileId(1), 91..92))]
             StmtBody@(FileId(1), 81..98): []
               StmtItem@(FileId(1), 81..98): ItemId(3)
                 ConstVar@(FileId(1), 81..98): var "u"@(FileId(1), 85..86)

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_module_def-5.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_module_def-5.snap
@@ -29,11 +29,11 @@ Library@(dummy)
                   Primitive@(FileId(1), 95..98): Int
 error in file FileId(1) at 85..86: `u` is already declared in the parent scope
 | note in file FileId(1) for 13..14: `u` previously declared here
-| error in file FileId(1) for 65..68: `u` exported from here
+| error in file FileId(1) for 65..68: `u` exported unqualified from here
 error in file FileId(1) at 88..89: `w` is already declared in the parent scope
 | note in file FileId(1) for 16..17: `w` previously declared here
-| error in file FileId(1) for 65..68: `w` exported from here
+| error in file FileId(1) for 65..68: `w` exported unqualified from here
 error in file FileId(1) at 91..92: `U` is already declared in the parent scope
 | note in file FileId(1) for 19..20: `U` previously declared here
-| error in file FileId(1) for 65..68: `U` exported from here
+| error in file FileId(1) for 65..68: `U` exported unqualified from here
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_module_exports-10.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_module_exports-10.snap
@@ -1,15 +1,13 @@
 ---
 source: compiler/toc_hir_lowering/tests/lowering.rs
-assertion_line: 61
 expression: "\n    module z\n        export var a, var b\n        type a : int\n        const b := 8080\n    end z"
-
 ---
 Library@(dummy)
   Root@(dummy): FileId(1) -> ItemId(3)
     Module@(FileId(1), 0..96): "<root>"@(dummy)
       StmtBody@(FileId(1), 5..96): []
         StmtItem@(FileId(1), 5..96): ItemId(2)
-          Module@(FileId(1), 5..96): "z"@(FileId(1), 12..13), exports [Const Qualified "a"@(FileId(1), 55..56), Const Qualified "b"@(FileId(1), 77..78)]
+          Module@(FileId(1), 5..96): "z"@(FileId(1), 12..13), exports [Const Qualified local("a"@(FileId(1), 55..56)), Const Qualified local("b"@(FileId(1), 77..78))]
             StmtBody@(FileId(1), 50..86): []
               StmtItem@(FileId(1), 50..62): ItemId(0)
                 Type@(FileId(1), 50..62): "a"@(FileId(1), 55..56)

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_module_exports-2.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_module_exports-2.snap
@@ -1,15 +1,13 @@
 ---
 source: compiler/toc_hir_lowering/tests/lowering.rs
-assertion_line: 61
 expression: "\n    module z\n        export *a\n        var a : int\n    end z"
-
 ---
 Library@(dummy)
   Root@(dummy): FileId(1) -> ItemId(2)
     Module@(FileId(1), 0..61): "<root>"@(dummy)
       StmtBody@(FileId(1), 5..61): []
         StmtItem@(FileId(1), 5..61): ItemId(1)
-          Module@(FileId(1), 5..61): "z"@(FileId(1), 12..13), exports [Const Qualified "a"@(FileId(1), 44..45)]
+          Module@(FileId(1), 5..61): "z"@(FileId(1), 12..13), exports [Const Qualified local("a"@(FileId(1), 44..45))]
             StmtBody@(FileId(1), 40..51): []
               StmtItem@(FileId(1), 40..51): ItemId(0)
                 ConstVar@(FileId(1), 40..51): var "a"@(FileId(1), 44..45)

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_module_exports-3.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_module_exports-3.snap
@@ -1,15 +1,13 @@
 ---
 source: compiler/toc_hir_lowering/tests/lowering.rs
-assertion_line: 61
 expression: "\n        module z\n            export opaque a, opaque z\n            var a : int\n        end z"
-
 ---
 Library@(dummy)
   Root@(dummy): FileId(1) -> ItemId(2)
     Module@(FileId(1), 0..93): "<root>"@(dummy)
       StmtBody@(FileId(1), 9..93): []
         StmtItem@(FileId(1), 9..93): ItemId(1)
-          Module@(FileId(1), 9..93): "z"@(FileId(1), 16..17), exports [Const Qualified "a"@(FileId(1), 72..73)]
+          Module@(FileId(1), 9..93): "z"@(FileId(1), 16..17), exports [Const Qualified local("a"@(FileId(1), 72..73))]
             StmtBody@(FileId(1), 68..79): []
               StmtItem@(FileId(1), 68..79): ItemId(0)
                 ConstVar@(FileId(1), 68..79): var "a"@(FileId(1), 72..73)

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_module_exports-6.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_module_exports-6.snap
@@ -1,15 +1,13 @@
 ---
 source: compiler/toc_hir_lowering/tests/lowering.rs
-assertion_line: 61
 expression: "\n    module z\n        export var *~. all\n        var heres, tree : int\n    end z"
-
 ---
 Library@(dummy)
   Root@(dummy): FileId(1) -> ItemId(3)
     Module@(FileId(1), 0..80): "<root>"@(dummy)
       StmtBody@(FileId(1), 5..80): []
         StmtItem@(FileId(1), 5..80): ItemId(2)
-          Module@(FileId(1), 5..80): "z"@(FileId(1), 12..13), exports [Var PervasiveUnqualified "heres"@(FileId(1), 53..58), Var PervasiveUnqualified "tree"@(FileId(1), 60..64)]
+          Module@(FileId(1), 5..80): "z"@(FileId(1), 12..13), exports [Var PervasiveUnqualified local("heres"@(FileId(1), 53..58)), Var PervasiveUnqualified local("tree"@(FileId(1), 60..64))]
             StmtBody@(FileId(1), 49..70): []
               StmtItem@(FileId(1), 49..70): ItemId(0)
                 ConstVar@(FileId(1), 49..70): var "heres"@(FileId(1), 53..58)

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_module_exports-7.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_module_exports-7.snap
@@ -1,15 +1,13 @@
 ---
 source: compiler/toc_hir_lowering/tests/lowering.rs
-assertion_line: 61
 expression: "\n    module z\n        export var *~. all, heres\n        var heres, tree : int\n    end z"
-
 ---
 Library@(dummy)
   Root@(dummy): FileId(1) -> ItemId(3)
     Module@(FileId(1), 0..87): "<root>"@(dummy)
       StmtBody@(FileId(1), 5..87): []
         StmtItem@(FileId(1), 5..87): ItemId(2)
-          Module@(FileId(1), 5..87): "z"@(FileId(1), 12..13), exports [Var PervasiveUnqualified "heres"@(FileId(1), 60..65), Var PervasiveUnqualified "tree"@(FileId(1), 67..71)]
+          Module@(FileId(1), 5..87): "z"@(FileId(1), 12..13), exports [Var PervasiveUnqualified local("heres"@(FileId(1), 60..65)), Var PervasiveUnqualified local("tree"@(FileId(1), 67..71))]
             StmtBody@(FileId(1), 56..77): []
               StmtItem@(FileId(1), 56..77): ItemId(0)
                 ConstVar@(FileId(1), 56..77): var "heres"@(FileId(1), 60..65)

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_module_exports-8.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_module_exports-8.snap
@@ -1,15 +1,13 @@
 ---
 source: compiler/toc_hir_lowering/tests/lowering.rs
-assertion_line: 61
 expression: "\n    module z\n        export var *~. opaque all\n        var heres, tree : int\n        type again : int\n    end z"
-
 ---
 Library@(dummy)
   Root@(dummy): FileId(1) -> ItemId(4)
     Module@(FileId(1), 0..112): "<root>"@(dummy)
       StmtBody@(FileId(1), 5..112): []
         StmtItem@(FileId(1), 5..112): ItemId(3)
-          Module@(FileId(1), 5..112): "z"@(FileId(1), 12..13), exports [Var PervasiveUnqualified "heres"@(FileId(1), 60..65), Var PervasiveUnqualified "tree"@(FileId(1), 67..71), Const PervasiveUnqualified Opaque "again"@(FileId(1), 91..96)]
+          Module@(FileId(1), 5..112): "z"@(FileId(1), 12..13), exports [Var PervasiveUnqualified local("heres"@(FileId(1), 60..65)), Var PervasiveUnqualified local("tree"@(FileId(1), 67..71)), Const PervasiveUnqualified opaque local("again"@(FileId(1), 91..96))]
             StmtBody@(FileId(1), 56..102): []
               StmtItem@(FileId(1), 56..77): ItemId(0)
                 ConstVar@(FileId(1), 56..77): var "heres"@(FileId(1), 60..65)

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_module_exports-9.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_module_exports-9.snap
@@ -1,15 +1,13 @@
 ---
 source: compiler/toc_hir_lowering/tests/lowering.rs
-assertion_line: 61
 expression: "\n    module z\n        export a, a, a, a, a\n        var a : int\n    end z"
-
 ---
 Library@(dummy)
   Root@(dummy): FileId(1) -> ItemId(2)
     Module@(FileId(1), 0..72): "<root>"@(dummy)
       StmtBody@(FileId(1), 5..72): []
         StmtItem@(FileId(1), 5..72): ItemId(1)
-          Module@(FileId(1), 5..72): "z"@(FileId(1), 12..13), exports [Const Qualified "a"@(FileId(1), 55..56)]
+          Module@(FileId(1), 5..72): "z"@(FileId(1), 12..13), exports [Const Qualified local("a"@(FileId(1), 55..56))]
             StmtBody@(FileId(1), 51..62): []
               StmtItem@(FileId(1), 51..62): ItemId(0)
                 ConstVar@(FileId(1), 51..62): var "a"@(FileId(1), 55..56)

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_module_exports.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_module_exports.snap
@@ -1,15 +1,13 @@
 ---
 source: compiler/toc_hir_lowering/tests/lowering.rs
-assertion_line: 61
 expression: "\n    module tree\n        export a, var b, unqualified c, pervasive unqualified d, opaque e\n\n        var a, b, c, d : int\n        type e : int\n    end tree"
-
 ---
 Library@(dummy)
   Root@(dummy): FileId(1) -> ItemId(6)
     Module@(FileId(1), 0..154): "<root>"@(dummy)
       StmtBody@(FileId(1), 5..154): []
         StmtItem@(FileId(1), 5..154): ItemId(5)
-          Module@(FileId(1), 5..154): "tree"@(FileId(1), 12..16), exports [Const Qualified "a"@(FileId(1), 104..105), Var Qualified "b"@(FileId(1), 107..108), Const Unqualified "c"@(FileId(1), 110..111), Const PervasiveUnqualified "d"@(FileId(1), 113..114), Const Qualified Opaque "e"@(FileId(1), 134..135)]
+          Module@(FileId(1), 5..154): "tree"@(FileId(1), 12..16), exports [Const Qualified local("a"@(FileId(1), 104..105)), Var Qualified local("b"@(FileId(1), 107..108)), Const Unqualified local("c"@(FileId(1), 110..111)), Const PervasiveUnqualified local("d"@(FileId(1), 113..114)), Const Qualified opaque local("e"@(FileId(1), 134..135))]
             StmtBody@(FileId(1), 100..141): []
               StmtItem@(FileId(1), 100..120): ItemId(0)
                 ConstVar@(FileId(1), 100..120): var "a"@(FileId(1), 104..105)

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_procedure_def-9.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_procedure_def-9.snap
@@ -1,0 +1,20 @@
+---
+source: compiler/toc_hir_lowering/tests/lowering.rs
+expression: "var lmao : int proc uwu : lmao end uwu"
+---
+Library@(dummy)
+  Root@(dummy): FileId(1) -> ItemId(2)
+    Module@(FileId(1), 0..38): "<root>"@(dummy)
+      StmtBody@(FileId(1), 0..38): []
+        StmtItem@(FileId(1), 0..14): ItemId(0)
+          ConstVar@(FileId(1), 0..14): var "lmao"@(FileId(1), 4..8)
+            Primitive@(FileId(1), 11..14): Int
+        StmtItem@(FileId(1), 15..38): ItemId(1)
+          Subprogram@(FileId(1), 15..38): "uwu"@(FileId(1), 20..23)
+            ExprBody@(FileId(1), 26..30)
+              Name@(FileId(1), 26..30): "lmao"@(FileId(1), 4..8)
+            Void@(FileId(1), 15..30)
+            StmtBody@(FileId(1), 31..31): []
+error in file FileId(1) at 24..30: device specification is not allowed here
+| error in file FileId(1) for 24..30: `procedure` is not in a device monitor
+

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_process_def-9.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_process_def-9.snap
@@ -1,0 +1,18 @@
+---
+source: compiler/toc_hir_lowering/tests/lowering.rs
+expression: "var lmao : int process uwu : lmao end uwu"
+---
+Library@(dummy)
+  Root@(dummy): FileId(1) -> ItemId(2)
+    Module@(FileId(1), 0..41): "<root>"@(dummy)
+      StmtBody@(FileId(1), 0..41): []
+        StmtItem@(FileId(1), 0..14): ItemId(0)
+          ConstVar@(FileId(1), 0..14): var "lmao"@(FileId(1), 4..8)
+            Primitive@(FileId(1), 11..14): Int
+        StmtItem@(FileId(1), 15..41): ItemId(1)
+          Subprogram@(FileId(1), 15..41): "uwu"@(FileId(1), 23..26)
+            ExprBody@(FileId(1), 29..33)
+              Name@(FileId(1), 29..33): "lmao"@(FileId(1), 4..8)
+            Void@(FileId(1), 15..33)
+            StmtBody@(FileId(1), 34..34): []
+

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_scoping_inner_use_outer_use.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_scoping_inner_use_outer_use.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler/toc_hir_lowering/tests/lowering.rs
 expression: "begin a := b end a := b"
-
 ---
 Library@(dummy)
   Root@(dummy): FileId(1) -> ItemId(0)
@@ -12,8 +11,8 @@ Library@(dummy)
             Name@(FileId(1), 6..7): "a"@(FileId(1), 6..7), undeclared
             Name@(FileId(1), 11..12): "b"@(FileId(1), 11..12), undeclared
         Assign@(FileId(1), 17..23)
-          Name@(FileId(1), 17..18): "a"@(FileId(1), 6..7), undeclared
-          Name@(FileId(1), 22..23): "b"@(FileId(1), 11..12), undeclared
+          Name@(FileId(1), 17..18): "a"@(FileId(1), 17..18), undeclared
+          Name@(FileId(1), 22..23): "b"@(FileId(1), 22..23), undeclared
 error in file FileId(1) at 6..7: `a` is undeclared
 | error in file FileId(1) for 6..7: no definitions of `a` are in scope
 error in file FileId(1) at 11..12: `b` is undeclared

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_scoping_outer_use_inner_use.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_scoping_outer_use_inner_use.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler/toc_hir_lowering/tests/lowering.rs
 expression: "q := j begin q := k end"
-
 ---
 Library@(dummy)
   Root@(dummy): FileId(1) -> ItemId(0)
@@ -12,7 +11,7 @@ Library@(dummy)
           Name@(FileId(1), 5..6): "j"@(FileId(1), 5..6), undeclared
         Block@(FileId(1), 7..23): Normal
           Assign@(FileId(1), 13..19)
-            Name@(FileId(1), 13..14): "q"@(FileId(1), 0..1), undeclared
+            Name@(FileId(1), 13..14): "q"@(FileId(1), 13..14), undeclared
             Name@(FileId(1), 18..19): "k"@(FileId(1), 18..19), undeclared
 error in file FileId(1) at 0..1: `q` is undeclared
 | error in file FileId(1) for 0..1: no definitions of `q` are in scope

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_scoping_redeclare_over_undef.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_scoping_redeclare_over_undef.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler/toc_hir_lowering/tests/lowering.rs
 expression: "a := a const a := 1"
-
 ---
 Library@(dummy)
   Root@(dummy): FileId(1) -> ItemId(1)
@@ -9,7 +8,7 @@ Library@(dummy)
       StmtBody@(FileId(1), 0..19): []
         Assign@(FileId(1), 0..6)
           Name@(FileId(1), 0..1): "a"@(FileId(1), 0..1), undeclared
-          Name@(FileId(1), 5..6): "a"@(FileId(1), 0..1), undeclared
+          Name@(FileId(1), 5..6): "a"@(FileId(1), 5..6), undeclared
         StmtItem@(FileId(1), 7..19): ItemId(0)
           ConstVar@(FileId(1), 7..19): const "a"@(FileId(1), 13..14)
             ExprBody@(FileId(1), 18..19)

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_scoping_redeclare_use_undef.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_scoping_redeclare_use_undef.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler/toc_hir_lowering/tests/lowering.rs
 expression: "a := a"
-
 ---
 Library@(dummy)
   Root@(dummy): FileId(1) -> ItemId(0)
@@ -9,7 +8,7 @@ Library@(dummy)
       StmtBody@(FileId(1), 0..6): []
         Assign@(FileId(1), 0..6)
           Name@(FileId(1), 0..1): "a"@(FileId(1), 0..1), undeclared
-          Name@(FileId(1), 5..6): "a"@(FileId(1), 0..1), undeclared
+          Name@(FileId(1), 5..6): "a"@(FileId(1), 5..6), undeclared
 error in file FileId(1) at 0..1: `a` is undeclared
 | error in file FileId(1) for 0..1: no definitions of `a` are in scope
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_type_alias.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_type_alias.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler/toc_hir_lowering/tests/lowering.rs
-assertion_line: 59
 expression: "\n    type a : int\n    type use_it : a\n    var _ : a\n    "
-
 ---
 Library@(dummy)
   Root@(dummy): FileId(1) -> ItemId(3)
@@ -13,8 +11,8 @@ Library@(dummy)
             Primitive@(FileId(1), 14..17): Int
         StmtItem@(FileId(1), 22..37): ItemId(1)
           Type@(FileId(1), 22..37): "use_it"@(FileId(1), 27..33)
-            Alias@(FileId(1), 36..37): "a"@(FileId(1), 10..11), resolved(Type)
+            Alias@(FileId(1), 36..37): "a"@(FileId(1), 10..11)
         StmtItem@(FileId(1), 42..51): ItemId(2)
           ConstVar@(FileId(1), 42..51): var "_"@(FileId(1), 46..47)
-            Alias@(FileId(1), 50..51): "a"@(FileId(1), 10..11), resolved(Type)
+            Alias@(FileId(1), 50..51): "a"@(FileId(1), 10..11)
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_type_def_forward-2.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_type_def_forward-2.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler/toc_hir_lowering/tests/lowering.rs
-assertion_line: 59
 expression: "\n    type a : forward\n    type a : forward\n    type use_it : a\n    type a : int\n    "
-
 ---
 Library@(dummy)
   Root@(dummy): FileId(1) -> ItemId(4)
@@ -14,7 +12,7 @@ Library@(dummy)
           Type@(FileId(1), 26..42): forward "a"@(FileId(1), 31..32)
         StmtItem@(FileId(1), 47..62): ItemId(2)
           Type@(FileId(1), 47..62): "use_it"@(FileId(1), 52..58)
-            Alias@(FileId(1), 61..62): "a"@(FileId(1), 31..32), forward(Type) -> "a"@(FileId(1), 72..73)
+            Alias@(FileId(1), 61..62): "a"@(FileId(1), 31..32)
         StmtItem@(FileId(1), 67..79): ItemId(3)
           Type@(FileId(1), 67..79): "a"@(FileId(1), 72..73)
             Primitive@(FileId(1), 76..79): Int

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_type_def_forward-3.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_type_def_forward-3.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler/toc_hir_lowering/tests/lowering.rs
-assertion_line: 59
 expression: "\n    type a : forward\n    begin\n        type a : int\n    end\n    type use_it : a\n    "
-
 ---
 Library@(dummy)
   Root@(dummy): FileId(1) -> ItemId(3)
@@ -16,7 +14,7 @@ Library@(dummy)
               Primitive@(FileId(1), 49..52): Int
         StmtItem@(FileId(1), 65..80): ItemId(2)
           Type@(FileId(1), 65..80): "use_it"@(FileId(1), 70..76)
-            Alias@(FileId(1), 79..80): "a"@(FileId(1), 10..11), unresolved forward(Type)
+            Alias@(FileId(1), 79..80): "a"@(FileId(1), 10..11)
 error in file FileId(1) at 45..46: `a` must be resolved in the same scope
 | note in file FileId(1) for 10..11: forward declaration of `a` here
 | error in file FileId(1) for 45..46: resolution of `a` is not in the same scope

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_type_def_forward-4.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_type_def_forward-4.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler/toc_hir_lowering/tests/lowering.rs
-assertion_line: 59
 expression: "\n    type a : forward\n    type use_it : a % should not be resolved to latter a\n    var a : int\n    type a : char\n    "
-
 ---
 Library@(dummy)
   Root@(dummy): FileId(1) -> ItemId(4)
@@ -12,7 +10,7 @@ Library@(dummy)
           Type@(FileId(1), 5..21): forward "a"@(FileId(1), 10..11)
         StmtItem@(FileId(1), 26..41): ItemId(1)
           Type@(FileId(1), 26..41): "use_it"@(FileId(1), 31..37)
-            Alias@(FileId(1), 40..41): "a"@(FileId(1), 10..11), unresolved forward(Type)
+            Alias@(FileId(1), 40..41): "a"@(FileId(1), 10..11)
         StmtItem@(FileId(1), 83..94): ItemId(2)
           ConstVar@(FileId(1), 83..94): var "a"@(FileId(1), 87..88)
             Primitive@(FileId(1), 91..94): Int

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_type_def_forward.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_type_def_forward.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler/toc_hir_lowering/tests/lowering.rs
-assertion_line: 59
 expression: "\n    type a : forward\n    type use_it : a\n    type a : int\n    "
-
 ---
 Library@(dummy)
   Root@(dummy): FileId(1) -> ItemId(3)
@@ -12,7 +10,7 @@ Library@(dummy)
           Type@(FileId(1), 5..21): forward "a"@(FileId(1), 10..11)
         StmtItem@(FileId(1), 26..41): ItemId(1)
           Type@(FileId(1), 26..41): "use_it"@(FileId(1), 31..37)
-            Alias@(FileId(1), 40..41): "a"@(FileId(1), 10..11), forward(Type) -> "a"@(FileId(1), 51..52)
+            Alias@(FileId(1), 40..41): "a"@(FileId(1), 10..11)
         StmtItem@(FileId(1), 46..58): ItemId(2)
           Type@(FileId(1), 46..58): "a"@(FileId(1), 51..52)
             Primitive@(FileId(1), 55..58): Int

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_type_path.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_type_path.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler/toc_hir_lowering/tests/lowering.rs
-assertion_line: 61
 expression: "\n    type a : int\n    type chain: a.b.c.d.e\n    "
-
 ---
 Library@(dummy)
   Root@(dummy): FileId(1) -> ItemId(2)
@@ -13,5 +11,5 @@ Library@(dummy)
             Primitive@(FileId(1), 14..17): Int
         StmtItem@(FileId(1), 22..43): ItemId(1)
           Type@(FileId(1), 22..43): "chain"@(FileId(1), 27..32)
-            Alias@(FileId(1), 34..43): "a"@(FileId(1), 10..11), resolved(Type).b.c.d.e
+            Alias@(FileId(1), 34..43): "a"@(FileId(1), 10..11).b.c.d.e
 

--- a/compiler/toc_hir_pretty/src/graph.rs
+++ b/compiler/toc_hir_pretty/src/graph.rs
@@ -228,13 +228,13 @@ impl<'out, 'hir> PrettyVisitor<'out, 'hir> {
 
     fn display_binding(&self, binding: Spanned<Symbol>) -> String {
         match self.library.lookup_resolve(binding) {
-            Some(Resolve::Def(def_id)) => {
+            Resolve::Def(def_id) => {
                 let def_info = self.library.local_def(def_id);
                 let name = escape_def_name(def_info.name);
 
                 format!("'{name}'\\n({def_id:?})")
             }
-            Some(Resolve::Err) | None => {
+            Resolve::Err => {
                 let name = escape_def_name(*binding.item());
 
                 format!("'{name}'\\n(undeclared)")

--- a/compiler/toc_hir_pretty/src/graph.rs
+++ b/compiler/toc_hir_pretty/src/graph.rs
@@ -250,7 +250,8 @@ impl<'out, 'hir> PrettyVisitor<'out, 'hir> {
             symbol::DefResolve::External(def) => {
                 format!("external({def:?})")
             }
-            symbol::DefResolve::None => "unresolved".to_string(),
+            symbol::DefResolve::Err => "unresolved".to_string(),
+            symbol::DefResolve::Canonical => "".to_string(),
         }
     }
 

--- a/compiler/toc_hir_pretty/src/tree.rs
+++ b/compiler/toc_hir_pretty/src/tree.rs
@@ -112,14 +112,14 @@ impl<'out, 'hir> PrettyVisitor<'out, 'hir> {
 
     fn display_extra_binding(&self, binding: Spanned<symbol::Symbol>) -> String {
         match self.library.lookup_resolve(binding) {
-            Some(symbol::Resolve::Def(def_id)) => {
+            symbol::Resolve::Def(def_id) => {
                 let def_info = self.library.local_def(def_id);
                 let name = def_info.name;
                 let def_span = self.display_span(def_info.def_at);
 
                 format!("{name:?}@{def_span}")
             }
-            Some(symbol::Resolve::Err) | None => {
+            symbol::Resolve::Err => {
                 let name = binding.item();
                 let bind_span = self.display_span(binding.span());
 

--- a/compiler/toc_hir_pretty/src/tree.rs
+++ b/compiler/toc_hir_pretty/src/tree.rs
@@ -12,11 +12,11 @@ use toc_hir::{
     item,
     library::{self, LoweredLibrary},
     stmt::{self, BodyStmt},
-    symbol::{LocalDefId, Mutability, SubprogramKind},
+    symbol::{self, LocalDefId, Mutability, SubprogramKind},
     ty,
     visitor::{HirVisitor, WalkEvent, Walker},
 };
-use toc_span::{HasSpanTable, SpanId};
+use toc_span::{HasSpanTable, SpanId, Spanned};
 
 pub fn pretty_print_tree(lowered: &LoweredLibrary) -> String {
     let mut output = String::new();
@@ -105,28 +105,26 @@ impl<'out, 'hir> PrettyVisitor<'out, 'hir> {
         format!("{name:?}@{def_span}")
     }
 
+    // TODO: fold the uses
     fn display_extra_def(&self, def_id: LocalDefId) -> String {
-        let def_info = self.library.local_def(def_id);
-        let def_display = self.display_def(def_id);
-        match def_info.declare_kind {
-            toc_hir::symbol::DeclareKind::Undeclared => {
-                format!("{def_display}, undeclared")
+        self.display_def(def_id)
+    }
+
+    fn display_extra_binding(&self, binding: Spanned<symbol::Symbol>) -> String {
+        match self.library.lookup_resolve(binding) {
+            Some(symbol::Resolve::Def(def_id)) => {
+                let def_info = self.library.local_def(def_id);
+                let name = def_info.name;
+                let def_span = self.display_span(def_info.def_at);
+
+                format!("{name:?}@{def_span}")
             }
-            toc_hir::symbol::DeclareKind::Forward(kind, None) => {
-                format!("{def_display}, unresolved forward({kind:?})")
+            Some(symbol::Resolve::Err) | None => {
+                let name = binding.item();
+                let bind_span = self.display_span(binding.span());
+
+                format!("{name:?}@{bind_span}, undeclared")
             }
-            toc_hir::symbol::DeclareKind::Forward(kind, Some(resolve_to)) => {
-                format!(
-                    "{}, forward({:?}) -> {}",
-                    def_display,
-                    kind,
-                    self.display_def(resolve_to)
-                )
-            }
-            toc_hir::symbol::DeclareKind::Resolved(kind) => {
-                format!("{def_display}, resolved({kind:?})")
-            }
-            _ => def_display,
         }
     }
 
@@ -494,8 +492,8 @@ impl<'out, 'hir> HirVisitor for PrettyVisitor<'out, 'hir> {
     fn visit_name(&self, id: BodyExpr, expr: &expr::Name) {
         let span = self.expr_span(id);
         match expr {
-            expr::Name::Name(def_id) => {
-                let extra = self.display_extra_def(*def_id);
+            expr::Name::Name(binding) => {
+                let extra = self.display_extra_binding(*binding);
                 self.emit_node("Name", span, Some(format_args!("{extra}")))
             }
             expr::Name::Self_ => self.emit_node("Self", span, None),
@@ -525,7 +523,7 @@ impl<'out, 'hir> HirVisitor for PrettyVisitor<'out, 'hir> {
     }
     fn visit_alias(&self, id: ty::TypeId, ty: &ty::Alias) {
         let span = self.type_span(id);
-        let extra = self.display_extra_def(*ty.base_def.item());
+        let extra = self.display_extra_binding(ty.base_def);
         let segments = ty
             .segments
             .iter()

--- a/compiler/toc_hir_pretty/src/tree.rs
+++ b/compiler/toc_hir_pretty/src/tree.rs
@@ -136,7 +136,8 @@ impl<'out, 'hir> PrettyVisitor<'out, 'hir> {
             symbol::DefResolve::External(def) => {
                 format!("external({def:?})")
             }
-            symbol::DefResolve::None => "unresolved".to_string(),
+            symbol::DefResolve::Err => "unresolved".to_string(),
+            symbol::DefResolve::Canonical => "".to_string(),
         }
     }
 


### PR DESCRIPTION
This separates the process of resolving names from defs from the process of lowering the AST to HIR.
This allows for greater flexibility in how defs are resolved, required for bringing unqualified imports in along with their associated imports, and also modularizes the resolving process under one module.

This also has the side benefit of not having to undeclared defs, and instead now only leaves unnamed def tracking as the only kind of special def tracking we need to do.