### PR TITLE
AST-based name resolution

### DIFF
--- a/compiler/toc_analysis/src/ty/lower.rs
+++ b/compiler/toc_analysis/src/ty/lower.rs
@@ -345,7 +345,7 @@ fn type_def_ty(
         module
             .exports_of()
             .iter()
-            .find(|export| export.item_id == item_id.1)
+            .find(|export| export.exported_def == item.def_id)
             .map_or(false, |export| export.is_opaque)
     };
 

--- a/compiler/toc_analysis/src/ty/query.rs
+++ b/compiler/toc_analysis/src/ty/query.rs
@@ -49,7 +49,7 @@ fn ty_of_def(db: &dyn db::TypeDatabase, def_id: DefId) -> TypeId {
 
                 let module = library.module_item(module_id);
                 let export = module.export(export_id);
-                let def_id = DefId(def_id.0, library.item(export.item_id).def_id);
+                let def_id = DefId(def_id.0, export.exported_def);
 
                 db.type_of(def_id.into())
             }
@@ -439,7 +439,7 @@ pub(crate) fn fields_of(
                         .exports
                         .iter()
                         .map(|export| {
-                            let local_def = library.item(export.item_id).def_id;
+                            let local_def = export.exported_def;
                             let field_name = library.local_def(local_def).name;
                             let def_id = DefId(library_id, local_def);
 

--- a/compiler/toc_hir/src/builder.rs
+++ b/compiler/toc_hir/src/builder.rs
@@ -1,32 +1,19 @@
 //! Helper builders for creating the HIR tree
 
-use std::collections::HashMap;
-
 use la_arena::Arena;
 use toc_span::{FileId, Span, SpanId, SpanTable};
 
-use crate::{
-    body, expr, item, library, stmt,
-    symbol::{self, NodeSpan, Symbol},
-    ty,
-};
+use crate::{body, expr, item, library, stmt, symbol, ty};
 
 /// Builder for constructing a [`Library`]
 ///
 /// [`Library`]: library::Library
 pub struct LibraryBuilder {
     library: library::Library,
-    node_defs: HashMap<NodeSpan, symbol::LocalDefId>,
-    assoc_defs: symbol::DefMap<Vec<symbol::LocalDefId>>,
 }
 
 impl LibraryBuilder {
-    pub fn new(
-        span_map: SpanTable,
-        defs: symbol::DefInfoTable,
-        node_defs: HashMap<NodeSpan, symbol::LocalDefId>,
-        assoc_defs: symbol::DefMap<Vec<symbol::LocalDefId>>,
-    ) -> Self {
+    pub fn new(span_map: SpanTable, defs: symbol::DefInfoTable) -> Self {
         Self {
             library: library::Library {
                 span_map,
@@ -38,8 +25,6 @@ impl LibraryBuilder {
                 type_map: Default::default(),
                 resolve_map: Default::default(),
             },
-            node_defs,
-            assoc_defs,
         }
     }
 
@@ -61,7 +46,7 @@ impl LibraryBuilder {
     /// [`LocalDefId`]: crate::symbol::LocalDefId
     pub fn add_def(
         &mut self,
-        name: Symbol,
+        name: symbol::Symbol,
         span: SpanId,
         kind: Option<symbol::SymbolKind>,
         pervasive: symbol::IsPervasive,
@@ -80,18 +65,6 @@ impl LibraryBuilder {
 
     pub fn intern_span(&mut self, span: Span) -> SpanId {
         self.span_map.intern_span(span)
-    }
-
-    /// Finds the def bound to a specific AST node.
-    /// Assumes that there is a def at the given `node_span`
-    pub fn node_def(&self, node_span: NodeSpan) -> symbol::LocalDefId {
-        self.node_defs[&node_span]
-    }
-
-    /// Finds defs assocatied with `local_def`
-    /// Assumes that there are associated defs
-    pub fn associated_defs(&self, local_def: symbol::LocalDefId) -> &Vec<symbol::LocalDefId> {
-        self.assoc_defs.get(local_def).unwrap()
     }
 
     pub fn make_body_with(

--- a/compiler/toc_hir/src/builder.rs
+++ b/compiler/toc_hir/src/builder.rs
@@ -90,10 +90,7 @@ impl LibraryBuilder {
 
     /// Finds defs assocatied with `local_def`
     /// Assumes that there are associated defs
-    pub fn associated_defs(
-        &self,
-        local_def: symbol::LocalDefId,
-    ) -> &Vec<symbol::LocalDefId> {
+    pub fn associated_defs(&self, local_def: symbol::LocalDefId) -> &Vec<symbol::LocalDefId> {
         self.assoc_defs.get(local_def).unwrap()
     }
 

--- a/compiler/toc_hir/src/builder.rs
+++ b/compiler/toc_hir/src/builder.rs
@@ -75,10 +75,6 @@ impl LibraryBuilder {
         self.add_body(body)
     }
 
-    pub fn local_def_mut(&mut self, def_id: symbol::LocalDefId) -> &mut symbol::DefInfo {
-        &mut self.defs[def_id.into()]
-    }
-
     pub fn freeze_root_items(self, root_items: Vec<(FileId, item::ItemId)>) -> Self {
         Self {
             library: library::Library {

--- a/compiler/toc_hir/src/item.rs
+++ b/compiler/toc_hir/src/item.rs
@@ -232,8 +232,8 @@ pub struct ExportItem {
     pub mutability: symbol::Mutability,
     pub qualify_as: QualifyAs,
     pub is_opaque: bool,
-    /// Associated item to export
-    pub item_id: ItemId,
+    /// Associated def to export
+    pub exported_def: symbol::LocalDefId,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/compiler/toc_hir/src/library.rs
+++ b/compiler/toc_hir/src/library.rs
@@ -70,7 +70,7 @@ pub struct Library {
     /// Table of all interned types
     pub(crate) type_map: ty::TypeTable,
     pub(crate) items: Arena<item::Item>,
-    pub(crate) defs: Arena<symbol::DefInfo>,
+    pub(crate) defs: symbol::DefInfoTable,
     pub(crate) bodies: Arena<body::Body>,
     pub(crate) resolve_map: ResolutionMap,
 }
@@ -99,8 +99,8 @@ impl Library {
         }
     }
 
-    pub fn local_def(&self, def_id: symbol::LocalDefId) -> &symbol::DefInfo {
-        &self.defs[def_id.into()]
+    pub fn local_def(&self, local_def: symbol::LocalDefId) -> &symbol::DefInfo {
+        self.defs.get_info(local_def)
     }
 
     pub fn lookup_type(&self, type_id: ty::TypeId) -> &ty::Type {
@@ -124,7 +124,7 @@ impl Library {
     }
 
     pub fn local_defs(&self) -> impl Iterator<Item = symbol::LocalDefId> + '_ {
-        self.defs.iter().map(|(id, _)| symbol::LocalDefId(id))
+        self.defs.iter().map(|(id, _)| id)
     }
 
     pub fn body_ids(&self) -> Vec<body::BodyId> {

--- a/compiler/toc_hir/src/symbol.rs
+++ b/compiler/toc_hir/src/symbol.rs
@@ -56,17 +56,14 @@ impl From<&str> for Symbol {
     }
 }
 
-/// A specific identifier in a [`Library`](crate::library::Library)
+// FIXME: This feels more like an AST or `toc_span` construct, move it elsewhere
+/// The span of a specific AST node in a [`Library`](crate::library::Library)
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct Ident(pub Symbol, pub SpanId);
+pub struct NodeSpan(pub SpanId);
 
-impl Ident {
-    pub fn symbol(self) -> Symbol {
-        self.0
-    }
-
+impl NodeSpan {
     pub fn span(self) -> SpanId {
-        self.1
+        self.0
     }
 }
 
@@ -103,6 +100,14 @@ impl DefInfoTable {
         };
         let index = self.defs.alloc(def);
         LocalDefId(index)
+    }
+
+    pub fn get_info(&self, local_def: LocalDefId) -> &DefInfo {
+        &self.defs[local_def.0]
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (LocalDefId, &'_ DefInfo)> + '_ {
+        self.defs.iter().map(|(id, info)| (LocalDefId(id), info))
     }
 }
 

--- a/compiler/toc_hir_lowering/src/ast_resolver.rs
+++ b/compiler/toc_hir_lowering/src/ast_resolver.rs
@@ -1,0 +1,403 @@
+//! AST-level resolution
+
+use std::collections::HashMap;
+
+use indexmap::IndexMap;
+use toc_hir::symbol::{DefInfoTable, DefMap, DefResolve, LocalDefId, NodeSpan};
+use toc_reporting::{CompileResult, MessageSink};
+use toc_span::{FileId, Span, SpanTable, TextRange};
+use toc_syntax::{
+    ast::{self, AstNode},
+    match_ast, SyntaxNode,
+};
+
+use crate::{
+    collector::CollectRes,
+    resolver::scopes::{DeclareKind, ForwardKind, ScopeKind},
+    LoweringDb,
+};
+
+#[derive(Debug, Default)]
+pub(crate) struct ResolveRes {
+    // taken from CollectRes
+    pub(crate) defs: DefInfoTable,
+    pub(crate) spans: SpanTable,
+    pub(crate) node_defs: HashMap<NodeSpan, LocalDefId>,
+
+    // resolution's contribution
+    pub(crate) assoc_defs: DefMap<Vec<LocalDefId>>,
+    pub(crate) def_resolves: DefMap<DefResolve>,
+}
+
+pub(crate) fn resolve_defs(
+    db: &dyn LoweringDb,
+    reachable_files: &[FileId],
+    collect_res: CollectRes,
+) -> CompileResult<ResolveRes> {
+    let CollectRes {
+        defs,
+        node_defs,
+        spans,
+    } = collect_res;
+    let mut res = ResolveRes {
+        defs,
+        node_defs,
+        spans,
+        assoc_defs: Default::default(),
+        def_resolves: Default::default(),
+    };
+
+    // Generate the scope trace, as well as the list of bindings to resolve
+    // Each file gets its own scope trace
+
+    let file_traces = reachable_files
+        .iter()
+        .map(|&file| {
+            let root = ast::Source::cast(db.parse_file(file).result().syntax()).unwrap();
+            let trace = FileTracer::trace_file(file, root, &mut res);
+
+            (file, trace)
+        })
+        .collect::<IndexMap<_, _>>();
+
+    eprintln!("{file_traces:#?}");
+
+    CompileResult::new(res, MessageSink::default().finish())
+}
+
+#[derive(Debug)]
+enum ScopeEvent {
+    /// Enters into a scope, applicable for the given [`NodeSpan`].
+    EnterScope(ScopeKind, NodeSpan),
+    /// Introduces the [`LocalDefId`] after the span of [`NodeSpan`].
+    IntroduceAfter(LocalDefId, DeclareKind, NodeSpan),
+    /// Introduces an import after the span of [`NodeSpan`].
+    /// Imports are treated specially, as they may also introduce extra
+    /// unqualified imports.
+    IntroduceImport(LocalDefId, NodeSpan),
+    /// Introduces unqualified exports of the [`LocalDefId`], if it has any.
+    IntroduceUnqualfieds(LocalDefId, NodeSpan),
+}
+
+#[derive(Debug, Default)]
+struct FileTrace {
+    scope_trace: Vec<ScopeEvent>,
+    import_bindings: Vec<NodeSpan>,
+    name_bindings: Vec<NodeSpan>,
+}
+
+struct FileTracer<'ctx> {
+    ctx: &'ctx mut ResolveRes,
+    file: FileId,
+    root: ast::Source,
+    res: FileTrace,
+}
+
+impl<'ctx> FileTracer<'ctx> {
+    fn trace_file(file: FileId, root: ast::Source, ctx: &'ctx mut ResolveRes) -> FileTrace {
+        let mut trace = Self {
+            ctx,
+            file,
+            root,
+            res: Default::default(),
+        };
+
+        trace.visit_root();
+
+        trace.res
+    }
+
+    fn node_span(&mut self, range: TextRange) -> NodeSpan {
+        NodeSpan(self.ctx.spans.intern_span(Span::new(self.file, range)))
+    }
+
+    fn name_def(&mut self, name: Option<ast::Name>) -> Option<LocalDefId> {
+        let name_span = self.node_span(name?.syntax().text_range());
+        let name_def = self.ctx.node_defs.get(&name_span).unwrap();
+
+        Some(*name_def)
+    }
+
+    fn introduce_name_after(
+        &mut self,
+        name: Option<ast::Name>,
+        decl_kind: DeclareKind,
+        introduce_after: NodeSpan,
+    ) {
+        let name = match name {
+            Some(name) => name,
+            None => return,
+        };
+        let name_span = self.node_span(name.syntax().text_range());
+        let name_def = self.ctx.node_defs.get(&name_span).unwrap();
+
+        self.res.scope_trace.push(ScopeEvent::IntroduceAfter(
+            *name_def,
+            decl_kind,
+            introduce_after,
+        ))
+    }
+
+    fn introduce_name(&mut self, name: Option<ast::Name>, decl_kind: DeclareKind) {
+        let name = match name {
+            Some(name) => name,
+            None => return,
+        };
+        let name_span = self.node_span(name.syntax().text_range());
+        let name_def = self.ctx.node_defs.get(&name_span).unwrap();
+
+        self.res
+            .scope_trace
+            .push(ScopeEvent::IntroduceAfter(*name_def, decl_kind, name_span))
+    }
+
+    fn introduce_unqualifieds(&mut self, name: Option<ast::Name>, after: &SyntaxNode) {
+        let name_def = match self.name_def(name) {
+            Some(def) => def,
+            None => return,
+        };
+        let after = self.node_span(after.text_range());
+
+        self.res
+            .scope_trace
+            .push(ScopeEvent::IntroduceUnqualfieds(name_def, after))
+    }
+
+    /// `in_scope` is used to logically denote what things are
+    /// only visible inside of the scope
+    fn inside_scope(
+        &mut self,
+        kind: ScopeKind,
+        stmts: ast::StmtList,
+        in_scope: impl FnOnce(&mut Self),
+    ) {
+        let span = self.node_span(stmts.syntax().text_range());
+        self.res
+            .scope_trace
+            .push(ScopeEvent::EnterScope(kind, span));
+        in_scope(self);
+    }
+}
+
+// Scoping //
+impl FileTracer<'_> {
+    fn visit_root(&mut self) {
+        for node in self.root.syntax().descendants() {
+            {
+                match_ast! {
+                    match node {
+                        ast::ConstVarDecl(decl) => self.visit_decl_constvar(decl),
+                        ast::TypeDecl(decl) => self.visit_decl_type(decl),
+                        ast::BindDecl(decl) => self.visit_decl_bind(decl),
+                        ast::ProcDecl(decl) => self.visit_decl_proc(decl),
+                        ast::FcnDecl(decl) => self.visit_decl_fcn(decl),
+                        ast::ProcessDecl(decl) => self.visit_decl_process(decl),
+                        ast::ExternalDecl(_decl) => {},
+                        ast::ForwardDecl(_decl) => {},
+                        ast::DeferredDecl(_decl) => {},
+                        ast::BodyDecl(_decl) => {},
+                        ast::ModuleDecl(decl) => self.visit_decl_module(decl),
+                        ast::ClassDecl(_decl) => {},
+                        ast::MonitorDecl(_decl) => {},
+
+                        // Notable stmts //
+                        ast::ForStmt(stmt) => self.visit_stmt_for(stmt),
+                        ast::LoopStmt(stmt) => self.visit_stmt_loop(stmt),
+                        ast::HandlerStmt(_stmt) => {},
+                        ast::StmtList(stmts) => self.visit_stmt_list(stmts),
+
+                        // Types //
+                        ast::CollectionType(_ty) => {},
+
+                        // Name refs //
+                        ast::ImportItem(decl) => self.visit_decl_import(decl),
+                        ast::NameExpr(expr) => self.visit_expr_name(expr),
+                        _ => {}
+                    }
+                }
+            }
+        }
+    }
+
+    fn visit_decl_constvar(&mut self, decl: ast::ConstVarDecl) {
+        // Collect defs from name list
+        // All of them are introduced after the initializer,
+        // so that they can't be used in the initializer
+
+        // ???: Do we want to do so, but error on use?
+        // Would mean cyclic evaluation, so we won't do it for now
+        let introduce_after = self.node_span(decl.syntax().text_range());
+        for name in decl.decl_list().unwrap().names() {
+            self.introduce_name_after(Some(name), DeclareKind::Declared, introduce_after);
+        }
+    }
+
+    fn visit_decl_type(&mut self, decl: ast::TypeDecl) {
+        let decl_kind = if decl.forward_token().is_some() {
+            DeclareKind::Resolved(ForwardKind::Type)
+        } else {
+            DeclareKind::Forward(ForwardKind::Type, None)
+        };
+
+        // Introduce after the item
+
+        // ???: Do we still want to introduce after?
+        // We can still create cycles by just introducing a forward def.
+        // Plus, we plan to have an occurrence check as part of type infer,
+        // making this useless.
+        let introduce_after = self.node_span(decl.syntax().text_range());
+        self.introduce_name_after(decl.decl_name(), decl_kind, introduce_after)
+    }
+
+    fn visit_decl_bind(&mut self, decl: ast::BindDecl) {
+        for binding in decl.bindings() {
+            let introduce_after = self.node_span(binding.syntax().text_range());
+            self.introduce_name_after(binding.bind_as(), DeclareKind::Declared, introduce_after)
+        }
+    }
+
+    fn visit_decl_proc(&mut self, decl: ast::ProcDecl) {
+        let header = decl.proc_header().unwrap();
+        self.introduce_name(header.name(), DeclareKind::Declared);
+
+        self.inside_scope(
+            ScopeKind::Subprogram,
+            decl.subprog_body().unwrap().stmt_list().unwrap(),
+            |this| {
+                this.visit_formal_params(header.params());
+            },
+        );
+    }
+
+    fn visit_decl_fcn(&mut self, decl: ast::FcnDecl) {
+        let header = decl.fcn_header().unwrap();
+        self.introduce_name(header.name(), DeclareKind::Declared);
+
+        self.inside_scope(
+            ScopeKind::Subprogram,
+            decl.subprog_body().unwrap().stmt_list().unwrap(),
+            |this| {
+                this.visit_formal_params(header.params());
+            },
+        );
+    }
+
+    fn visit_decl_process(&mut self, decl: ast::ProcessDecl) {
+        let header = decl.process_header().unwrap();
+        self.introduce_name(header.name(), DeclareKind::Declared);
+
+        self.inside_scope(
+            ScopeKind::Subprogram,
+            decl.subprog_body().unwrap().stmt_list().unwrap(),
+            |this| {
+                this.visit_formal_params(header.params());
+            },
+        );
+    }
+
+    fn visit_formal_params(&mut self, param_list: Option<ast::ParamSpec>) {
+        let param_list = match param_list {
+            Some(it) => it,
+            None => return,
+        };
+
+        for param in param_list.param_decl() {
+            match param {
+                ast::ParamDecl::ConstVarParam(param) => {
+                    for name in param.param_names().unwrap().names() {
+                        self.introduce_name(Some(name), DeclareKind::AlwaysShadow);
+                    }
+                }
+                ast::ParamDecl::SubprogType(ast::SubprogType::FcnType(param)) => {
+                    self.introduce_name(param.name(), DeclareKind::AlwaysShadow);
+                }
+                ast::ParamDecl::SubprogType(ast::SubprogType::ProcType(param)) => {
+                    self.introduce_name(param.name(), DeclareKind::AlwaysShadow);
+                }
+            }
+        }
+    }
+
+    fn visit_decl_module(&mut self, decl: ast::ModuleDecl) {
+        self.introduce_name(decl.name(), DeclareKind::Declared);
+
+        // TODO: pervasive stuff
+        self.inside_scope(ScopeKind::Module, decl.stmt_list().unwrap(), |this| {
+            // Make visible in the inner scope, but only if it isn't pervasive
+            // (it being pervasive would mean it's already visible)
+            if decl.pervasive_attr().is_none() {
+                this.introduce_name(decl.name(), DeclareKind::Declared);
+            }
+
+            // Applicable imports are handled by
+        });
+
+        // Unqualifieds are explicitly introduced after
+        self.introduce_unqualifieds(decl.name(), decl.stmt_list().unwrap().syntax());
+    }
+
+    fn visit_stmt_for(&mut self, stmt: ast::ForStmt) {
+        self.inside_scope(ScopeKind::Loop, stmt.stmt_list().unwrap(), |this| {
+            // Introduce counter, if present
+            if let Some(name) = stmt.name() {
+                let introduce_after = this.node_span(name.syntax().text_range());
+                this.introduce_name_after(Some(name), DeclareKind::Declared, introduce_after);
+            }
+        });
+    }
+
+    fn visit_stmt_loop(&mut self, stmt: ast::LoopStmt) {
+        self.inside_scope(ScopeKind::Loop, stmt.stmt_list().unwrap(), |_| ());
+    }
+
+    fn visit_stmt_list(&mut self, stmts: ast::StmtList) {
+        self.inside_scope(ScopeKind::Block, stmts, |_| ());
+    }
+}
+
+// Name refs //
+impl FileTracer<'_> {
+    fn visit_decl_import(&mut self, decl: ast::ImportItem) {
+        // ???: How to deal with things that have no name?
+        // Issue is mostly fetching that name from the referring file
+        // We know what it is, it's mostly just the issue of fetching that name
+        // We know what it resolves to, so we'll defer it to later
+
+        if let Some(external_name) = decl.external_item().and_then(|item| item.name()) {
+            // Name that needs to be resolved, as well as introducing a def
+            let node = self.node_span(external_name.syntax().text_range());
+            self.res.import_bindings.push(node);
+
+            // Note: for import decls:
+            // Only consider as an export candidate if we aren't in a forward decl
+            // <ImportItem> => ImportList => ForwardDecl
+            // FIXME: use a def scope instead once we deal with forward decls
+
+            // Note: Imports on forward decls need special treatment, since
+            // the resolved impls need to collect them together and be introduced
+            // there, not at the forward decl
+            let in_forward_decl = decl
+                .syntax()
+                .parent()
+                .and_then(ast::ImportList::cast)
+                .and_then(|n| n.syntax().parent())
+                .and_then(ast::ForwardDecl::cast)
+                .is_some();
+
+            if in_forward_decl {
+                let import_def = self.ctx.node_defs.get(&node).copied().unwrap();
+                self.res
+                    .scope_trace
+                    .push(ScopeEvent::IntroduceImport(import_def, node));
+            }
+        } else {
+            // FIXME: Handle external imports
+        }
+    }
+
+    fn visit_expr_name(&mut self, expr: ast::NameExpr) {
+        let name = expr.name().unwrap();
+        let node = self.node_span(name.syntax().text_range());
+        self.res.name_bindings.push(node);
+    }
+}

--- a/compiler/toc_hir_lowering/src/collector.rs
+++ b/compiler/toc_hir_lowering/src/collector.rs
@@ -4,8 +4,8 @@ use std::collections::HashMap;
 
 use toc_hir::{
     symbol::{
-        syms, DefInfoTable, DefMap, IsMonitor, IsPervasive, IsRegister, LocalDefId, Mutability,
-        NodeSpan, SubprogramKind, Symbol, SymbolKind,
+        syms, DefInfoTable, IsMonitor, IsPervasive, IsRegister, LocalDefId, Mutability, NodeSpan,
+        SubprogramKind, Symbol, SymbolKind,
     },
     ty::PassBy,
 };
@@ -13,7 +13,7 @@ use toc_reporting::{CompileResult, MessageSink};
 use toc_span::{FileId, Span, SpanId, SpanTable, TextRange};
 use toc_syntax::{
     ast::{self, AstNode},
-    match_ast, SyntaxKind, WalkEvent,
+    match_ast,
 };
 
 use crate::LoweringDb;
@@ -22,7 +22,6 @@ use crate::LoweringDb;
 pub(crate) struct CollectRes {
     pub(crate) defs: DefInfoTable,
     pub(crate) node_defs: HashMap<NodeSpan, LocalDefId>,
-    pub(crate) assoc_defs: DefMap<Vec<LocalDefId>>,
     pub(crate) spans: SpanTable,
 }
 
@@ -41,50 +40,11 @@ pub(crate) fn collect_defs(
     CompileResult::new(res, messages.finish())
 }
 
-/// Whether we're entering or leaving a node
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum NodeState {
-    Enter,
-    Leave,
-}
-
-struct DefScope {
-    defs: Vec<Vec<LocalDefId>>,
-}
-
-impl DefScope {
-    fn new() -> Self {
-        Self { defs: vec![vec![]] }
-    }
-
-    fn introduce_def(&mut self, local_def: LocalDefId) {
-        self.defs
-            .last_mut()
-            .expect("root scope was popped off")
-            .push(local_def);
-    }
-
-    fn push_scope(&mut self) {
-        self.defs.push(vec![])
-    }
-
-    fn pop_scope(&mut self) -> Vec<LocalDefId> {
-        self.defs.pop().expect("root scope was popped off")
-    }
-}
-
-impl Default for DefScope {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 struct FileCollector<'a> {
     file: FileId,
     root: ast::Source,
     res: &'a mut CollectRes,
     _messages: &'a mut MessageSink,
-    scopes: DefScope,
 }
 
 impl<'a> FileCollector<'a> {
@@ -99,7 +59,6 @@ impl<'a> FileCollector<'a> {
             root,
             res,
             _messages: messages,
-            scopes: Default::default(),
         };
 
         ctx.collect_root();
@@ -112,130 +71,50 @@ impl<'a> FileCollector<'a> {
         // Doesn't matter if it's a unit, since def generation is the
         // same regardless
 
-        for event in self.root.syntax().preorder() {
+        for node in self.root.syntax().descendants() {
             // FIXME: Handle include globs
             // AAAAAAAAAAAAAAAAAAAAAAAAAAA
 
             // Pull out node & state
-            match event {
-                WalkEvent::Enter(node) => {
-                    let state = NodeState::Enter;
+            match_ast! {
+                match (node) {
+                    // Decls //
+                    ast::ConstVarDecl(decl) => self.collect_decl_constvar(decl),
+                    ast::TypeDecl(decl) => self.collect_decl_type(decl),
+                    ast::BindDecl(decl) => self.collect_decl_bind(decl),
+                    ast::ProcDecl(decl) => self.collect_decl_proc(decl),
+                    ast::FcnDecl(decl) => self.collect_decl_fcn(decl),
+                    ast::ProcessDecl(decl) => self.collect_decl_process(decl),
+                    ast::ExternalDecl(_decl) => {},
+                    ast::ForwardDecl(_decl) => {},
+                    ast::DeferredDecl(_decl) => {},
+                    ast::BodyDecl(_decl) => {},
+                    ast::ModuleDecl(decl) => self.collect_decl_module(decl),
+                    ast::ClassDecl(_decl) => {},
+                    ast::MonitorDecl(_decl) => {},
 
-                    match_ast! {
-                        match (node) {
-                            // Decls //
-                            ast::ConstVarDecl(decl) => self.collect_decl_constvar(decl),
-                            ast::TypeDecl(decl) => self.collect_decl_type(decl),
-                            ast::BindDecl(decl) => self.collect_decl_bind(decl),
-                            ast::ProcDecl(decl) => self.collect_decl_proc(decl),
-                            ast::FcnDecl(decl) => self.collect_decl_fcn(decl),
-                            ast::ProcessDecl(decl) => self.collect_decl_process(decl),
-                            ast::ExternalDecl(_decl) => {},
-                            ast::ForwardDecl(_decl) => {},
-                            ast::DeferredDecl(_decl) => {},
-                            ast::BodyDecl(_decl) => {},
-                            ast::ModuleDecl(decl) => self.collect_decl_module(decl, state),
-                            ast::ClassDecl(_decl) => {},
-                            ast::MonitorDecl(_decl) => {},
+                    ast::ImportItem(decl) => self.collect_decl_import(decl),
 
-                            ast::ImportItem(decl) => self.collect_decl_import(decl),
+                    // Notable stmts //
+                    ast::ForStmt(stmt) => self.collect_stmt_for(stmt),
+                    ast::HandlerStmt(_stmt) => {},
 
-                            // Notable stmts //
-                            ast::ForStmt(stmt) => self.collect_stmt_for(stmt),
-                            ast::HandlerStmt(_stmt) => {},
-
-                            // Scopes don't need to be precise, so long as they
-                            // prevent defs from escaping & being considered
-                            // export candidates
-                            ast::StmtList(stmt) => self.wrap_scope(stmt, state),
-
-                            // Types //
-                            ast::EnumType(ty) => self.collect_ty_enum(ty),
-                            ast::SetType(ty) => self.collect_ty_set(ty),
-                            ast::RecordType(_ty) => {},
-                            ast::UnionType(_ty) => {},
-                            ast::FcnType(ty) => self.collect_ty_fcn(ty),
-                            ast::ProcType(ty) => self.collect_ty_proc(ty),
-                            ast::CollectionType(_ty) => {},
-                            _ => {}
-                        }
-                    }
+                    // Types //
+                    ast::EnumType(ty) => self.collect_ty_enum(ty),
+                    ast::SetType(ty) => self.collect_ty_set(ty),
+                    ast::RecordType(_ty) => {},
+                    ast::UnionType(_ty) => {},
+                    ast::FcnType(ty) => self.collect_ty_fcn(ty),
+                    ast::ProcType(ty) => self.collect_ty_proc(ty),
+                    ast::CollectionType(_ty) => {},
+                    _ => {}
                 }
-                WalkEvent::Leave(node) => {
-                    let state = NodeState::Leave;
-
-                    // These are the only nodes which care about node exit
-                    match_ast! {
-                        match (node) {
-                            ast::ModuleDecl(decl) => self.collect_decl_module(decl, state),
-                            ast::ClassDecl(_decl) => {},
-                            ast::MonitorDecl(_decl) => {},
-                            ast::StmtList(stmt) => self.wrap_scope(stmt, state),
-                            _ => {}
-                        }
-                    }
-                }
-            };
-        }
-    }
-
-    /// Wraps stmt nodes in a scope, but only if it doesn't have a significant scope
-    /// (i.e. the scope isn't used to collect defs as export candidates)
-    fn wrap_scope(&mut self, node: ast::StmtList, state: NodeState) {
-        let is_significant_scope = node.syntax().parent().map_or(false, |parent| {
-            matches!(
-                parent.kind(),
-                SyntaxKind::Source
-                    | SyntaxKind::ModuleDecl
-                    | SyntaxKind::ClassDecl
-                    | SyntaxKind::MonitorDecl
-            )
-        });
-
-        if is_significant_scope {
-            return;
-        }
-
-        match state {
-            NodeState::Enter => {
-                self.scopes.push_scope();
-            }
-            NodeState::Leave => {
-                self.scopes.pop_scope();
             }
         }
     }
 
     fn intern_range(&mut self, range: TextRange) -> SpanId {
         self.res.spans.intern_span(Span::new(self.file, range))
-    }
-
-    fn add_exported_name(
-        &mut self,
-        name: ast::Name,
-        kind: Option<SymbolKind>,
-        is_pervasive: IsPervasive,
-    ) -> LocalDefId {
-        let local_def = self.add_name(name, kind, is_pervasive);
-        // introduce into export candidates
-        self.scopes.introduce_def(local_def);
-        local_def
-    }
-
-    fn add_exported_name_list(
-        &mut self,
-        name_list: ast::NameList,
-        kind: Option<SymbolKind>,
-        is_pervasive: IsPervasive,
-    ) -> Vec<LocalDefId> {
-        let defs = self.add_name_list(name_list, kind, is_pervasive);
-
-        // introduce into export candidates
-        for &local_def in &defs {
-            self.scopes.introduce_def(local_def);
-        }
-
-        defs
     }
 
     fn add_name_list(
@@ -269,21 +148,6 @@ impl<'a> FileCollector<'a> {
     fn bind_span(&mut self, local_def: LocalDefId, span: SpanId) {
         self.res.node_defs.insert(NodeSpan(span), local_def);
     }
-
-    fn lookup_name_def(&mut self, name: Option<ast::Name>) -> Option<LocalDefId> {
-        let name = name?.identifier_token().unwrap();
-
-        let span = self.intern_range(name.text_range());
-        let ident = NodeSpan(span);
-        let local_def = self
-            .res
-            .node_defs
-            .get(&ident)
-            .copied()
-            .expect("def didn't get added beforehand");
-
-        Some(local_def)
-    }
 }
 
 impl FileCollector<'_> {
@@ -294,7 +158,7 @@ impl FileCollector<'_> {
         let is_var = node.var_token().is_some();
         let mutability = Mutability::from_is_mutable(is_var);
 
-        self.add_exported_name_list(
+        self.add_name_list(
             node.decl_list().unwrap(),
             Some(SymbolKind::ConstVar(mutability, is_register.into())),
             is_pervasive.into(),
@@ -304,7 +168,7 @@ impl FileCollector<'_> {
     fn collect_decl_type(&mut self, node: ast::TypeDecl) {
         if let Some(name) = node.decl_name() {
             let is_pervasive = node.pervasive_attr().is_some();
-            self.add_exported_name(name, Some(SymbolKind::Type), is_pervasive.into());
+            self.add_name(name, Some(SymbolKind::Type), is_pervasive.into());
         }
     }
 
@@ -316,7 +180,7 @@ impl FileCollector<'_> {
 
                 // Bindings are never pervasive, since they aren't meant to escape
                 // the local scope
-                self.add_exported_name(
+                self.add_name(
                     name,
                     Some(SymbolKind::Binding(mutability, is_register.into())),
                     IsPervasive::No,
@@ -331,7 +195,7 @@ impl FileCollector<'_> {
 
         if let Some(name) = header.name() {
             let is_pervasive = header.pervasive_attr().is_some();
-            self.add_exported_name(
+            self.add_name(
                 name,
                 Some(SymbolKind::Subprogram(SubprogramKind::Procedure)),
                 is_pervasive.into(),
@@ -347,7 +211,7 @@ impl FileCollector<'_> {
 
         if let Some(name) = header.name() {
             let is_pervasive = header.pervasive_attr().is_some();
-            self.add_exported_name(
+            self.add_name(
                 name,
                 Some(SymbolKind::Subprogram(SubprogramKind::Function)),
                 is_pervasive.into(),
@@ -372,7 +236,7 @@ impl FileCollector<'_> {
 
         if let Some(name) = header.name() {
             let is_pervasive = header.pervasive_attr().is_some();
-            self.add_exported_name(
+            self.add_name(
                 name,
                 Some(SymbolKind::Subprogram(SubprogramKind::Process)),
                 is_pervasive.into(),
@@ -421,55 +285,27 @@ impl FileCollector<'_> {
         }
     }
 
-    fn collect_decl_module(&mut self, node: ast::ModuleDecl, state: NodeState) {
-        match state {
-            NodeState::Enter => {
-                // name
-                if let Some(name) = node.name() {
-                    let is_pervasive = node.pervasive_attr().is_some();
-                    self.add_exported_name(
-                        name,
-                        Some(SymbolKind::Module(IsMonitor::No)),
-                        is_pervasive.into(),
-                    );
-                }
-
-                self.scopes.push_scope();
-            }
-            NodeState::Leave => {
-                let candidates = self.scopes.pop_scope();
-
-                if let Some(local_def) = self.lookup_name_def(node.name()) {
-                    // associate defs as export candidates
-                    self.res.assoc_defs.insert(local_def, candidates);
-                }
-            }
+    fn collect_decl_module(&mut self, node: ast::ModuleDecl) {
+        // name
+        if let Some(name) = node.name() {
+            let is_pervasive = node.pervasive_attr().is_some();
+            self.add_name(
+                name,
+                Some(SymbolKind::Module(IsMonitor::No)),
+                is_pervasive.into(),
+            );
         }
     }
 
     fn collect_decl_import(&mut self, node: ast::ImportItem) {
         if let Some(name) = node.external_item().and_then(|item| item.name()) {
-            let local_def = self.add_name(name, Some(SymbolKind::Import), IsPervasive::No);
-
-            // Only consider as an export candidate if we aren't in a forward decl
-            // <ImportItem> => ImportList => ForwardDecl
-            // TODO: use a def scope instead once we deal with forward decls
-            let in_forward_decl = Some(node)
-                .and_then(|n| n.syntax().parent())
-                .and_then(ast::ImportList::cast)
-                .and_then(|n| n.syntax().parent())
-                .and_then(ast::ForwardDecl::cast)
-                .is_some();
-
-            if !in_forward_decl {
-                self.scopes.introduce_def(local_def);
-            }
+            self.add_name(name, Some(SymbolKind::Import), IsPervasive::No);
         }
     }
 
     fn collect_stmt_for(&mut self, node: ast::ForStmt) {
         if let Some(name) = node.name() {
-            self.add_exported_name(
+            self.add_name(
                 name,
                 Some(SymbolKind::ConstVar(Mutability::Const, IsRegister::No)),
                 IsPervasive::No,
@@ -478,16 +314,9 @@ impl FileCollector<'_> {
     }
 
     fn collect_ty_enum(&mut self, node: ast::EnumType) {
-        let variants = node
-            .fields()
-            .unwrap()
-            .names()
-            .map(|name| self.add_name(name, Some(SymbolKind::EnumVariant), IsPervasive::No))
-            .collect();
-
         let span = self.intern_range(node.syntax().text_range());
         let local_def = self.res.defs.add_def(
-            type_decl_name(node),
+            type_decl_name(&node),
             span,
             Some(SymbolKind::Enum),
             IsPervasive::No,
@@ -496,13 +325,19 @@ impl FileCollector<'_> {
         // bind it to the entire type node, since it doesn't have a name
         self.bind_span(local_def, span);
 
-        self.res.assoc_defs.insert(local_def, variants);
+        // Make the variant defs after the name so that adding new variants
+        // doesn't affect the primary enum def
+        self.add_name_list(
+            node.fields().unwrap(),
+            Some(SymbolKind::EnumVariant),
+            IsPervasive::No,
+        );
     }
 
     fn collect_ty_set(&mut self, node: ast::SetType) {
         let span = self.intern_range(node.syntax().text_range());
         let local_def = self.res.defs.add_def(
-            type_decl_name(node),
+            type_decl_name(&node),
             span,
             Some(SymbolKind::Set),
             IsPervasive::No,
@@ -524,7 +359,7 @@ impl FileCollector<'_> {
 }
 
 /// Gets the name from the enclosing `type` decl, or the [`Anonymous`](syms::Anonymous) symbol
-fn type_decl_name(ty: impl ast::AstNode) -> Symbol {
+fn type_decl_name(ty: &impl ast::AstNode) -> Symbol {
     ty.syntax()
         .parent()
         .and_then(ast::TypeDecl::cast)

--- a/compiler/toc_hir_lowering/src/collector.rs
+++ b/compiler/toc_hir_lowering/src/collector.rs
@@ -1,0 +1,464 @@
+//! Collecting all defs declared in a library
+
+use std::collections::HashMap;
+
+use toc_hir::{
+    symbol::{
+        DefInfoTable, DefMap, Ident, IsMonitor, IsPervasive, IsRegister, LocalDefId, Mutability,
+        SubprogramKind, SymbolKind,
+    },
+    ty::PassBy,
+};
+use toc_reporting::{CompileResult, MessageSink};
+use toc_span::{FileId, Span, SpanId, SpanTable, TextRange};
+use toc_syntax::{
+    ast::{self, AstNode},
+    match_ast, SyntaxKind, WalkEvent,
+};
+
+use crate::LoweringDb;
+
+#[derive(Debug, Default)]
+pub(crate) struct CollectRes {
+    pub(crate) defs: DefInfoTable,
+    pub(crate) ident_defs: HashMap<Ident, LocalDefId>,
+    pub(crate) export_candidates: DefMap<Vec<LocalDefId>>,
+    pub(crate) spans: SpanTable,
+}
+
+pub(crate) fn collect_defs(
+    db: &dyn LoweringDb,
+    reachable_files: &[FileId],
+) -> CompileResult<CollectRes> {
+    let mut res = CollectRes::default();
+    let mut messages = MessageSink::default();
+
+    for &file in reachable_files {
+        let root = ast::Source::cast(db.parse_file(file).result().syntax()).unwrap();
+        CollectCtx::collect(file, root, &mut res, &mut messages);
+    }
+
+    CompileResult::new(res, messages.finish())
+}
+
+/// Whether we're entering or leaving a node
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum NodeState {
+    Enter,
+    Leave,
+}
+
+struct DefScope {
+    defs: Vec<Vec<LocalDefId>>,
+}
+
+impl DefScope {
+    fn new() -> Self {
+        Self { defs: vec![vec![]] }
+    }
+
+    fn introduce_def(&mut self, local_def: LocalDefId) {
+        self.defs
+            .last_mut()
+            .expect("root scope was popped off")
+            .push(local_def);
+    }
+
+    fn push_scope(&mut self) {
+        self.defs.push(vec![])
+    }
+
+    fn pop_scope(&mut self) -> Vec<LocalDefId> {
+        self.defs.pop().expect("root scope was popped off")
+    }
+}
+
+impl Default for DefScope {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+struct CollectCtx<'a> {
+    file: FileId,
+    root: ast::Source,
+    res: &'a mut CollectRes,
+    _messages: &'a mut MessageSink,
+    scopes: DefScope,
+}
+
+impl<'a> CollectCtx<'a> {
+    fn collect(
+        file: FileId,
+        root: ast::Source,
+        res: &'a mut CollectRes,
+        messages: &'a mut MessageSink,
+    ) {
+        let mut ctx = Self {
+            file,
+            root,
+            res,
+            _messages: messages,
+            scopes: Default::default(),
+        };
+
+        ctx.collect_root();
+    }
+
+    fn collect_root(&mut self) {
+        // FIXME: generate defs for this import statement
+        // self.root.import_stmt();
+
+        // Doesn't matter if it's a unit, since def generation is the
+        // same regardless
+
+        for event in self.root.syntax().preorder() {
+            // Pull out node & state
+            let (node, state) = match event {
+                WalkEvent::Enter(n) => (n, NodeState::Enter),
+                WalkEvent::Leave(n) => (n, NodeState::Leave),
+            };
+
+            // FIXME: Handle include globs
+            // AAAAAAAAAAAAAAAAAAAAAAAAAAA
+
+            match_ast! {
+                match (node) {
+                    // Decls //
+                    ast::ConstVarDecl(decl) => self.collect_decl_constvar(decl, state),
+                    ast::TypeDecl(decl) => self.collect_decl_type(decl, state),
+                    ast::BindDecl(decl) => self.collect_decl_bind(decl, state),
+                    ast::ProcDecl(decl) => self.collect_decl_proc(decl, state),
+                    ast::FcnDecl(decl) => self.collect_decl_fcn(decl, state),
+                    ast::ProcessDecl(decl) => self.collect_decl_process(decl, state),
+                    ast::ExternalDecl(_decl) => {},
+                    ast::ForwardDecl(_decl) => {},
+                    ast::DeferredDecl(_decl) => {},
+                    ast::BodyDecl(_decl) => {},
+                    ast::ModuleDecl(decl) => self.collect_decl_module(decl, state),
+                    ast::ClassDecl(_decl) => {},
+                    ast::MonitorDecl(_decl) => {},
+
+                    // Notable stmts //
+                    ast::ForStmt(stmt) => self.collect_stmt_for(stmt, state),
+                    ast::HandlerStmt(_stmt) => {},
+
+                    // Scopes don't need to be precise, so long as they
+                    // prevent defs from escaping & being considered
+                    // export candidates
+                    ast::StmtList(stmt) => self.wrap_scope(stmt, state),
+
+                    // Types //
+                    ast::CollectionType(_ty) => {},
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    /// Wraps stmt nodes in a scope, but only if it doesn't have a significant scope
+    /// (i.e. the scope isn't used to collect defs as export candidates)
+    fn wrap_scope(&mut self, node: ast::StmtList, state: NodeState) {
+        let is_significant_scope = node.syntax().parent().map_or(false, |parent| {
+            matches!(
+                parent.kind(),
+                SyntaxKind::Source
+                    | SyntaxKind::ModuleDecl
+                    | SyntaxKind::ClassDecl
+                    | SyntaxKind::MonitorDecl
+            )
+        });
+
+        if is_significant_scope {
+            return;
+        }
+
+        match state {
+            NodeState::Enter => {
+                self.scopes.push_scope();
+            }
+            NodeState::Leave => {
+                self.scopes.pop_scope();
+            }
+        }
+    }
+
+    fn intern_range(&mut self, range: TextRange) -> SpanId {
+        self.res.spans.intern_span(Span::new(self.file, range))
+    }
+
+    fn add_exported_name(
+        &mut self,
+        name: ast::Name,
+        kind: Option<SymbolKind>,
+        is_pervasive: IsPervasive,
+    ) -> LocalDefId {
+        let local_def = self.add_name(name, kind, is_pervasive);
+        // introduce into export candidates
+        self.scopes.introduce_def(local_def);
+        local_def
+    }
+
+    fn add_exported_name_list(
+        &mut self,
+        name_list: ast::NameList,
+        kind: Option<SymbolKind>,
+        is_pervasive: IsPervasive,
+    ) -> Vec<LocalDefId> {
+        let defs = self.add_name_list(name_list, kind, is_pervasive);
+
+        // introduce into export candidates
+        for &local_def in &defs {
+            self.scopes.introduce_def(local_def);
+        }
+
+        defs
+    }
+
+    fn add_name_list(
+        &mut self,
+        name_list: ast::NameList,
+        kind: Option<SymbolKind>,
+        is_pervasive: IsPervasive,
+    ) -> Vec<LocalDefId> {
+        name_list
+            .names()
+            .map(|name| self.add_name(name, kind, is_pervasive))
+            .collect()
+    }
+
+    fn add_name(
+        &mut self,
+        name: ast::Name,
+        kind: Option<SymbolKind>,
+        is_pervasive: IsPervasive,
+    ) -> LocalDefId {
+        let name_tok = name.identifier_token().unwrap();
+        let name = name_tok.text();
+        let span = self.intern_range(name_tok.text_range());
+
+        let def_id = self.res.defs.add_def(name.into(), span, kind, is_pervasive);
+        self.res.ident_defs.insert(Ident(name.into(), span), def_id);
+
+        def_id
+    }
+
+    fn lookup_def(&mut self, name: Option<ast::Name>) -> Option<LocalDefId> {
+        let name = name?.identifier_token().unwrap();
+
+        let span = self.intern_range(name.text_range());
+        let ident = Ident(name.text().into(), span);
+        let local_def = self
+            .res
+            .ident_defs
+            .get(&ident)
+            .copied()
+            .expect("def didn't get added beforehand");
+
+        Some(local_def)
+    }
+}
+
+impl CollectCtx<'_> {
+    // Decls //
+    fn collect_decl_constvar(&mut self, node: ast::ConstVarDecl, state: NodeState) {
+        if matches!(state, NodeState::Leave) {
+            return;
+        }
+
+        let is_pervasive = node.pervasive_attr().is_some();
+        let is_register = node.register_attr().is_some();
+        let is_var = node.var_token().is_some();
+        let mutability = Mutability::from_is_mutable(is_var);
+
+        self.add_exported_name_list(
+            node.decl_list().unwrap(),
+            Some(SymbolKind::ConstVar(mutability, is_register.into())),
+            is_pervasive.into(),
+        );
+    }
+
+    fn collect_decl_type(&mut self, node: ast::TypeDecl, state: NodeState) {
+        if matches!(state, NodeState::Leave) {
+            return;
+        }
+
+        if let Some(name) = node.decl_name() {
+            let is_pervasive = node.pervasive_attr().is_some();
+            self.add_exported_name(name, Some(SymbolKind::Type), is_pervasive.into());
+        }
+    }
+
+    fn collect_decl_bind(&mut self, node: ast::BindDecl, state: NodeState) {
+        if matches!(state, NodeState::Leave) {
+            return;
+        }
+
+        for binding in node.bindings() {
+            if let Some(name) = binding.bind_as() {
+                let mutability = Mutability::from_is_mutable(binding.as_var().is_some());
+                let is_register = binding.to_register().is_some();
+
+                // Bindings are never pervasive, since they aren't meant to escape
+                // the local scope
+                self.add_exported_name(
+                    name,
+                    Some(SymbolKind::Binding(mutability, is_register.into())),
+                    IsPervasive::No,
+                );
+            }
+        }
+    }
+
+    fn collect_decl_proc(&mut self, node: ast::ProcDecl, state: NodeState) {
+        // scope wrapping handled by `wrap_scope`
+        if matches!(state, NodeState::Leave) {
+            return;
+        }
+
+        // name + param names
+        let header = node.proc_header().unwrap();
+
+        if let Some(name) = header.name() {
+            let is_pervasive = header.pervasive_attr().is_some();
+            self.add_exported_name(
+                name,
+                Some(SymbolKind::Subprogram(SubprogramKind::Procedure)),
+                is_pervasive.into(),
+            );
+        }
+
+        self.collect_formals_spec(header.params());
+    }
+
+    fn collect_decl_fcn(&mut self, node: ast::FcnDecl, state: NodeState) {
+        // scope wrapping handled by `wrap_scope`
+        if matches!(state, NodeState::Leave) {
+            return;
+        }
+
+        // name + param names + maybe result name
+        let header = node.fcn_header().unwrap();
+
+        if let Some(name) = header.name() {
+            let is_pervasive = header.pervasive_attr().is_some();
+            self.add_exported_name(
+                name,
+                Some(SymbolKind::Subprogram(SubprogramKind::Function)),
+                is_pervasive.into(),
+            );
+        }
+
+        self.collect_formals_spec(header.params());
+
+        if let Some(res_name) = header.fcn_result().and_then(|res| res.name()) {
+            // ???: Does this need to be pass by value? (can it be pass by const ref?)
+            self.add_name(
+                res_name,
+                Some(SymbolKind::Param(PassBy::Value, IsRegister::No)),
+                IsPervasive::No,
+            );
+        }
+    }
+
+    fn collect_decl_process(&mut self, node: ast::ProcessDecl, state: NodeState) {
+        // scope wrapping handled by `wrap_scope`
+        if matches!(state, NodeState::Leave) {
+            return;
+        }
+
+        // name + param names
+        let header = node.process_header().unwrap();
+
+        if let Some(name) = header.name() {
+            let is_pervasive = header.pervasive_attr().is_some();
+            self.add_exported_name(
+                name,
+                Some(SymbolKind::Subprogram(SubprogramKind::Process)),
+                is_pervasive.into(),
+            );
+        }
+
+        self.collect_formals_spec(header.params());
+    }
+
+    fn collect_formals_spec(&mut self, param_spec: Option<ast::ParamSpec>) {
+        let param_spec = match param_spec {
+            Some(it) => it,
+            _ => return,
+        };
+
+        for param in param_spec.param_decl() {
+            match param {
+                ast::ParamDecl::ConstVarParam(param) => {
+                    let is_register = param.bind_to_register().is_some();
+                    let pass_by = match param.pass_as_ref() {
+                        None => PassBy::Value,
+                        Some(_) => PassBy::Reference(Mutability::Var),
+                    };
+
+                    self.add_name_list(
+                        param.param_names().unwrap(),
+                        Some(SymbolKind::Param(pass_by, is_register.into())),
+                        IsPervasive::No,
+                    );
+                }
+                ast::ParamDecl::SubprogType(param) => {
+                    let name = match param {
+                        ast::SubprogType::FcnType(header) => header.name(),
+                        ast::SubprogType::ProcType(header) => header.name(),
+                    };
+
+                    if let Some(name) = name {
+                        self.add_name(
+                            name,
+                            Some(SymbolKind::Param(PassBy::Value, IsRegister::No)),
+                            IsPervasive::No,
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    fn collect_decl_module(&mut self, node: ast::ModuleDecl, state: NodeState) {
+        match state {
+            NodeState::Enter => {
+                // name
+                if let Some(name) = node.name() {
+                    let is_pervasive = node.pervasive_attr().is_some();
+                    self.add_exported_name(
+                        name,
+                        Some(SymbolKind::Module(IsMonitor::No)),
+                        is_pervasive.into(),
+                    );
+                }
+
+                self.scopes.push_scope();
+            }
+            NodeState::Leave => {
+                let candidates = self.scopes.pop_scope();
+
+                if let Some(local_def) = self.lookup_def(node.name()) {
+                    // associate defs as export candidates
+                    self.res.export_candidates.insert(local_def, candidates);
+                }
+            }
+        }
+    }
+
+    fn collect_stmt_for(&mut self, node: ast::ForStmt, state: NodeState) {
+        // scope wrapping handled by `wrap_scope`
+        if matches!(state, NodeState::Leave) {
+            return;
+        }
+
+        if let Some(name) = node.name() {
+            self.add_exported_name(
+                name,
+                Some(SymbolKind::ConstVar(Mutability::Const, IsRegister::No)),
+                IsPervasive::No,
+            );
+        }
+    }
+}

--- a/compiler/toc_hir_lowering/src/lib.rs
+++ b/compiler/toc_hir_lowering/src/lib.rs
@@ -19,6 +19,7 @@
 
 mod lower;
 mod resolver;
+mod collector;
 
 use toc_hir::{library::LoweredLibrary, library_graph::LibraryGraph};
 use toc_reporting::CompileResult;

--- a/compiler/toc_hir_lowering/src/lib.rs
+++ b/compiler/toc_hir_lowering/src/lib.rs
@@ -20,6 +20,7 @@
 mod lower;
 mod resolver;
 mod collector;
+mod ast_resolver;
 
 use toc_hir::{library::LoweredLibrary, library_graph::LibraryGraph};
 use toc_reporting::CompileResult;

--- a/compiler/toc_hir_lowering/src/lower.rs
+++ b/compiler/toc_hir_lowering/src/lower.rs
@@ -66,6 +66,11 @@ where
         }
 
         let reachable_files: Vec<_> = self.depend_graph(library_root).unit_sources().collect();
+
+        // Collect all the defs in the library
+        let (collect_res, msgs) = crate::collector::collect_defs(db, &reachable_files).take();
+        messages = messages.combine(msgs);
+
         let mut root_items = vec![];
         let mut library = builder::LibraryBuilder::default();
 

--- a/compiler/toc_hir_lowering/src/lower.rs
+++ b/compiler/toc_hir_lowering/src/lower.rs
@@ -72,13 +72,20 @@ where
         let (collect_res, msgs) = crate::collector::collect_defs(db, &reachable_files).take();
         messages = messages.combine(msgs);
 
+        let (resolve_res, msgs) =
+            crate::ast_resolver::resolve_defs(db, &reachable_files, collect_res).take();
+        messages = messages.combine(msgs);
+
         let mut root_items = vec![];
-        let mut library = builder::LibraryBuilder::new(collect_res.spans, collect_res.defs);
+        let mut library = builder::LibraryBuilder::new(
+            resolve_res.spans,
+            resolve_res.defs,
+        );
 
         // Lower all files reachable from the library root
         for file in reachable_files {
             let (item, msgs) =
-                FileLowering::lower_file(db, file, &mut library, &collect_res.node_defs).take();
+                FileLowering::lower_file(db, file, &mut library, &resolve_res.node_defs).take();
             messages = messages.combine(msgs);
             root_items.push((file, item));
         }

--- a/compiler/toc_hir_lowering/src/lower/stmt.rs
+++ b/compiler/toc_hir_lowering/src/lower/stmt.rs
@@ -741,6 +741,7 @@ impl super::BodyLowering<'_, '_> {
                 .into_iter()
                 .map(|(export_name, item_id)| {
                     let item = self.ctx.library.item(item_id);
+                    let exported_def = item.def_id;
                     let is_opaque = if !matches!(item.kind, item::ItemKind::Type(_)) {
                         // Opaque is only applicable to types
                         false
@@ -772,7 +773,7 @@ impl super::BodyLowering<'_, '_> {
                         mutability,
                         qualify_as,
                         is_opaque,
-                        item_id,
+                        exported_def,
                     }
                 })
                 .collect()
@@ -817,6 +818,7 @@ impl super::BodyLowering<'_, '_> {
 
                     if let Some(item_id) = item {
                         let item = self.ctx.library.item(item_id);
+                        let exported_def = item.def_id;
 
                         // Report when opaqueness is not applicable
                         let is_opaque = if is_opaque
@@ -911,7 +913,7 @@ impl super::BodyLowering<'_, '_> {
                             mutability,
                             qualify_as,
                             is_opaque,
-                            item_id,
+                            exported_def,
                         })
                     } else {
                         let span = Span::new(self.ctx.file, name.syntax().text_range());

--- a/compiler/toc_hir_lowering/src/lower/ty.rs
+++ b/compiler/toc_hir_lowering/src/lower/ty.rs
@@ -270,8 +270,8 @@ impl super::BodyLowering<'_, '_> {
 
     fn lower_enum_type(&mut self, ty: ast::EnumType) -> Option<ty::TypeKind> {
         let node_span = self.ctx.node_span(ty.syntax().text_range());
-        let def_id = self.ctx.library.node_def(node_span);
-        let variants = self.ctx.library.associated_defs(def_id).clone();
+        let def_id = self.ctx.node_def(node_span);
+        let variants = self.ctx.collect_optional_name_defs(ty.fields().unwrap());
 
         Some(ty::TypeKind::Enum(ty::Enum { def_id, variants }))
     }
@@ -389,7 +389,7 @@ impl super::BodyLowering<'_, '_> {
 
     fn lower_set_type(&mut self, ty: ast::SetType) -> Option<ty::TypeKind> {
         let node_span = self.ctx.node_span(ty.syntax().text_range());
-        let def_id = self.ctx.library.node_def(node_span);
+        let def_id = self.ctx.node_def(node_span);
         let elem = self.lower_required_type(ty.elem_ty());
 
         Some(ty::TypeKind::Set(ty::Set {

--- a/compiler/toc_hir_lowering/src/resolver.rs
+++ b/compiler/toc_hir_lowering/src/resolver.rs
@@ -455,13 +455,6 @@ impl<'a> ResolveCtx<'a> {
                 this.introduce_def(item.def_id, DeclareKind::Declared);
 
                 if let Some(param_list) = &item.param_list {
-                    // Make sure there aren't any duplicate names
-                    this.with_scope(ScopeKind::SubprogramHeader, |this| {
-                        for param_def in &param_list.names {
-                            this.introduce_def(*param_def, DeclareKind::Declared);
-                        }
-                    });
-
                     for param in &param_list.tys {
                         this.resolve_type(param.param_ty);
                     }
@@ -479,16 +472,11 @@ impl<'a> ResolveCtx<'a> {
                 this.with_scope(ScopeKind::Subprogram, |this| {
                     this.with_scope(ScopeKind::Block, |this| {
                         // Introduce params
+                        // `AlwaysShadow` takes care of reporting duplicate params,
+                        // while also properly shadowing external names
                         if let Some(param_list) = &item.param_list {
                             for &param_def in &param_list.names {
-                                let def_info = &this.library.local_def(param_def);
-                                let name = def_info.name;
-                                this.scopes.def_sym(
-                                    name,
-                                    param_def,
-                                    DeclareKind::Declared,
-                                    def_info.pervasive.into(),
-                                );
+                                this.introduce_def(param_def, DeclareKind::AlwaysShadow);
                             }
                         }
 

--- a/compiler/toc_hir_lowering/src/resolver.rs
+++ b/compiler/toc_hir_lowering/src/resolver.rs
@@ -1,6 +1,6 @@
 //! Resolution of name nodes to specific local defs
 
-mod scopes;
+pub(crate) mod scopes;
 
 use toc_hir::{
     body::{BodyId, BodyKind},

--- a/compiler/toc_hir_pretty/src/graph.rs
+++ b/compiler/toc_hir_pretty/src/graph.rs
@@ -634,12 +634,12 @@ impl<'out, 'hir> HirVisitor for PrettyVisitor<'out, 'hir> {
                         format!("ex_{idx}_def_id"),
                         self.display_def_id(export.def_id),
                     ),
-                    Layout::NamedPort(format!("ex_{idx}_item_id"), "item_id".into()),
+                    Layout::NamedPort(format!("ex_{idx}_exported_def"), "exported_def".into()),
                 ]));
 
                 self.emit_edge(
-                    format!("{export_table}:ex_{idx}_item_id"),
-                    self.item_id(export.item_id),
+                    format!("{export_table}:ex_{idx}_exported_def"),
+                    self.def_id(export.def_id),
                 );
 
                 v_layout.push(Layout::Hbox(h_layout));

--- a/compiler/toc_syntax/src/lib.rs
+++ b/compiler/toc_syntax/src/lib.rs
@@ -443,6 +443,9 @@ pub type SyntaxToken = rowan::SyntaxToken<Lang>;
 #[allow(unused)]
 pub type SyntaxElement = rowan::NodeOrToken<SyntaxNode, SyntaxToken>;
 
+// Other rowan re-exports
+pub use rowan::WalkEvent;
+
 // Operators
 
 pub const MIN_REF_BINDING_POWER: u8 = 19;


### PR DESCRIPTION
The main disadvantage to doing name res after HIR construction is that we can't generate defs for foreign unqualified items, since the def map is frozen in the `Library`.
Moving resolution to before HIR construction allows us to do so.