### PR TITLE
Precollect defs before HIR lowering

### DIFF
--- a/compiler/toc_analysis/src/const_eval/snapshots/toc_analysis__const_eval__test__error_no_const_expr-4.snap
+++ b/compiler/toc_analysis/src/const_eval/snapshots/toc_analysis__const_eval__test__error_no_const_expr-4.snap
@@ -2,6 +2,6 @@
 source: compiler/toc_analysis/src/const_eval/test.rs
 expression: "const b := a"
 ---
-"b"@(FileId(1), 6..7) -> ConstError { kind: NotConstExpr(Binding(LibraryId(0), Spanned("a", SpanId(3)))), span: (FileId(1), 11..12) }
+"b"@(FileId(1), 6..7) -> ConstError { kind: NotConstExpr(Binding(LibraryId(0), Spanned("a", SpanId(4)))), span: (FileId(1), 11..12) }
 
 

--- a/compiler/toc_analysis/src/const_eval/snapshots/toc_analysis__const_eval__test__error_no_const_expr-6.snap
+++ b/compiler/toc_analysis/src/const_eval/snapshots/toc_analysis__const_eval__test__error_no_const_expr-6.snap
@@ -2,7 +2,7 @@
 source: compiler/toc_analysis/src/const_eval/test.rs
 expression: "\n    module base\n        export ~. tail\n    end base\n\n    module target\n        import tail\n        const _ := tail\n    end target\n    "
 ---
-"_"@(FileId(1), 106..107) -> ConstError { kind: NotConstExpr(Binding(LibraryId(0), Spanned("tail", SpanId(9)))), span: (FileId(1), 111..115) }
+"_"@(FileId(1), 106..107) -> ConstError { kind: NotConstExpr(Binding(LibraryId(0), Spanned("tail", SpanId(10)))), span: (FileId(1), 111..115) }
 
 error in file FileId(1) at 111..115: cannot compute `tail` at compile-time
 | error in file FileId(1) for 111..115: expression cannot be computed at compile-time

--- a/compiler/toc_analysis/src/ty/lower.rs
+++ b/compiler/toc_analysis/src/ty/lower.rs
@@ -345,7 +345,7 @@ fn type_def_ty(
         module
             .exports_of()
             .iter()
-            .find(|export| export.item_id == item_id.1)
+            .find(|export| export.exported_def == item.def_id)
             .map_or(false, |export| export.is_opaque)
     };
 

--- a/compiler/toc_analysis/src/ty/query.rs
+++ b/compiler/toc_analysis/src/ty/query.rs
@@ -49,7 +49,7 @@ fn ty_of_def(db: &dyn db::TypeDatabase, def_id: DefId) -> TypeId {
 
                 let module = library.module_item(module_id);
                 let export = module.export(export_id);
-                let def_id = DefId(def_id.0, library.item(export.item_id).def_id);
+                let def_id = DefId(def_id.0, export.exported_def);
 
                 db.type_of(def_id.into())
             }
@@ -439,7 +439,7 @@ pub(crate) fn fields_of(
                         .exports
                         .iter()
                         .map(|export| {
-                            let local_def = library.item(export.item_id).def_id;
+                            let local_def = export.exported_def;
                             let field_name = library.local_def(local_def).name;
                             let def_id = DefId(library_id, local_def);
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_array_param.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_array_param.snap
@@ -2,11 +2,11 @@
 source: compiler/toc_analysis/src/typeck/test.rs
 expression: "type tp: proc(_ : array 1..2 of char(*))\nvar a : array 1..2 of char\nvar b : array 1..2 of char(42)\nvar p : tp\n\n% element type is also coercible\np(a)\np(b)\n"
 ---
-"<unnamed>"@(dummy) [Undeclared]: <error>
+"tp"@(FileId(1), 5..7) [Type]: alias[DefId(LibraryId(0), LocalDefId(0))] of procedure ( pass(value) array ( range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No)), ) of char_n Any, ) -> void
 "_"@(FileId(1), 14..15) [Param(Value, No)]: <error>
-"tp"@(FileId(1), 5..7) [Type]: alias[DefId(LibraryId(0), LocalDefId(2))] of procedure ( pass(value) array ( range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No)), ) of char_n Any, ) -> void
 "a"@(FileId(1), 45..46) [ConstVar(Var, No)]: array ( range of `int` (Unevaluated(LibraryId(0), BodyId(2)) .. Expr(Unevaluated(LibraryId(0), BodyId(3)), Yes)), ) of char
 "b"@(FileId(1), 72..73) [ConstVar(Var, No)]: array ( range of `int` (Unevaluated(LibraryId(0), BodyId(4)) .. Expr(Unevaluated(LibraryId(0), BodyId(5)), Yes)), ) of char_n Fixed(Unevaluated(LibraryId(0), BodyId(6)))
-"p"@(FileId(1), 103..104) [ConstVar(Var, No)]: alias[DefId(LibraryId(0), LocalDefId(2))] of procedure ( pass(value) array ( range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No)), ) of char_n Any, ) -> void
+"p"@(FileId(1), 103..104) [ConstVar(Var, No)]: alias[DefId(LibraryId(0), LocalDefId(0))] of procedure ( pass(value) array ( range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No)), ) of char_n Any, ) -> void
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "<root>"@(dummy) [Module(No)]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_char_any_lhs.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_char_any_lhs.snap
@@ -3,7 +3,6 @@ source: compiler/toc_analysis/src/typeck/test.rs
 expression: "proc __(var c_any : char(*), var s_any : string(*), var _v00, _v01, _v02, _v03, _v04, _v05, _v06, _v07, _v08 : char(*))\n% all runtime checked\nvar c : char\nvar c1 : char(1)\nvar c5 : char(5)\nvar c255 : char(255)\nvar s : string\nvar s1 : string(1)\nvar s5 : string(5)\n\n_v00 := c\n_v01 := c1\n_v02 := c5\n_v03 := c255\n_v04 := c_any\n_v05 := s\n_v06 := s1\n_v07 := s5\n_v08 := s_any\nend __\n"
 ---
 "__"@(FileId(1), 5..7) [Subprogram(Procedure)]: procedure ( pass(var ref) char_n Any, pass(var ref) string_n Any, pass(var ref) char_n Any, pass(var ref) char_n Any, pass(var ref) char_n Any, pass(var ref) char_n Any, pass(var ref) char_n Any, pass(var ref) char_n Any, pass(var ref) char_n Any, pass(var ref) char_n Any, pass(var ref) char_n Any, ) -> void
-"<unnamed>"@(dummy) [Undeclared]: <error>
 "c_any"@(FileId(1), 12..17) [Param(Reference(Var), No)]: char_n Any
 "s_any"@(FileId(1), 33..38) [Param(Reference(Var), No)]: string_n Any
 "_v00"@(FileId(1), 56..60) [Param(Reference(Var), No)]: char_n Any
@@ -22,5 +21,6 @@ expression: "proc __(var c_any : char(*), var s_any : string(*), var _v00, _v01,
 "s"@(FileId(1), 214..215) [ConstVar(Var, No)]: string
 "s1"@(FileId(1), 229..231) [ConstVar(Var, No)]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(3)))
 "s5"@(FileId(1), 248..250) [ConstVar(Var, No)]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(4)))
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "<root>"@(dummy) [Module(No)]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_char_any_rhs.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_char_any_rhs.snap
@@ -3,7 +3,6 @@ source: compiler/toc_analysis/src/typeck/test.rs
 expression: "% all runtime checked\nproc __(var s_any, _v09 : string(*), var c_any, _v05 : char(*))\n\nvar _v00 : char := c_any\nvar _v01 : char(1) := c_any\nvar _v02 : char(5) := c_any\nvar _v03 : char(255) := c_any\nvar _v04 : char(256) := c_any\n_v05 := c_any\nvar _v06 : string := c_any\nvar _v07 : string(1) := c_any\nvar _v08 : string(5) := c_any\n_v09 := c_any\nend __\n"
 ---
 "__"@(FileId(1), 27..29) [Subprogram(Procedure)]: procedure ( pass(var ref) string_n Any, pass(var ref) string_n Any, pass(var ref) char_n Any, pass(var ref) char_n Any, ) -> void
-"<unnamed>"@(dummy) [Undeclared]: <error>
 "s_any"@(FileId(1), 34..39) [Param(Reference(Var), No)]: string_n Any
 "_v09"@(FileId(1), 41..45) [Param(Reference(Var), No)]: string_n Any
 "c_any"@(FileId(1), 63..68) [Param(Reference(Var), No)]: char_n Any
@@ -16,5 +15,6 @@ expression: "% all runtime checked\nproc __(var s_any, _v09 : string(*), var c_a
 "_v06"@(FileId(1), 246..250) [ConstVar(Var, No)]: string
 "_v07"@(FileId(1), 273..277) [ConstVar(Var, No)]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(10)))
 "_v08"@(FileId(1), 303..307) [ConstVar(Var, No)]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(12)))
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "<root>"@(dummy) [Module(No)]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_constrained_array_range.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_constrained_array_range.snap
@@ -2,12 +2,12 @@
 source: compiler/toc_analysis/src/typeck/test.rs
 expression: "type tp : proc(var _ : array 1 .. * of int)\nvar a : array 1 .. 3 of int\nvar b : array 2 .. 3 of int\nvar p : tp\n\n% only coercible if start bound is the same\np(a) % success\np(b) % fail\n"
 ---
-"<unnamed>"@(dummy) [Undeclared]: <error>
+"tp"@(FileId(1), 5..7) [Type]: alias[DefId(LibraryId(0), LocalDefId(0))] of procedure ( pass(var ref) array ( range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Any), ) of int, ) -> void
 "_"@(FileId(1), 19..20) [Param(Reference(Var), No)]: <error>
-"tp"@(FileId(1), 5..7) [Type]: alias[DefId(LibraryId(0), LocalDefId(2))] of procedure ( pass(var ref) array ( range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Any), ) of int, ) -> void
 "a"@(FileId(1), 48..49) [ConstVar(Var, No)]: array ( range of `int` (Unevaluated(LibraryId(0), BodyId(1)) .. Expr(Unevaluated(LibraryId(0), BodyId(2)), Yes)), ) of int
 "b"@(FileId(1), 76..77) [ConstVar(Var, No)]: array ( range of `int` (Unevaluated(LibraryId(0), BodyId(3)) .. Expr(Unevaluated(LibraryId(0), BodyId(4)), Yes)), ) of int
-"p"@(FileId(1), 104..105) [ConstVar(Var, No)]: alias[DefId(LibraryId(0), LocalDefId(2))] of procedure ( pass(var ref) array ( range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Any), ) of int, ) -> void
+"p"@(FileId(1), 104..105) [ConstVar(Var, No)]: alias[DefId(LibraryId(0), LocalDefId(0))] of procedure ( pass(var ref) array ( range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Any), ) of int, ) -> void
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "<root>"@(dummy) [Module(No)]: <error>
 
 error in file FileId(1) at 173..174: mismatched types

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_constrained_set_elem.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_constrained_set_elem.snap
@@ -2,11 +2,11 @@
 source: compiler/toc_analysis/src/typeck/test.rs
 expression: "type cs : set of 1 .. 2\nvar i : int\nvar n : int\nvar _ : boolean\n\nvar s : cs := cs(1, 2)\n_ := 1 in s\n_ := i in s\n_ := n in s\n"
 ---
+"cs"@(FileId(1), 5..7) [Type]: set[DefId(LibraryId(0), LocalDefId(1))] of range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No))
 "cs"@(FileId(1), 10..23) [Set]: <error>
-"cs"@(FileId(1), 5..7) [Type]: set[DefId(LibraryId(0), LocalDefId(0))] of range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No))
 "i"@(FileId(1), 28..29) [ConstVar(Var, No)]: int
 "n"@(FileId(1), 40..41) [ConstVar(Var, No)]: int
 "_"@(FileId(1), 52..53) [ConstVar(Var, No)]: boolean
-"s"@(FileId(1), 69..70) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(0))] of range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No))
+"s"@(FileId(1), 69..70) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(1))] of range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No))
 "<root>"@(dummy) [Module(No)]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_dyn_array_param_err.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_dyn_array_param_err.snap
@@ -5,8 +5,8 @@ expression: "% dyn arrays aren't allowed, since the range is expected to be know
 "c"@(FileId(1), 89..90) [ConstVar(Var, No)]: int
 "a"@(FileId(1), 101..102) [ConstVar(Var, No)]: array ( range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), Yes)), ) of char
 "p"@(FileId(1), 129..130) [Subprogram(Procedure)]: procedure ( pass(value) array ( range of `int` (Unevaluated(LibraryId(0), BodyId(2)) .. Expr(Unevaluated(LibraryId(0), BodyId(3)), No)), ) of char_n Any, ) -> void
-"<unnamed>"@(dummy) [Undeclared]: <error>
 "_"@(FileId(1), 131..132) [Param(Value, No)]: array ( range of `int` (Unevaluated(LibraryId(0), BodyId(2)) .. Expr(Unevaluated(LibraryId(0), BodyId(3)), No)), ) of char_n Any
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "<root>"@(dummy) [Module(No)]: <error>
 
 error in file FileId(1) at 167..168: mismatched types

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_string_any_lhs.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_string_any_lhs.snap
@@ -3,7 +3,6 @@ source: compiler/toc_analysis/src/typeck/test.rs
 expression: "proc __(var c_any : char(*), var s_any : string(*), var _v00, _v01, _v02, _v03, _v04, _v05, _v06, _v07, _v08 : string(*))\n% all runtime checked\nvar c : char\nvar c1 : char(1)\nvar c5 : char(5)\nvar c255 : char(255)\nvar s : string\nvar s1 : string(1)\nvar s5 : string(5)\n\n_v00 := c\n_v01 := c1\n_v02 := c5\n_v03 := c255\n_v04 := c_any\n_v05 := s\n_v06 := s1\n_v07 := s5\n_v08 := s_any\nend __\n"
 ---
 "__"@(FileId(1), 5..7) [Subprogram(Procedure)]: procedure ( pass(var ref) char_n Any, pass(var ref) string_n Any, pass(var ref) string_n Any, pass(var ref) string_n Any, pass(var ref) string_n Any, pass(var ref) string_n Any, pass(var ref) string_n Any, pass(var ref) string_n Any, pass(var ref) string_n Any, pass(var ref) string_n Any, pass(var ref) string_n Any, ) -> void
-"<unnamed>"@(dummy) [Undeclared]: <error>
 "c_any"@(FileId(1), 12..17) [Param(Reference(Var), No)]: char_n Any
 "s_any"@(FileId(1), 33..38) [Param(Reference(Var), No)]: string_n Any
 "_v00"@(FileId(1), 56..60) [Param(Reference(Var), No)]: string_n Any
@@ -22,5 +21,6 @@ expression: "proc __(var c_any : char(*), var s_any : string(*), var _v00, _v01,
 "s"@(FileId(1), 216..217) [ConstVar(Var, No)]: string
 "s1"@(FileId(1), 231..233) [ConstVar(Var, No)]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(3)))
 "s5"@(FileId(1), 250..252) [ConstVar(Var, No)]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(4)))
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "<root>"@(dummy) [Module(No)]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_string_any_rhs.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_string_any_rhs.snap
@@ -3,7 +3,6 @@ source: compiler/toc_analysis/src/typeck/test.rs
 expression: "% all runtime checked\nproc __(var s_any, _v09 : string(*), var c_any, _v05 : char(*))\n\nvar _v00 : char := s_any\nvar _v01 : char(1) := s_any\nvar _v02 : char(5) := s_any\nvar _v03 : char(255) := s_any\nvar _v04 : char(256) := s_any\n_v05 := s_any\nvar _v06 : string := s_any\nvar _v07 : string(1) := s_any\nvar _v08 : string(5) := s_any\n_v09 := s_any\nend __\n"
 ---
 "__"@(FileId(1), 27..29) [Subprogram(Procedure)]: procedure ( pass(var ref) string_n Any, pass(var ref) string_n Any, pass(var ref) char_n Any, pass(var ref) char_n Any, ) -> void
-"<unnamed>"@(dummy) [Undeclared]: <error>
 "s_any"@(FileId(1), 34..39) [Param(Reference(Var), No)]: string_n Any
 "_v09"@(FileId(1), 41..45) [Param(Reference(Var), No)]: string_n Any
 "c_any"@(FileId(1), 63..68) [Param(Reference(Var), No)]: char_n Any
@@ -16,5 +15,6 @@ expression: "% all runtime checked\nproc __(var s_any, _v09 : string(*), var c_a
 "_v06"@(FileId(1), 246..250) [ConstVar(Var, No)]: string
 "_v07"@(FileId(1), 273..277) [ConstVar(Var, No)]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(10)))
 "_v08"@(FileId(1), 303..307) [ConstVar(Var, No)]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(12)))
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "<root>"@(dummy) [Module(No)]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_string_err_lhs.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__assignability_into_string_err_lhs.snap
@@ -4,8 +4,8 @@ expression: "var cmx : char(256)\n\nproc __(var _e00 : string(*))\n_e00 := cmx %
 ---
 "cmx"@(FileId(1), 4..7) [ConstVar(Var, No)]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
 "__"@(FileId(1), 26..28) [Subprogram(Procedure)]: procedure ( pass(var ref) string_n Any, ) -> void
-"<unnamed>"@(dummy) [Undeclared]: <error>
 "_e00"@(FileId(1), 33..37) [Param(Reference(Var), No)]: string_n Any
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "<root>"@(dummy) [Module(No)]: <error>
 
 error in file FileId(1) at 56..58: mismatched types

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_enums_equal.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_enums_equal.snap
@@ -2,9 +2,9 @@
 source: compiler/toc_analysis/src/typeck/test.rs
 expression: "\n    type s : enum(a)\n    var a, b : s\n\n    % should all produce booleans\n    var _v_res : boolean\n\n    _v_res := a = b\n    _v_res := b = a\n    % enum variants are covered by equivalence rules\n    "
 ---
-"a"@(FileId(1), 19..20) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "a"@(FileId(1), 19..20), )
-"s"@(FileId(1), 14..21) [Enum]: <error>
 "s"@(FileId(1), 10..11) [Type]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "a"@(FileId(1), 19..20), )
+"s"@(FileId(1), 14..21) [Enum]: <error>
+"a"@(FileId(1), 19..20) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "a"@(FileId(1), 19..20), )
 "a"@(FileId(1), 30..31) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "a"@(FileId(1), 19..20), )
 "b"@(FileId(1), 33..34) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "a"@(FileId(1), 19..20), )
 "_v_res"@(FileId(1), 82..88) [ConstVar(Var, No)]: boolean

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_enums_greater.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_enums_greater.snap
@@ -2,9 +2,9 @@
 source: compiler/toc_analysis/src/typeck/test.rs
 expression: "\n    type s : enum(a)\n    var a, b : s\n\n    % should all produce booleans\n    var _v_res : boolean\n\n    _v_res := a > b\n    _v_res := b > a\n    % enum variants are covered by equivalence rules\n    "
 ---
-"a"@(FileId(1), 19..20) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "a"@(FileId(1), 19..20), )
-"s"@(FileId(1), 14..21) [Enum]: <error>
 "s"@(FileId(1), 10..11) [Type]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "a"@(FileId(1), 19..20), )
+"s"@(FileId(1), 14..21) [Enum]: <error>
+"a"@(FileId(1), 19..20) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "a"@(FileId(1), 19..20), )
 "a"@(FileId(1), 30..31) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "a"@(FileId(1), 19..20), )
 "b"@(FileId(1), 33..34) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "a"@(FileId(1), 19..20), )
 "_v_res"@(FileId(1), 82..88) [ConstVar(Var, No)]: boolean

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_enums_greater_eq.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_enums_greater_eq.snap
@@ -2,9 +2,9 @@
 source: compiler/toc_analysis/src/typeck/test.rs
 expression: "\n    type s : enum(a)\n    var a, b : s\n\n    % should all produce booleans\n    var _v_res : boolean\n\n    _v_res := a >= b\n    _v_res := b >= a\n    % enum variants are covered by equivalence rules\n    "
 ---
-"a"@(FileId(1), 19..20) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "a"@(FileId(1), 19..20), )
-"s"@(FileId(1), 14..21) [Enum]: <error>
 "s"@(FileId(1), 10..11) [Type]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "a"@(FileId(1), 19..20), )
+"s"@(FileId(1), 14..21) [Enum]: <error>
+"a"@(FileId(1), 19..20) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "a"@(FileId(1), 19..20), )
 "a"@(FileId(1), 30..31) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "a"@(FileId(1), 19..20), )
 "b"@(FileId(1), 33..34) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "a"@(FileId(1), 19..20), )
 "_v_res"@(FileId(1), 82..88) [ConstVar(Var, No)]: boolean

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_enums_less.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_enums_less.snap
@@ -2,9 +2,9 @@
 source: compiler/toc_analysis/src/typeck/test.rs
 expression: "\n    type s : enum(a)\n    var a, b : s\n\n    % should all produce booleans\n    var _v_res : boolean\n\n    _v_res := a < b\n    _v_res := b < a\n    % enum variants are covered by equivalence rules\n    "
 ---
-"a"@(FileId(1), 19..20) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "a"@(FileId(1), 19..20), )
-"s"@(FileId(1), 14..21) [Enum]: <error>
 "s"@(FileId(1), 10..11) [Type]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "a"@(FileId(1), 19..20), )
+"s"@(FileId(1), 14..21) [Enum]: <error>
+"a"@(FileId(1), 19..20) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "a"@(FileId(1), 19..20), )
 "a"@(FileId(1), 30..31) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "a"@(FileId(1), 19..20), )
 "b"@(FileId(1), 33..34) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "a"@(FileId(1), 19..20), )
 "_v_res"@(FileId(1), 82..88) [ConstVar(Var, No)]: boolean

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_enums_less_eq.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_enums_less_eq.snap
@@ -2,9 +2,9 @@
 source: compiler/toc_analysis/src/typeck/test.rs
 expression: "\n    type s : enum(a)\n    var a, b : s\n\n    % should all produce booleans\n    var _v_res : boolean\n\n    _v_res := a <= b\n    _v_res := b <= a\n    % enum variants are covered by equivalence rules\n    "
 ---
-"a"@(FileId(1), 19..20) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "a"@(FileId(1), 19..20), )
-"s"@(FileId(1), 14..21) [Enum]: <error>
 "s"@(FileId(1), 10..11) [Type]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "a"@(FileId(1), 19..20), )
+"s"@(FileId(1), 14..21) [Enum]: <error>
+"a"@(FileId(1), 19..20) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "a"@(FileId(1), 19..20), )
 "a"@(FileId(1), 30..31) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "a"@(FileId(1), 19..20), )
 "b"@(FileId(1), 33..34) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "a"@(FileId(1), 19..20), )
 "_v_res"@(FileId(1), 82..88) [ConstVar(Var, No)]: boolean

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_enums_not_equal.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_enums_not_equal.snap
@@ -2,9 +2,9 @@
 source: compiler/toc_analysis/src/typeck/test.rs
 expression: "\n    type s : enum(a)\n    var a, b : s\n\n    % should all produce booleans\n    var _v_res : boolean\n\n    _v_res := a not= b\n    _v_res := b not= a\n    % enum variants are covered by equivalence rules\n    "
 ---
-"a"@(FileId(1), 19..20) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "a"@(FileId(1), 19..20), )
-"s"@(FileId(1), 14..21) [Enum]: <error>
 "s"@(FileId(1), 10..11) [Type]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "a"@(FileId(1), 19..20), )
+"s"@(FileId(1), 14..21) [Enum]: <error>
+"a"@(FileId(1), 19..20) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "a"@(FileId(1), 19..20), )
 "a"@(FileId(1), 30..31) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "a"@(FileId(1), 19..20), )
 "b"@(FileId(1), 33..34) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "a"@(FileId(1), 19..20), )
 "_v_res"@(FileId(1), 82..88) [ConstVar(Var, No)]: boolean

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_sets_equal.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_sets_equal.snap
@@ -2,10 +2,10 @@
 source: compiler/toc_analysis/src/typeck/test.rs
 expression: "\n    type s : set of boolean\n    var a, b : s\n\n    % should all produce booleans\n    var _v_res : boolean\n\n    _v_res := a = b\n    _v_res := b = a\n    "
 ---
+"s"@(FileId(1), 10..11) [Type]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
 "s"@(FileId(1), 14..28) [Set]: <error>
-"s"@(FileId(1), 10..11) [Type]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
-"a"@(FileId(1), 37..38) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
-"b"@(FileId(1), 40..41) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
+"a"@(FileId(1), 37..38) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
+"b"@(FileId(1), 40..41) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
 "_v_res"@(FileId(1), 89..95) [ConstVar(Var, No)]: boolean
 "<root>"@(dummy) [Module(No)]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_sets_greater.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_sets_greater.snap
@@ -2,10 +2,10 @@
 source: compiler/toc_analysis/src/typeck/test.rs
 expression: "\n    type s : set of boolean\n    var a, b : s\n\n    % should all produce booleans\n    var _v_res : boolean\n\n    _v_res := a > b\n    _v_res := b > a\n    "
 ---
+"s"@(FileId(1), 10..11) [Type]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
 "s"@(FileId(1), 14..28) [Set]: <error>
-"s"@(FileId(1), 10..11) [Type]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
-"a"@(FileId(1), 37..38) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
-"b"@(FileId(1), 40..41) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
+"a"@(FileId(1), 37..38) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
+"b"@(FileId(1), 40..41) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
 "_v_res"@(FileId(1), 89..95) [ConstVar(Var, No)]: boolean
 "<root>"@(dummy) [Module(No)]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_sets_greater_eq.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_sets_greater_eq.snap
@@ -2,10 +2,10 @@
 source: compiler/toc_analysis/src/typeck/test.rs
 expression: "\n    type s : set of boolean\n    var a, b : s\n\n    % should all produce booleans\n    var _v_res : boolean\n\n    _v_res := a >= b\n    _v_res := b >= a\n    "
 ---
+"s"@(FileId(1), 10..11) [Type]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
 "s"@(FileId(1), 14..28) [Set]: <error>
-"s"@(FileId(1), 10..11) [Type]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
-"a"@(FileId(1), 37..38) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
-"b"@(FileId(1), 40..41) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
+"a"@(FileId(1), 37..38) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
+"b"@(FileId(1), 40..41) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
 "_v_res"@(FileId(1), 89..95) [ConstVar(Var, No)]: boolean
 "<root>"@(dummy) [Module(No)]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_sets_less.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_sets_less.snap
@@ -2,10 +2,10 @@
 source: compiler/toc_analysis/src/typeck/test.rs
 expression: "\n    type s : set of boolean\n    var a, b : s\n\n    % should all produce booleans\n    var _v_res : boolean\n\n    _v_res := a < b\n    _v_res := b < a\n    "
 ---
+"s"@(FileId(1), 10..11) [Type]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
 "s"@(FileId(1), 14..28) [Set]: <error>
-"s"@(FileId(1), 10..11) [Type]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
-"a"@(FileId(1), 37..38) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
-"b"@(FileId(1), 40..41) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
+"a"@(FileId(1), 37..38) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
+"b"@(FileId(1), 40..41) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
 "_v_res"@(FileId(1), 89..95) [ConstVar(Var, No)]: boolean
 "<root>"@(dummy) [Module(No)]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_sets_less_eq.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_sets_less_eq.snap
@@ -2,10 +2,10 @@
 source: compiler/toc_analysis/src/typeck/test.rs
 expression: "\n    type s : set of boolean\n    var a, b : s\n\n    % should all produce booleans\n    var _v_res : boolean\n\n    _v_res := a <= b\n    _v_res := b <= a\n    "
 ---
+"s"@(FileId(1), 10..11) [Type]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
 "s"@(FileId(1), 14..28) [Set]: <error>
-"s"@(FileId(1), 10..11) [Type]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
-"a"@(FileId(1), 37..38) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
-"b"@(FileId(1), 40..41) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
+"a"@(FileId(1), 37..38) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
+"b"@(FileId(1), 40..41) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
 "_v_res"@(FileId(1), 89..95) [ConstVar(Var, No)]: boolean
 "<root>"@(dummy) [Module(No)]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_sets_not_equal.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_sets_not_equal.snap
@@ -2,10 +2,10 @@
 source: compiler/toc_analysis/src/typeck/test.rs
 expression: "\n    type s : set of boolean\n    var a, b : s\n\n    % should all produce booleans\n    var _v_res : boolean\n\n    _v_res := a not= b\n    _v_res := b not= a\n    "
 ---
+"s"@(FileId(1), 10..11) [Type]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
 "s"@(FileId(1), 14..28) [Set]: <error>
-"s"@(FileId(1), 10..11) [Type]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
-"a"@(FileId(1), 37..38) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
-"b"@(FileId(1), 40..41) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
+"a"@(FileId(1), 37..38) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
+"b"@(FileId(1), 40..41) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
 "_v_res"@(FileId(1), 89..95) [ConstVar(Var, No)]: boolean
 "<root>"@(dummy) [Module(No)]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_enums_equal.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_enums_equal.snap
@@ -2,20 +2,20 @@
 source: compiler/toc_analysis/src/typeck/test.rs
 expression: "\n    % Different enums\n    type e1 : enum(v)\n    type e2 : enum(v)\n    var ae : e1\n    var be : e2\n    var aA : enum(v)\n    var bA : enum(v)\n\n    % should all produce boolean anyway\n    var _v_res : boolean\n\n    _v_res := ae = be\n    _v_res := be = ae\n    _v_res := aA = ae\n    _v_res := ae = aA\n    _v_res := aA = bA\n    "
 ---
-"v"@(FileId(1), 42..43) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "v"@(FileId(1), 42..43), )
-"e1"@(FileId(1), 37..44) [Enum]: <error>
 "e1"@(FileId(1), 32..34) [Type]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "v"@(FileId(1), 42..43), )
-"v"@(FileId(1), 64..65) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(4))] ( "v"@(FileId(1), 64..65), )
-"e2"@(FileId(1), 59..66) [Enum]: <error>
+"e1"@(FileId(1), 37..44) [Enum]: <error>
+"v"@(FileId(1), 42..43) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "v"@(FileId(1), 42..43), )
 "e2"@(FileId(1), 54..56) [Type]: enum[DefId(LibraryId(0), LocalDefId(4))] ( "v"@(FileId(1), 64..65), )
+"e2"@(FileId(1), 59..66) [Enum]: <error>
+"v"@(FileId(1), 64..65) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(4))] ( "v"@(FileId(1), 64..65), )
 "ae"@(FileId(1), 75..77) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "v"@(FileId(1), 42..43), )
 "be"@(FileId(1), 91..93) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(4))] ( "v"@(FileId(1), 64..65), )
-"v"@(FileId(1), 117..118) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(9))] ( "v"@(FileId(1), 117..118), )
-"<anonymous>"@(FileId(1), 112..119) [Enum]: <error>
 "aA"@(FileId(1), 107..109) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(9))] ( "v"@(FileId(1), 117..118), )
-"v"@(FileId(1), 138..139) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(12))] ( "v"@(FileId(1), 138..139), )
-"<anonymous>"@(FileId(1), 133..140) [Enum]: <error>
+"<anonymous>"@(FileId(1), 112..119) [Enum]: <error>
+"v"@(FileId(1), 117..118) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(9))] ( "v"@(FileId(1), 117..118), )
 "bA"@(FileId(1), 128..130) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(12))] ( "v"@(FileId(1), 138..139), )
+"<anonymous>"@(FileId(1), 133..140) [Enum]: <error>
+"v"@(FileId(1), 138..139) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(12))] ( "v"@(FileId(1), 138..139), )
 "_v_res"@(FileId(1), 190..196) [ConstVar(Var, No)]: boolean
 "<root>"@(dummy) [Module(No)]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_enums_greater.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_enums_greater.snap
@@ -2,20 +2,20 @@
 source: compiler/toc_analysis/src/typeck/test.rs
 expression: "\n    % Different enums\n    type e1 : enum(v)\n    type e2 : enum(v)\n    var ae : e1\n    var be : e2\n    var aA : enum(v)\n    var bA : enum(v)\n\n    % should all produce boolean anyway\n    var _v_res : boolean\n\n    _v_res := ae > be\n    _v_res := be > ae\n    _v_res := aA > ae\n    _v_res := ae > aA\n    _v_res := aA > bA\n    "
 ---
-"v"@(FileId(1), 42..43) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "v"@(FileId(1), 42..43), )
-"e1"@(FileId(1), 37..44) [Enum]: <error>
 "e1"@(FileId(1), 32..34) [Type]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "v"@(FileId(1), 42..43), )
-"v"@(FileId(1), 64..65) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(4))] ( "v"@(FileId(1), 64..65), )
-"e2"@(FileId(1), 59..66) [Enum]: <error>
+"e1"@(FileId(1), 37..44) [Enum]: <error>
+"v"@(FileId(1), 42..43) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "v"@(FileId(1), 42..43), )
 "e2"@(FileId(1), 54..56) [Type]: enum[DefId(LibraryId(0), LocalDefId(4))] ( "v"@(FileId(1), 64..65), )
+"e2"@(FileId(1), 59..66) [Enum]: <error>
+"v"@(FileId(1), 64..65) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(4))] ( "v"@(FileId(1), 64..65), )
 "ae"@(FileId(1), 75..77) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "v"@(FileId(1), 42..43), )
 "be"@(FileId(1), 91..93) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(4))] ( "v"@(FileId(1), 64..65), )
-"v"@(FileId(1), 117..118) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(9))] ( "v"@(FileId(1), 117..118), )
-"<anonymous>"@(FileId(1), 112..119) [Enum]: <error>
 "aA"@(FileId(1), 107..109) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(9))] ( "v"@(FileId(1), 117..118), )
-"v"@(FileId(1), 138..139) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(12))] ( "v"@(FileId(1), 138..139), )
-"<anonymous>"@(FileId(1), 133..140) [Enum]: <error>
+"<anonymous>"@(FileId(1), 112..119) [Enum]: <error>
+"v"@(FileId(1), 117..118) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(9))] ( "v"@(FileId(1), 117..118), )
 "bA"@(FileId(1), 128..130) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(12))] ( "v"@(FileId(1), 138..139), )
+"<anonymous>"@(FileId(1), 133..140) [Enum]: <error>
+"v"@(FileId(1), 138..139) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(12))] ( "v"@(FileId(1), 138..139), )
 "_v_res"@(FileId(1), 190..196) [ConstVar(Var, No)]: boolean
 "<root>"@(dummy) [Module(No)]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_enums_greater_eq.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_enums_greater_eq.snap
@@ -2,20 +2,20 @@
 source: compiler/toc_analysis/src/typeck/test.rs
 expression: "\n    % Different enums\n    type e1 : enum(v)\n    type e2 : enum(v)\n    var ae : e1\n    var be : e2\n    var aA : enum(v)\n    var bA : enum(v)\n\n    % should all produce boolean anyway\n    var _v_res : boolean\n\n    _v_res := ae >= be\n    _v_res := be >= ae\n    _v_res := aA >= ae\n    _v_res := ae >= aA\n    _v_res := aA >= bA\n    "
 ---
-"v"@(FileId(1), 42..43) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "v"@(FileId(1), 42..43), )
-"e1"@(FileId(1), 37..44) [Enum]: <error>
 "e1"@(FileId(1), 32..34) [Type]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "v"@(FileId(1), 42..43), )
-"v"@(FileId(1), 64..65) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(4))] ( "v"@(FileId(1), 64..65), )
-"e2"@(FileId(1), 59..66) [Enum]: <error>
+"e1"@(FileId(1), 37..44) [Enum]: <error>
+"v"@(FileId(1), 42..43) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "v"@(FileId(1), 42..43), )
 "e2"@(FileId(1), 54..56) [Type]: enum[DefId(LibraryId(0), LocalDefId(4))] ( "v"@(FileId(1), 64..65), )
+"e2"@(FileId(1), 59..66) [Enum]: <error>
+"v"@(FileId(1), 64..65) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(4))] ( "v"@(FileId(1), 64..65), )
 "ae"@(FileId(1), 75..77) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "v"@(FileId(1), 42..43), )
 "be"@(FileId(1), 91..93) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(4))] ( "v"@(FileId(1), 64..65), )
-"v"@(FileId(1), 117..118) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(9))] ( "v"@(FileId(1), 117..118), )
-"<anonymous>"@(FileId(1), 112..119) [Enum]: <error>
 "aA"@(FileId(1), 107..109) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(9))] ( "v"@(FileId(1), 117..118), )
-"v"@(FileId(1), 138..139) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(12))] ( "v"@(FileId(1), 138..139), )
-"<anonymous>"@(FileId(1), 133..140) [Enum]: <error>
+"<anonymous>"@(FileId(1), 112..119) [Enum]: <error>
+"v"@(FileId(1), 117..118) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(9))] ( "v"@(FileId(1), 117..118), )
 "bA"@(FileId(1), 128..130) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(12))] ( "v"@(FileId(1), 138..139), )
+"<anonymous>"@(FileId(1), 133..140) [Enum]: <error>
+"v"@(FileId(1), 138..139) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(12))] ( "v"@(FileId(1), 138..139), )
 "_v_res"@(FileId(1), 190..196) [ConstVar(Var, No)]: boolean
 "<root>"@(dummy) [Module(No)]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_enums_less.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_enums_less.snap
@@ -2,20 +2,20 @@
 source: compiler/toc_analysis/src/typeck/test.rs
 expression: "\n    % Different enums\n    type e1 : enum(v)\n    type e2 : enum(v)\n    var ae : e1\n    var be : e2\n    var aA : enum(v)\n    var bA : enum(v)\n\n    % should all produce boolean anyway\n    var _v_res : boolean\n\n    _v_res := ae < be\n    _v_res := be < ae\n    _v_res := aA < ae\n    _v_res := ae < aA\n    _v_res := aA < bA\n    "
 ---
-"v"@(FileId(1), 42..43) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "v"@(FileId(1), 42..43), )
-"e1"@(FileId(1), 37..44) [Enum]: <error>
 "e1"@(FileId(1), 32..34) [Type]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "v"@(FileId(1), 42..43), )
-"v"@(FileId(1), 64..65) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(4))] ( "v"@(FileId(1), 64..65), )
-"e2"@(FileId(1), 59..66) [Enum]: <error>
+"e1"@(FileId(1), 37..44) [Enum]: <error>
+"v"@(FileId(1), 42..43) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "v"@(FileId(1), 42..43), )
 "e2"@(FileId(1), 54..56) [Type]: enum[DefId(LibraryId(0), LocalDefId(4))] ( "v"@(FileId(1), 64..65), )
+"e2"@(FileId(1), 59..66) [Enum]: <error>
+"v"@(FileId(1), 64..65) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(4))] ( "v"@(FileId(1), 64..65), )
 "ae"@(FileId(1), 75..77) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "v"@(FileId(1), 42..43), )
 "be"@(FileId(1), 91..93) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(4))] ( "v"@(FileId(1), 64..65), )
-"v"@(FileId(1), 117..118) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(9))] ( "v"@(FileId(1), 117..118), )
-"<anonymous>"@(FileId(1), 112..119) [Enum]: <error>
 "aA"@(FileId(1), 107..109) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(9))] ( "v"@(FileId(1), 117..118), )
-"v"@(FileId(1), 138..139) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(12))] ( "v"@(FileId(1), 138..139), )
-"<anonymous>"@(FileId(1), 133..140) [Enum]: <error>
+"<anonymous>"@(FileId(1), 112..119) [Enum]: <error>
+"v"@(FileId(1), 117..118) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(9))] ( "v"@(FileId(1), 117..118), )
 "bA"@(FileId(1), 128..130) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(12))] ( "v"@(FileId(1), 138..139), )
+"<anonymous>"@(FileId(1), 133..140) [Enum]: <error>
+"v"@(FileId(1), 138..139) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(12))] ( "v"@(FileId(1), 138..139), )
 "_v_res"@(FileId(1), 190..196) [ConstVar(Var, No)]: boolean
 "<root>"@(dummy) [Module(No)]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_enums_less_eq.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_enums_less_eq.snap
@@ -2,20 +2,20 @@
 source: compiler/toc_analysis/src/typeck/test.rs
 expression: "\n    % Different enums\n    type e1 : enum(v)\n    type e2 : enum(v)\n    var ae : e1\n    var be : e2\n    var aA : enum(v)\n    var bA : enum(v)\n\n    % should all produce boolean anyway\n    var _v_res : boolean\n\n    _v_res := ae <= be\n    _v_res := be <= ae\n    _v_res := aA <= ae\n    _v_res := ae <= aA\n    _v_res := aA <= bA\n    "
 ---
-"v"@(FileId(1), 42..43) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "v"@(FileId(1), 42..43), )
-"e1"@(FileId(1), 37..44) [Enum]: <error>
 "e1"@(FileId(1), 32..34) [Type]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "v"@(FileId(1), 42..43), )
-"v"@(FileId(1), 64..65) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(4))] ( "v"@(FileId(1), 64..65), )
-"e2"@(FileId(1), 59..66) [Enum]: <error>
+"e1"@(FileId(1), 37..44) [Enum]: <error>
+"v"@(FileId(1), 42..43) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "v"@(FileId(1), 42..43), )
 "e2"@(FileId(1), 54..56) [Type]: enum[DefId(LibraryId(0), LocalDefId(4))] ( "v"@(FileId(1), 64..65), )
+"e2"@(FileId(1), 59..66) [Enum]: <error>
+"v"@(FileId(1), 64..65) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(4))] ( "v"@(FileId(1), 64..65), )
 "ae"@(FileId(1), 75..77) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "v"@(FileId(1), 42..43), )
 "be"@(FileId(1), 91..93) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(4))] ( "v"@(FileId(1), 64..65), )
-"v"@(FileId(1), 117..118) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(9))] ( "v"@(FileId(1), 117..118), )
-"<anonymous>"@(FileId(1), 112..119) [Enum]: <error>
 "aA"@(FileId(1), 107..109) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(9))] ( "v"@(FileId(1), 117..118), )
-"v"@(FileId(1), 138..139) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(12))] ( "v"@(FileId(1), 138..139), )
-"<anonymous>"@(FileId(1), 133..140) [Enum]: <error>
+"<anonymous>"@(FileId(1), 112..119) [Enum]: <error>
+"v"@(FileId(1), 117..118) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(9))] ( "v"@(FileId(1), 117..118), )
 "bA"@(FileId(1), 128..130) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(12))] ( "v"@(FileId(1), 138..139), )
+"<anonymous>"@(FileId(1), 133..140) [Enum]: <error>
+"v"@(FileId(1), 138..139) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(12))] ( "v"@(FileId(1), 138..139), )
 "_v_res"@(FileId(1), 190..196) [ConstVar(Var, No)]: boolean
 "<root>"@(dummy) [Module(No)]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_enums_not_equal.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_enums_not_equal.snap
@@ -2,20 +2,20 @@
 source: compiler/toc_analysis/src/typeck/test.rs
 expression: "\n    % Different enums\n    type e1 : enum(v)\n    type e2 : enum(v)\n    var ae : e1\n    var be : e2\n    var aA : enum(v)\n    var bA : enum(v)\n\n    % should all produce boolean anyway\n    var _v_res : boolean\n\n    _v_res := ae not= be\n    _v_res := be not= ae\n    _v_res := aA not= ae\n    _v_res := ae not= aA\n    _v_res := aA not= bA\n    "
 ---
-"v"@(FileId(1), 42..43) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "v"@(FileId(1), 42..43), )
-"e1"@(FileId(1), 37..44) [Enum]: <error>
 "e1"@(FileId(1), 32..34) [Type]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "v"@(FileId(1), 42..43), )
-"v"@(FileId(1), 64..65) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(4))] ( "v"@(FileId(1), 64..65), )
-"e2"@(FileId(1), 59..66) [Enum]: <error>
+"e1"@(FileId(1), 37..44) [Enum]: <error>
+"v"@(FileId(1), 42..43) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "v"@(FileId(1), 42..43), )
 "e2"@(FileId(1), 54..56) [Type]: enum[DefId(LibraryId(0), LocalDefId(4))] ( "v"@(FileId(1), 64..65), )
+"e2"@(FileId(1), 59..66) [Enum]: <error>
+"v"@(FileId(1), 64..65) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(4))] ( "v"@(FileId(1), 64..65), )
 "ae"@(FileId(1), 75..77) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "v"@(FileId(1), 42..43), )
 "be"@(FileId(1), 91..93) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(4))] ( "v"@(FileId(1), 64..65), )
-"v"@(FileId(1), 117..118) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(9))] ( "v"@(FileId(1), 117..118), )
-"<anonymous>"@(FileId(1), 112..119) [Enum]: <error>
 "aA"@(FileId(1), 107..109) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(9))] ( "v"@(FileId(1), 117..118), )
-"v"@(FileId(1), 138..139) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(12))] ( "v"@(FileId(1), 138..139), )
-"<anonymous>"@(FileId(1), 133..140) [Enum]: <error>
+"<anonymous>"@(FileId(1), 112..119) [Enum]: <error>
+"v"@(FileId(1), 117..118) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(9))] ( "v"@(FileId(1), 117..118), )
 "bA"@(FileId(1), 128..130) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(12))] ( "v"@(FileId(1), 138..139), )
+"<anonymous>"@(FileId(1), 133..140) [Enum]: <error>
+"v"@(FileId(1), 138..139) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(12))] ( "v"@(FileId(1), 138..139), )
 "_v_res"@(FileId(1), 190..196) [ConstVar(Var, No)]: boolean
 "<root>"@(dummy) [Module(No)]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_equal.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_equal.snap
@@ -10,16 +10,16 @@ expression: "\n    % Numerics\n    var r : real\n    var i : int\n    var n : na
 "c_sz"@(FileId(1), 153..157) [ConstVar(Var, No)]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
 "s"@(FileId(1), 176..177) [ConstVar(Var, No)]: string
 "s_sz"@(FileId(1), 195..199) [ConstVar(Var, No)]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
+"s1"@(FileId(1), 243..245) [Type]: set[DefId(LibraryId(0), LocalDefId(9))] of boolean
 "s1"@(FileId(1), 248..262) [Set]: <error>
-"s1"@(FileId(1), 243..245) [Type]: set[DefId(LibraryId(0), LocalDefId(8))] of boolean
+"s2"@(FileId(1), 272..274) [Type]: set[DefId(LibraryId(0), LocalDefId(11))] of boolean
 "s2"@(FileId(1), 277..291) [Set]: <error>
-"s2"@(FileId(1), 272..274) [Type]: set[DefId(LibraryId(0), LocalDefId(10))] of boolean
-"as1"@(FileId(1), 300..303) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(8))] of boolean
-"as2"@(FileId(1), 305..308) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(8))] of boolean
-"bs1"@(FileId(1), 322..325) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(10))] of boolean
-"bs2"@(FileId(1), 327..330) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(10))] of boolean
+"as1"@(FileId(1), 300..303) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(9))] of boolean
+"as2"@(FileId(1), 305..308) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(9))] of boolean
+"bs1"@(FileId(1), 322..325) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(11))] of boolean
+"bs2"@(FileId(1), 327..330) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(11))] of boolean
+"aas"@(FileId(1), 344..347) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(17))] of boolean
 "<anonymous>"@(FileId(1), 350..364) [Set]: <error>
-"aas"@(FileId(1), 344..347) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(16))] of boolean
 "_v_res"@(FileId(1), 414..420) [ConstVar(Var, No)]: boolean
 "<root>"@(dummy) [Module(No)]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_greater.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_greater.snap
@@ -10,16 +10,16 @@ expression: "\n    % Numerics\n    var r : real\n    var i : int\n    var n : na
 "c_sz"@(FileId(1), 153..157) [ConstVar(Var, No)]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
 "s"@(FileId(1), 176..177) [ConstVar(Var, No)]: string
 "s_sz"@(FileId(1), 195..199) [ConstVar(Var, No)]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
+"s1"@(FileId(1), 243..245) [Type]: set[DefId(LibraryId(0), LocalDefId(9))] of boolean
 "s1"@(FileId(1), 248..262) [Set]: <error>
-"s1"@(FileId(1), 243..245) [Type]: set[DefId(LibraryId(0), LocalDefId(8))] of boolean
+"s2"@(FileId(1), 272..274) [Type]: set[DefId(LibraryId(0), LocalDefId(11))] of boolean
 "s2"@(FileId(1), 277..291) [Set]: <error>
-"s2"@(FileId(1), 272..274) [Type]: set[DefId(LibraryId(0), LocalDefId(10))] of boolean
-"as1"@(FileId(1), 300..303) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(8))] of boolean
-"as2"@(FileId(1), 305..308) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(8))] of boolean
-"bs1"@(FileId(1), 322..325) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(10))] of boolean
-"bs2"@(FileId(1), 327..330) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(10))] of boolean
+"as1"@(FileId(1), 300..303) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(9))] of boolean
+"as2"@(FileId(1), 305..308) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(9))] of boolean
+"bs1"@(FileId(1), 322..325) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(11))] of boolean
+"bs2"@(FileId(1), 327..330) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(11))] of boolean
+"aas"@(FileId(1), 344..347) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(17))] of boolean
 "<anonymous>"@(FileId(1), 350..364) [Set]: <error>
-"aas"@(FileId(1), 344..347) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(16))] of boolean
 "_v_res"@(FileId(1), 414..420) [ConstVar(Var, No)]: boolean
 "<root>"@(dummy) [Module(No)]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_greater_eq.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_greater_eq.snap
@@ -10,16 +10,16 @@ expression: "\n    % Numerics\n    var r : real\n    var i : int\n    var n : na
 "c_sz"@(FileId(1), 153..157) [ConstVar(Var, No)]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
 "s"@(FileId(1), 176..177) [ConstVar(Var, No)]: string
 "s_sz"@(FileId(1), 195..199) [ConstVar(Var, No)]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
+"s1"@(FileId(1), 243..245) [Type]: set[DefId(LibraryId(0), LocalDefId(9))] of boolean
 "s1"@(FileId(1), 248..262) [Set]: <error>
-"s1"@(FileId(1), 243..245) [Type]: set[DefId(LibraryId(0), LocalDefId(8))] of boolean
+"s2"@(FileId(1), 272..274) [Type]: set[DefId(LibraryId(0), LocalDefId(11))] of boolean
 "s2"@(FileId(1), 277..291) [Set]: <error>
-"s2"@(FileId(1), 272..274) [Type]: set[DefId(LibraryId(0), LocalDefId(10))] of boolean
-"as1"@(FileId(1), 300..303) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(8))] of boolean
-"as2"@(FileId(1), 305..308) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(8))] of boolean
-"bs1"@(FileId(1), 322..325) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(10))] of boolean
-"bs2"@(FileId(1), 327..330) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(10))] of boolean
+"as1"@(FileId(1), 300..303) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(9))] of boolean
+"as2"@(FileId(1), 305..308) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(9))] of boolean
+"bs1"@(FileId(1), 322..325) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(11))] of boolean
+"bs2"@(FileId(1), 327..330) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(11))] of boolean
+"aas"@(FileId(1), 344..347) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(17))] of boolean
 "<anonymous>"@(FileId(1), 350..364) [Set]: <error>
-"aas"@(FileId(1), 344..347) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(16))] of boolean
 "_v_res"@(FileId(1), 414..420) [ConstVar(Var, No)]: boolean
 "<root>"@(dummy) [Module(No)]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_less.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_less.snap
@@ -10,16 +10,16 @@ expression: "\n    % Numerics\n    var r : real\n    var i : int\n    var n : na
 "c_sz"@(FileId(1), 153..157) [ConstVar(Var, No)]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
 "s"@(FileId(1), 176..177) [ConstVar(Var, No)]: string
 "s_sz"@(FileId(1), 195..199) [ConstVar(Var, No)]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
+"s1"@(FileId(1), 243..245) [Type]: set[DefId(LibraryId(0), LocalDefId(9))] of boolean
 "s1"@(FileId(1), 248..262) [Set]: <error>
-"s1"@(FileId(1), 243..245) [Type]: set[DefId(LibraryId(0), LocalDefId(8))] of boolean
+"s2"@(FileId(1), 272..274) [Type]: set[DefId(LibraryId(0), LocalDefId(11))] of boolean
 "s2"@(FileId(1), 277..291) [Set]: <error>
-"s2"@(FileId(1), 272..274) [Type]: set[DefId(LibraryId(0), LocalDefId(10))] of boolean
-"as1"@(FileId(1), 300..303) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(8))] of boolean
-"as2"@(FileId(1), 305..308) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(8))] of boolean
-"bs1"@(FileId(1), 322..325) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(10))] of boolean
-"bs2"@(FileId(1), 327..330) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(10))] of boolean
+"as1"@(FileId(1), 300..303) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(9))] of boolean
+"as2"@(FileId(1), 305..308) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(9))] of boolean
+"bs1"@(FileId(1), 322..325) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(11))] of boolean
+"bs2"@(FileId(1), 327..330) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(11))] of boolean
+"aas"@(FileId(1), 344..347) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(17))] of boolean
 "<anonymous>"@(FileId(1), 350..364) [Set]: <error>
-"aas"@(FileId(1), 344..347) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(16))] of boolean
 "_v_res"@(FileId(1), 414..420) [ConstVar(Var, No)]: boolean
 "<root>"@(dummy) [Module(No)]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_less_eq.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_less_eq.snap
@@ -10,16 +10,16 @@ expression: "\n    % Numerics\n    var r : real\n    var i : int\n    var n : na
 "c_sz"@(FileId(1), 153..157) [ConstVar(Var, No)]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
 "s"@(FileId(1), 176..177) [ConstVar(Var, No)]: string
 "s_sz"@(FileId(1), 195..199) [ConstVar(Var, No)]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
+"s1"@(FileId(1), 243..245) [Type]: set[DefId(LibraryId(0), LocalDefId(9))] of boolean
 "s1"@(FileId(1), 248..262) [Set]: <error>
-"s1"@(FileId(1), 243..245) [Type]: set[DefId(LibraryId(0), LocalDefId(8))] of boolean
+"s2"@(FileId(1), 272..274) [Type]: set[DefId(LibraryId(0), LocalDefId(11))] of boolean
 "s2"@(FileId(1), 277..291) [Set]: <error>
-"s2"@(FileId(1), 272..274) [Type]: set[DefId(LibraryId(0), LocalDefId(10))] of boolean
-"as1"@(FileId(1), 300..303) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(8))] of boolean
-"as2"@(FileId(1), 305..308) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(8))] of boolean
-"bs1"@(FileId(1), 322..325) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(10))] of boolean
-"bs2"@(FileId(1), 327..330) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(10))] of boolean
+"as1"@(FileId(1), 300..303) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(9))] of boolean
+"as2"@(FileId(1), 305..308) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(9))] of boolean
+"bs1"@(FileId(1), 322..325) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(11))] of boolean
+"bs2"@(FileId(1), 327..330) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(11))] of boolean
+"aas"@(FileId(1), 344..347) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(17))] of boolean
 "<anonymous>"@(FileId(1), 350..364) [Set]: <error>
-"aas"@(FileId(1), 344..347) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(16))] of boolean
 "_v_res"@(FileId(1), 414..420) [ConstVar(Var, No)]: boolean
 "<root>"@(dummy) [Module(No)]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_not_equal.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__comparison_op_wrong_types_not_equal.snap
@@ -10,16 +10,16 @@ expression: "\n    % Numerics\n    var r : real\n    var i : int\n    var n : na
 "c_sz"@(FileId(1), 153..157) [ConstVar(Var, No)]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
 "s"@(FileId(1), 176..177) [ConstVar(Var, No)]: string
 "s_sz"@(FileId(1), 195..199) [ConstVar(Var, No)]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
+"s1"@(FileId(1), 243..245) [Type]: set[DefId(LibraryId(0), LocalDefId(9))] of boolean
 "s1"@(FileId(1), 248..262) [Set]: <error>
-"s1"@(FileId(1), 243..245) [Type]: set[DefId(LibraryId(0), LocalDefId(8))] of boolean
+"s2"@(FileId(1), 272..274) [Type]: set[DefId(LibraryId(0), LocalDefId(11))] of boolean
 "s2"@(FileId(1), 277..291) [Set]: <error>
-"s2"@(FileId(1), 272..274) [Type]: set[DefId(LibraryId(0), LocalDefId(10))] of boolean
-"as1"@(FileId(1), 300..303) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(8))] of boolean
-"as2"@(FileId(1), 305..308) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(8))] of boolean
-"bs1"@(FileId(1), 322..325) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(10))] of boolean
-"bs2"@(FileId(1), 327..330) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(10))] of boolean
+"as1"@(FileId(1), 300..303) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(9))] of boolean
+"as2"@(FileId(1), 305..308) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(9))] of boolean
+"bs1"@(FileId(1), 322..325) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(11))] of boolean
+"bs2"@(FileId(1), 327..330) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(11))] of boolean
+"aas"@(FileId(1), 344..347) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(17))] of boolean
 "<anonymous>"@(FileId(1), 350..364) [Set]: <error>
-"aas"@(FileId(1), 344..347) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(16))] of boolean
 "_v_res"@(FileId(1), 414..420) [ConstVar(Var, No)]: boolean
 "<root>"@(dummy) [Module(No)]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__enum_field_not_variant.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__enum_field_not_variant.snap
@@ -2,11 +2,11 @@
 source: compiler/toc_analysis/src/typeck/test.rs
 expression: "type e : enum(a, b, c)\nvar _ := e.e\n"
 ---
-"a"@(FileId(1), 14..15) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(3))] ( "a"@(FileId(1), 14..15), "b"@(FileId(1), 17..18), "c"@(FileId(1), 20..21), )
-"b"@(FileId(1), 17..18) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(3))] ( "a"@(FileId(1), 14..15), "b"@(FileId(1), 17..18), "c"@(FileId(1), 20..21), )
-"c"@(FileId(1), 20..21) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(3))] ( "a"@(FileId(1), 14..15), "b"@(FileId(1), 17..18), "c"@(FileId(1), 20..21), )
+"e"@(FileId(1), 5..6) [Type]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "a"@(FileId(1), 14..15), "b"@(FileId(1), 17..18), "c"@(FileId(1), 20..21), )
 "e"@(FileId(1), 9..22) [Enum]: <error>
-"e"@(FileId(1), 5..6) [Type]: enum[DefId(LibraryId(0), LocalDefId(3))] ( "a"@(FileId(1), 14..15), "b"@(FileId(1), 17..18), "c"@(FileId(1), 20..21), )
+"a"@(FileId(1), 14..15) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "a"@(FileId(1), 14..15), "b"@(FileId(1), 17..18), "c"@(FileId(1), 20..21), )
+"b"@(FileId(1), 17..18) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "a"@(FileId(1), 14..15), "b"@(FileId(1), 17..18), "c"@(FileId(1), 20..21), )
+"c"@(FileId(1), 20..21) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "a"@(FileId(1), 14..15), "b"@(FileId(1), 17..18), "c"@(FileId(1), 20..21), )
 "_"@(FileId(1), 27..28) [ConstVar(Var, No)]: <error>
 "<root>"@(dummy) [Module(No)]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__enum_field_on_type.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__enum_field_on_type.snap
@@ -2,11 +2,11 @@
 source: compiler/toc_analysis/src/typeck/test.rs
 expression: "type e : enum(a, b, c)\nvar _ := e.a\n"
 ---
-"a"@(FileId(1), 14..15) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(3))] ( "a"@(FileId(1), 14..15), "b"@(FileId(1), 17..18), "c"@(FileId(1), 20..21), )
-"b"@(FileId(1), 17..18) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(3))] ( "a"@(FileId(1), 14..15), "b"@(FileId(1), 17..18), "c"@(FileId(1), 20..21), )
-"c"@(FileId(1), 20..21) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(3))] ( "a"@(FileId(1), 14..15), "b"@(FileId(1), 17..18), "c"@(FileId(1), 20..21), )
+"e"@(FileId(1), 5..6) [Type]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "a"@(FileId(1), 14..15), "b"@(FileId(1), 17..18), "c"@(FileId(1), 20..21), )
 "e"@(FileId(1), 9..22) [Enum]: <error>
-"e"@(FileId(1), 5..6) [Type]: enum[DefId(LibraryId(0), LocalDefId(3))] ( "a"@(FileId(1), 14..15), "b"@(FileId(1), 17..18), "c"@(FileId(1), 20..21), )
-"_"@(FileId(1), 27..28) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(3))] ( "a"@(FileId(1), 14..15), "b"@(FileId(1), 17..18), "c"@(FileId(1), 20..21), )
+"a"@(FileId(1), 14..15) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "a"@(FileId(1), 14..15), "b"@(FileId(1), 17..18), "c"@(FileId(1), 20..21), )
+"b"@(FileId(1), 17..18) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "a"@(FileId(1), 14..15), "b"@(FileId(1), 17..18), "c"@(FileId(1), 20..21), )
+"c"@(FileId(1), 20..21) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "a"@(FileId(1), 14..15), "b"@(FileId(1), 17..18), "c"@(FileId(1), 20..21), )
+"_"@(FileId(1), 27..28) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "a"@(FileId(1), 14..15), "b"@(FileId(1), 17..18), "c"@(FileId(1), 20..21), )
 "<root>"@(dummy) [Module(No)]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__enum_field_on_var.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__enum_field_on_var.snap
@@ -2,12 +2,12 @@
 source: compiler/toc_analysis/src/typeck/test.rs
 expression: "type e : enum(a, b, c)\nvar a : e\na := a.a\n"
 ---
-"a"@(FileId(1), 14..15) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(3))] ( "a"@(FileId(1), 14..15), "b"@(FileId(1), 17..18), "c"@(FileId(1), 20..21), )
-"b"@(FileId(1), 17..18) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(3))] ( "a"@(FileId(1), 14..15), "b"@(FileId(1), 17..18), "c"@(FileId(1), 20..21), )
-"c"@(FileId(1), 20..21) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(3))] ( "a"@(FileId(1), 14..15), "b"@(FileId(1), 17..18), "c"@(FileId(1), 20..21), )
+"e"@(FileId(1), 5..6) [Type]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "a"@(FileId(1), 14..15), "b"@(FileId(1), 17..18), "c"@(FileId(1), 20..21), )
 "e"@(FileId(1), 9..22) [Enum]: <error>
-"e"@(FileId(1), 5..6) [Type]: enum[DefId(LibraryId(0), LocalDefId(3))] ( "a"@(FileId(1), 14..15), "b"@(FileId(1), 17..18), "c"@(FileId(1), 20..21), )
-"a"@(FileId(1), 27..28) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(3))] ( "a"@(FileId(1), 14..15), "b"@(FileId(1), 17..18), "c"@(FileId(1), 20..21), )
+"a"@(FileId(1), 14..15) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "a"@(FileId(1), 14..15), "b"@(FileId(1), 17..18), "c"@(FileId(1), 20..21), )
+"b"@(FileId(1), 17..18) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "a"@(FileId(1), 14..15), "b"@(FileId(1), 17..18), "c"@(FileId(1), 20..21), )
+"c"@(FileId(1), 20..21) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "a"@(FileId(1), 14..15), "b"@(FileId(1), 17..18), "c"@(FileId(1), 20..21), )
+"a"@(FileId(1), 27..28) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "a"@(FileId(1), 14..15), "b"@(FileId(1), 17..18), "c"@(FileId(1), 20..21), )
 "<root>"@(dummy) [Module(No)]: <error>
 
 error in file FileId(1) at 40..41: no field named `a` in expression

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__equivalence_of_enums.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__equivalence_of_enums.snap
@@ -2,14 +2,14 @@
 source: compiler/toc_analysis/src/typeck/test.rs
 expression: "type e : enum(v)\nvar a, b : e\n\n% compatible with itself\na := b\n% with its own variants\na := e.v\n\n% incompatible with different defs\ntype f : enum(v)\nvar c : f\na := c\na := f.v\n"
 ---
-"v"@(FileId(1), 14..15) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "v"@(FileId(1), 14..15), )
-"e"@(FileId(1), 9..16) [Enum]: <error>
 "e"@(FileId(1), 5..6) [Type]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "v"@(FileId(1), 14..15), )
+"e"@(FileId(1), 9..16) [Enum]: <error>
+"v"@(FileId(1), 14..15) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "v"@(FileId(1), 14..15), )
 "a"@(FileId(1), 21..22) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "v"@(FileId(1), 14..15), )
 "b"@(FileId(1), 24..25) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "v"@(FileId(1), 14..15), )
-"v"@(FileId(1), 146..147) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(6))] ( "v"@(FileId(1), 146..147), )
-"f"@(FileId(1), 141..148) [Enum]: <error>
 "f"@(FileId(1), 137..138) [Type]: enum[DefId(LibraryId(0), LocalDefId(6))] ( "v"@(FileId(1), 146..147), )
+"f"@(FileId(1), 141..148) [Enum]: <error>
+"v"@(FileId(1), 146..147) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(6))] ( "v"@(FileId(1), 146..147), )
 "c"@(FileId(1), 153..154) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(6))] ( "v"@(FileId(1), 146..147), )
 "<root>"@(dummy) [Module(No)]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__equivalence_of_opaques.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__equivalence_of_opaques.snap
@@ -5,18 +5,18 @@ expression: "module z\n    export unqualified opaque ty, unwrap, make\n\n    typ
 "z"@(FileId(1), 7..8) [Module(No)]: <error>
 "ty"@(FileId(1), 66..68) [Type]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
 "unwrap"@(FileId(1), 84..90) [Subprogram(Function)]: function ( pass(value) opaque[DefId(LibraryId(0), LocalDefId(1))] type to int, ) -> int
-"<unnamed>"@(dummy) [Undeclared]: <error>
 "t"@(FileId(1), 91..92) [Param(Value, No)]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
 "make"@(FileId(1), 146..150) [Subprogram(Function)]: function ( pass(value) int, ) -> opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
-"<unnamed>"@(dummy) [Undeclared]: <error>
 "i"@(FileId(1), 151..152) [Param(Value, No)]: int
-"ty"@(FileId(1), 39..41) [Export]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
-"unwrap"@(FileId(1), 43..49) [Export]: function ( pass(value) opaque[DefId(LibraryId(0), LocalDefId(1))] type to int, ) -> int
-"make"@(FileId(1), 51..55) [Export]: function ( pass(value) int, ) -> opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
 "a"@(FileId(1), 257..258) [ConstVar(Var, No)]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
 "b"@(FileId(1), 260..261) [ConstVar(Var, No)]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
 "c"@(FileId(1), 271..272) [ConstVar(Var, No)]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
 "i"@(FileId(1), 358..359) [ConstVar(Var, No)]: int
+"<unnamed>"@(dummy) [Undeclared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
+"ty"@(FileId(1), 39..41) [Export]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
+"unwrap"@(FileId(1), 43..49) [Export]: function ( pass(value) opaque[DefId(LibraryId(0), LocalDefId(1))] type to int, ) -> int
+"make"@(FileId(1), 51..55) [Export]: function ( pass(value) int, ) -> opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
 "<root>"@(dummy) [Module(No)]: <error>
 
 error in file FileId(1) at 409..411: mismatched types

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__equivalence_of_sets.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__equivalence_of_sets.snap
@@ -2,19 +2,19 @@
 source: compiler/toc_analysis/src/typeck/test.rs
 expression: "type sb : set of boolean\ntype sc : set of char\ntype sc2 : set of char\n\nvar v_sb : sb\nvar v_sc : sc\nvar v_sc2 : sc2\nvar v_anon : set of char\n\n% compat\nv_sb := v_sb\nv_sc := v_sc\nv_sc2 := v_sc2\n\n% incompatible - different elem types\nv_sc := v_sb\n% incompatible - different def locations\nv_sc := v_sc2\nv_sc := v_anon\n\n% compatible through aliases\ntype asc : sc\nvar v_asc : asc\nv_sc := v_asc\n"
 ---
+"sb"@(FileId(1), 5..7) [Type]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
 "sb"@(FileId(1), 10..24) [Set]: <error>
-"sb"@(FileId(1), 5..7) [Type]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
+"sc"@(FileId(1), 30..32) [Type]: set[DefId(LibraryId(0), LocalDefId(3))] of char
 "sc"@(FileId(1), 35..46) [Set]: <error>
-"sc"@(FileId(1), 30..32) [Type]: set[DefId(LibraryId(0), LocalDefId(2))] of char
+"sc2"@(FileId(1), 52..55) [Type]: set[DefId(LibraryId(0), LocalDefId(5))] of char
 "sc2"@(FileId(1), 58..69) [Set]: <error>
-"sc2"@(FileId(1), 52..55) [Type]: set[DefId(LibraryId(0), LocalDefId(4))] of char
-"v_sb"@(FileId(1), 75..79) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
-"v_sc"@(FileId(1), 89..93) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(2))] of char
-"v_sc2"@(FileId(1), 103..108) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(4))] of char
+"v_sb"@(FileId(1), 75..79) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
+"v_sc"@(FileId(1), 89..93) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(3))] of char
+"v_sc2"@(FileId(1), 103..108) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(5))] of char
+"v_anon"@(FileId(1), 119..125) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(10))] of char
 "<anonymous>"@(FileId(1), 128..139) [Set]: <error>
-"v_anon"@(FileId(1), 119..125) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(9))] of char
-"asc"@(FileId(1), 348..351) [Type]: alias[DefId(LibraryId(0), LocalDefId(11))] of set[DefId(LibraryId(0), LocalDefId(2))] of char
-"v_asc"@(FileId(1), 361..366) [ConstVar(Var, No)]: alias[DefId(LibraryId(0), LocalDefId(11))] of set[DefId(LibraryId(0), LocalDefId(2))] of char
+"asc"@(FileId(1), 348..351) [Type]: alias[DefId(LibraryId(0), LocalDefId(11))] of set[DefId(LibraryId(0), LocalDefId(3))] of char
+"v_asc"@(FileId(1), 361..366) [ConstVar(Var, No)]: alias[DefId(LibraryId(0), LocalDefId(11))] of set[DefId(LibraryId(0), LocalDefId(3))] of char
 "<root>"@(dummy) [Module(No)]: <error>
 
 error in file FileId(1) at 235..237: mismatched types

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__equivalence_of_subprogram_formals.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__equivalence_of_subprogram_formals.snap
@@ -2,16 +2,16 @@
 source: compiler/toc_analysis/src/typeck/test.rs
 expression: "type t_p : procedure(a, b : int, var c : string)\nprocedure p(a, b : int, var c : string) end p\n\nvar _ : t_p := p\n"
 ---
-"<unnamed>"@(dummy) [Undeclared]: <error>
+"t_p"@(FileId(1), 5..8) [Type]: alias[DefId(LibraryId(0), LocalDefId(0))] of procedure ( pass(value) int, pass(value) int, pass(var ref) string, ) -> void
 "a"@(FileId(1), 21..22) [Param(Value, No)]: <error>
 "b"@(FileId(1), 24..25) [Param(Value, No)]: <error>
 "c"@(FileId(1), 37..38) [Param(Reference(Var), No)]: <error>
-"t_p"@(FileId(1), 5..8) [Type]: alias[DefId(LibraryId(0), LocalDefId(4))] of procedure ( pass(value) int, pass(value) int, pass(var ref) string, ) -> void
 "p"@(FileId(1), 59..60) [Subprogram(Procedure)]: procedure ( pass(value) int, pass(value) int, pass(var ref) string, ) -> void
-"<unnamed>"@(dummy) [Undeclared]: <error>
 "a"@(FileId(1), 61..62) [Param(Value, No)]: int
 "b"@(FileId(1), 64..65) [Param(Value, No)]: int
 "c"@(FileId(1), 77..78) [Param(Reference(Var), No)]: string
-"_"@(FileId(1), 100..101) [ConstVar(Var, No)]: alias[DefId(LibraryId(0), LocalDefId(4))] of procedure ( pass(value) int, pass(value) int, pass(var ref) string, ) -> void
+"_"@(FileId(1), 100..101) [ConstVar(Var, No)]: alias[DefId(LibraryId(0), LocalDefId(0))] of procedure ( pass(value) int, pass(value) int, pass(var ref) string, ) -> void
+"<unnamed>"@(dummy) [Undeclared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "<root>"@(dummy) [Module(No)]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__equivalence_of_subprogram_formals_bare.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__equivalence_of_subprogram_formals_bare.snap
@@ -4,13 +4,13 @@ expression: "type t_f : function : int\ntype t_p : procedure\ntype t_fp : functi
 ---
 "t_f"@(FileId(1), 5..8) [Type]: alias[DefId(LibraryId(0), LocalDefId(0))] of function -> int
 "t_p"@(FileId(1), 31..34) [Type]: alias[DefId(LibraryId(0), LocalDefId(1))] of procedure -> void
-"<unnamed>"@(dummy) [Undeclared]: <error>
-"t_fp"@(FileId(1), 52..56) [Type]: alias[DefId(LibraryId(0), LocalDefId(3))] of function ( ) -> int
-"<unnamed>"@(dummy) [Undeclared]: <error>
-"t_pp"@(FileId(1), 81..85) [Type]: alias[DefId(LibraryId(0), LocalDefId(5))] of procedure ( ) -> void
+"t_fp"@(FileId(1), 52..56) [Type]: alias[DefId(LibraryId(0), LocalDefId(2))] of function ( ) -> int
+"t_pp"@(FileId(1), 81..85) [Type]: alias[DefId(LibraryId(0), LocalDefId(3))] of procedure ( ) -> void
 "f"@(FileId(1), 105..106) [ConstVar(Var, No)]: alias[DefId(LibraryId(0), LocalDefId(0))] of function -> int
 "p"@(FileId(1), 117..118) [ConstVar(Var, No)]: alias[DefId(LibraryId(0), LocalDefId(1))] of procedure -> void
-"fp"@(FileId(1), 129..131) [ConstVar(Var, No)]: alias[DefId(LibraryId(0), LocalDefId(3))] of function ( ) -> int
-"pp"@(FileId(1), 143..145) [ConstVar(Var, No)]: alias[DefId(LibraryId(0), LocalDefId(5))] of procedure ( ) -> void
+"fp"@(FileId(1), 129..131) [ConstVar(Var, No)]: alias[DefId(LibraryId(0), LocalDefId(2))] of function ( ) -> int
+"pp"@(FileId(1), 143..145) [ConstVar(Var, No)]: alias[DefId(LibraryId(0), LocalDefId(3))] of procedure ( ) -> void
+"<unnamed>"@(dummy) [Undeclared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "<root>"@(dummy) [Module(No)]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__equivalence_of_subprogram_formals_cheat.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__equivalence_of_subprogram_formals_cheat.snap
@@ -2,17 +2,17 @@
 source: compiler/toc_analysis/src/typeck/test.rs
 expression: "type t_f : function(a, b : int, var c : string) : int\ntype t_fc : function(a, b : cheat int, var c : cheat string) : int\nvar f : t_f\nvar fc : t_fc\n\n% transitive\nf := fc\nfc := f\n"
 ---
-"<unnamed>"@(dummy) [Undeclared]: <error>
+"t_f"@(FileId(1), 5..8) [Type]: alias[DefId(LibraryId(0), LocalDefId(0))] of function ( pass(value) int, pass(value) int, pass(var ref) string, ) -> int
 "a"@(FileId(1), 20..21) [Param(Value, No)]: <error>
 "b"@(FileId(1), 23..24) [Param(Value, No)]: <error>
 "c"@(FileId(1), 36..37) [Param(Reference(Var), No)]: <error>
-"t_f"@(FileId(1), 5..8) [Type]: alias[DefId(LibraryId(0), LocalDefId(4))] of function ( pass(value) int, pass(value) int, pass(var ref) string, ) -> int
-"<unnamed>"@(dummy) [Undeclared]: <error>
+"t_fc"@(FileId(1), 59..63) [Type]: alias[DefId(LibraryId(0), LocalDefId(4))] of function ( pass(value) cheat int, pass(value) cheat int, pass(var ref) cheat string, ) -> int
 "a"@(FileId(1), 75..76) [Param(Value, No)]: <error>
 "b"@(FileId(1), 78..79) [Param(Value, No)]: <error>
 "c"@(FileId(1), 97..98) [Param(Reference(Var), No)]: <error>
-"t_fc"@(FileId(1), 59..63) [Type]: alias[DefId(LibraryId(0), LocalDefId(9))] of function ( pass(value) cheat int, pass(value) cheat int, pass(var ref) cheat string, ) -> int
-"f"@(FileId(1), 125..126) [ConstVar(Var, No)]: alias[DefId(LibraryId(0), LocalDefId(4))] of function ( pass(value) int, pass(value) int, pass(var ref) string, ) -> int
-"fc"@(FileId(1), 137..139) [ConstVar(Var, No)]: alias[DefId(LibraryId(0), LocalDefId(9))] of function ( pass(value) cheat int, pass(value) cheat int, pass(var ref) cheat string, ) -> int
+"f"@(FileId(1), 125..126) [ConstVar(Var, No)]: alias[DefId(LibraryId(0), LocalDefId(0))] of function ( pass(value) int, pass(value) int, pass(var ref) string, ) -> int
+"fc"@(FileId(1), 137..139) [ConstVar(Var, No)]: alias[DefId(LibraryId(0), LocalDefId(4))] of function ( pass(value) cheat int, pass(value) cheat int, pass(var ref) cheat string, ) -> int
+"<unnamed>"@(dummy) [Undeclared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "<root>"@(dummy) [Module(No)]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__equivalence_of_subprogram_formals_err_not_var.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__equivalence_of_subprogram_formals_err_not_var.snap
@@ -2,17 +2,17 @@
 source: compiler/toc_analysis/src/typeck/test.rs
 expression: "type t_p : procedure(a, b : int, var c : string)\nprocedure p(a, b : int, c : string) end p\n\nvar _ : t_p := p\n"
 ---
-"<unnamed>"@(dummy) [Undeclared]: <error>
+"t_p"@(FileId(1), 5..8) [Type]: alias[DefId(LibraryId(0), LocalDefId(0))] of procedure ( pass(value) int, pass(value) int, pass(var ref) string, ) -> void
 "a"@(FileId(1), 21..22) [Param(Value, No)]: <error>
 "b"@(FileId(1), 24..25) [Param(Value, No)]: <error>
 "c"@(FileId(1), 37..38) [Param(Reference(Var), No)]: <error>
-"t_p"@(FileId(1), 5..8) [Type]: alias[DefId(LibraryId(0), LocalDefId(4))] of procedure ( pass(value) int, pass(value) int, pass(var ref) string, ) -> void
 "p"@(FileId(1), 59..60) [Subprogram(Procedure)]: procedure ( pass(value) int, pass(value) int, pass(value) string, ) -> void
-"<unnamed>"@(dummy) [Undeclared]: <error>
 "a"@(FileId(1), 61..62) [Param(Value, No)]: int
 "b"@(FileId(1), 64..65) [Param(Value, No)]: int
 "c"@(FileId(1), 73..74) [Param(Value, No)]: string
-"_"@(FileId(1), 96..97) [ConstVar(Var, No)]: alias[DefId(LibraryId(0), LocalDefId(4))] of procedure ( pass(value) int, pass(value) int, pass(var ref) string, ) -> void
+"_"@(FileId(1), 96..97) [ConstVar(Var, No)]: alias[DefId(LibraryId(0), LocalDefId(0))] of procedure ( pass(value) int, pass(value) int, pass(var ref) string, ) -> void
+"<unnamed>"@(dummy) [Undeclared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "<root>"@(dummy) [Module(No)]: <error>
 
 error in file FileId(1) at 107..108: mismatched types

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__equivalence_of_subprogram_formals_err_too_few.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__equivalence_of_subprogram_formals_err_too_few.snap
@@ -2,16 +2,16 @@
 source: compiler/toc_analysis/src/typeck/test.rs
 expression: "type t_p : procedure(a, b : int, var c : string)\nprocedure p(a : int, var c : string) end p\n\nvar _ : t_p := p\n"
 ---
-"<unnamed>"@(dummy) [Undeclared]: <error>
+"t_p"@(FileId(1), 5..8) [Type]: alias[DefId(LibraryId(0), LocalDefId(0))] of procedure ( pass(value) int, pass(value) int, pass(var ref) string, ) -> void
 "a"@(FileId(1), 21..22) [Param(Value, No)]: <error>
 "b"@(FileId(1), 24..25) [Param(Value, No)]: <error>
 "c"@(FileId(1), 37..38) [Param(Reference(Var), No)]: <error>
-"t_p"@(FileId(1), 5..8) [Type]: alias[DefId(LibraryId(0), LocalDefId(4))] of procedure ( pass(value) int, pass(value) int, pass(var ref) string, ) -> void
 "p"@(FileId(1), 59..60) [Subprogram(Procedure)]: procedure ( pass(value) int, pass(var ref) string, ) -> void
-"<unnamed>"@(dummy) [Undeclared]: <error>
 "a"@(FileId(1), 61..62) [Param(Value, No)]: int
 "c"@(FileId(1), 74..75) [Param(Reference(Var), No)]: string
-"_"@(FileId(1), 97..98) [ConstVar(Var, No)]: alias[DefId(LibraryId(0), LocalDefId(4))] of procedure ( pass(value) int, pass(value) int, pass(var ref) string, ) -> void
+"_"@(FileId(1), 97..98) [ConstVar(Var, No)]: alias[DefId(LibraryId(0), LocalDefId(0))] of procedure ( pass(value) int, pass(value) int, pass(var ref) string, ) -> void
+"<unnamed>"@(dummy) [Undeclared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "<root>"@(dummy) [Module(No)]: <error>
 
 error in file FileId(1) at 108..109: mismatched types

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__equivalence_of_subprogram_formals_err_too_many.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__equivalence_of_subprogram_formals_err_too_many.snap
@@ -2,18 +2,18 @@
 source: compiler/toc_analysis/src/typeck/test.rs
 expression: "type t_p : procedure(a, b : int, var c : string)\nprocedure p(a, b, k : int, var c : string) end p\n\nvar _ : t_p := p\n"
 ---
-"<unnamed>"@(dummy) [Undeclared]: <error>
+"t_p"@(FileId(1), 5..8) [Type]: alias[DefId(LibraryId(0), LocalDefId(0))] of procedure ( pass(value) int, pass(value) int, pass(var ref) string, ) -> void
 "a"@(FileId(1), 21..22) [Param(Value, No)]: <error>
 "b"@(FileId(1), 24..25) [Param(Value, No)]: <error>
 "c"@(FileId(1), 37..38) [Param(Reference(Var), No)]: <error>
-"t_p"@(FileId(1), 5..8) [Type]: alias[DefId(LibraryId(0), LocalDefId(4))] of procedure ( pass(value) int, pass(value) int, pass(var ref) string, ) -> void
 "p"@(FileId(1), 59..60) [Subprogram(Procedure)]: procedure ( pass(value) int, pass(value) int, pass(value) int, pass(var ref) string, ) -> void
-"<unnamed>"@(dummy) [Undeclared]: <error>
 "a"@(FileId(1), 61..62) [Param(Value, No)]: int
 "b"@(FileId(1), 64..65) [Param(Value, No)]: int
 "k"@(FileId(1), 67..68) [Param(Value, No)]: int
 "c"@(FileId(1), 80..81) [Param(Reference(Var), No)]: string
-"_"@(FileId(1), 103..104) [ConstVar(Var, No)]: alias[DefId(LibraryId(0), LocalDefId(4))] of procedure ( pass(value) int, pass(value) int, pass(var ref) string, ) -> void
+"_"@(FileId(1), 103..104) [ConstVar(Var, No)]: alias[DefId(LibraryId(0), LocalDefId(0))] of procedure ( pass(value) int, pass(value) int, pass(var ref) string, ) -> void
+"<unnamed>"@(dummy) [Undeclared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "<root>"@(dummy) [Module(No)]: <error>
 
 error in file FileId(1) at 114..115: mismatched types

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__equivalence_of_subprogram_formals_register.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__equivalence_of_subprogram_formals_register.snap
@@ -2,17 +2,17 @@
 source: compiler/toc_analysis/src/typeck/test.rs
 expression: "type t_f : function(a, b : int, var c : string) : int\ntype t_fr : function(register a, b : int, var register c : string) : int\nvar f : t_f\nvar fc : t_fr\n\n% transitive\nf := fc\nfc := f\n"
 ---
-"<unnamed>"@(dummy) [Undeclared]: <error>
+"t_f"@(FileId(1), 5..8) [Type]: alias[DefId(LibraryId(0), LocalDefId(0))] of function ( pass(value) int, pass(value) int, pass(var ref) string, ) -> int
 "a"@(FileId(1), 20..21) [Param(Value, No)]: <error>
 "b"@(FileId(1), 23..24) [Param(Value, No)]: <error>
 "c"@(FileId(1), 36..37) [Param(Reference(Var), No)]: <error>
-"t_f"@(FileId(1), 5..8) [Type]: alias[DefId(LibraryId(0), LocalDefId(4))] of function ( pass(value) int, pass(value) int, pass(var ref) string, ) -> int
-"<unnamed>"@(dummy) [Undeclared]: <error>
+"t_fr"@(FileId(1), 59..63) [Type]: alias[DefId(LibraryId(0), LocalDefId(4))] of function ( pass(value) register int, pass(value) register int, pass(var ref) register string, ) -> int
 "a"@(FileId(1), 84..85) [Param(Value, Yes)]: <error>
 "b"@(FileId(1), 87..88) [Param(Value, Yes)]: <error>
 "c"@(FileId(1), 109..110) [Param(Reference(Var), Yes)]: <error>
-"t_fr"@(FileId(1), 59..63) [Type]: alias[DefId(LibraryId(0), LocalDefId(9))] of function ( pass(value) register int, pass(value) register int, pass(var ref) register string, ) -> int
-"f"@(FileId(1), 131..132) [ConstVar(Var, No)]: alias[DefId(LibraryId(0), LocalDefId(4))] of function ( pass(value) int, pass(value) int, pass(var ref) string, ) -> int
-"fc"@(FileId(1), 143..145) [ConstVar(Var, No)]: alias[DefId(LibraryId(0), LocalDefId(9))] of function ( pass(value) register int, pass(value) register int, pass(var ref) register string, ) -> int
+"f"@(FileId(1), 131..132) [ConstVar(Var, No)]: alias[DefId(LibraryId(0), LocalDefId(0))] of function ( pass(value) int, pass(value) int, pass(var ref) string, ) -> int
+"fc"@(FileId(1), 143..145) [ConstVar(Var, No)]: alias[DefId(LibraryId(0), LocalDefId(4))] of function ( pass(value) register int, pass(value) register int, pass(var ref) register string, ) -> int
+"<unnamed>"@(dummy) [Undeclared]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "<root>"@(dummy) [Module(No)]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__equivalence_of_subprogram_result.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__equivalence_of_subprogram_result.snap
@@ -2,10 +2,10 @@
 source: compiler/toc_analysis/src/typeck/test.rs
 expression: "type fa : function () : int\nfunction fb () : int end fb\n\nvar _ : fa := fb\n"
 ---
-"<unnamed>"@(dummy) [Undeclared]: <error>
-"fa"@(FileId(1), 5..7) [Type]: alias[DefId(LibraryId(0), LocalDefId(1))] of function ( ) -> int
+"fa"@(FileId(1), 5..7) [Type]: alias[DefId(LibraryId(0), LocalDefId(0))] of function ( ) -> int
 "fb"@(FileId(1), 37..39) [Subprogram(Function)]: function ( ) -> int
+"_"@(FileId(1), 61..62) [ConstVar(Var, No)]: alias[DefId(LibraryId(0), LocalDefId(0))] of function ( ) -> int
 "<unnamed>"@(dummy) [Undeclared]: <error>
-"_"@(FileId(1), 61..62) [ConstVar(Var, No)]: alias[DefId(LibraryId(0), LocalDefId(1))] of function ( ) -> int
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "<root>"@(dummy) [Module(No)]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__equivalence_of_subprogram_result_err.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__equivalence_of_subprogram_result_err.snap
@@ -2,11 +2,11 @@
 source: compiler/toc_analysis/src/typeck/test.rs
 expression: "type fa : function () : int1\nfunction fb () : int end fb\n\nvar _ : fa := fb\n"
 ---
-"<unnamed>"@(dummy) [Undeclared]: <error>
-"fa"@(FileId(1), 5..7) [Type]: alias[DefId(LibraryId(0), LocalDefId(1))] of function ( ) -> int1
+"fa"@(FileId(1), 5..7) [Type]: alias[DefId(LibraryId(0), LocalDefId(0))] of function ( ) -> int1
 "fb"@(FileId(1), 38..40) [Subprogram(Function)]: function ( ) -> int
+"_"@(FileId(1), 62..63) [ConstVar(Var, No)]: alias[DefId(LibraryId(0), LocalDefId(0))] of function ( ) -> int1
 "<unnamed>"@(dummy) [Undeclared]: <error>
-"_"@(FileId(1), 62..63) [ConstVar(Var, No)]: alias[DefId(LibraryId(0), LocalDefId(1))] of function ( ) -> int1
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "<root>"@(dummy) [Module(No)]: <error>
 
 error in file FileId(1) at 72..74: mismatched types

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__report_aliased_type_in_subprog_ty.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__report_aliased_type_in_subprog_ty.snap
@@ -6,13 +6,13 @@ expression: "type i : int\ntype am_in : real\ntype misery : char(*)\ntype eat_em
 "am_in"@(FileId(1), 18..23) [Type]: alias[DefId(LibraryId(0), LocalDefId(1))] of real
 "misery"@(FileId(1), 36..42) [Type]: alias[DefId(LibraryId(0), LocalDefId(2))] of char_n Any
 "eat_em_up"@(FileId(1), 58..67) [Type]: alias[DefId(LibraryId(0), LocalDefId(3))] of string
-"<unnamed>"@(dummy) [Undeclared]: <error>
+"f"@(FileId(1), 82..83) [Type]: alias[DefId(LibraryId(0), LocalDefId(4))] of function ( pass(value) alias[DefId(LibraryId(0), LocalDefId(0))] of int, pass(value) alias[DefId(LibraryId(0), LocalDefId(1))] of real, pass(value) alias[DefId(LibraryId(0), LocalDefId(2))] of char_n Any, ) -> alias[DefId(LibraryId(0), LocalDefId(3))] of string
 "c"@(FileId(1), 95..96) [Param(Value, No)]: <error>
 "p"@(FileId(1), 102..103) [Param(Value, No)]: <error>
 "r"@(FileId(1), 113..114) [Param(Value, No)]: <error>
-"f"@(FileId(1), 82..83) [Type]: alias[DefId(LibraryId(0), LocalDefId(8))] of function ( pass(value) alias[DefId(LibraryId(0), LocalDefId(0))] of int, pass(value) alias[DefId(LibraryId(0), LocalDefId(1))] of real, pass(value) alias[DefId(LibraryId(0), LocalDefId(2))] of char_n Any, ) -> alias[DefId(LibraryId(0), LocalDefId(3))] of string
-"y"@(FileId(1), 142..143) [ConstVar(Var, No)]: alias[DefId(LibraryId(0), LocalDefId(8))] of function ( pass(value) alias[DefId(LibraryId(0), LocalDefId(0))] of int, pass(value) alias[DefId(LibraryId(0), LocalDefId(1))] of real, pass(value) alias[DefId(LibraryId(0), LocalDefId(2))] of char_n Any, ) -> alias[DefId(LibraryId(0), LocalDefId(3))] of string
+"y"@(FileId(1), 142..143) [ConstVar(Var, No)]: alias[DefId(LibraryId(0), LocalDefId(4))] of function ( pass(value) alias[DefId(LibraryId(0), LocalDefId(0))] of int, pass(value) alias[DefId(LibraryId(0), LocalDefId(1))] of real, pass(value) alias[DefId(LibraryId(0), LocalDefId(2))] of char_n Any, ) -> alias[DefId(LibraryId(0), LocalDefId(3))] of string
 "_"@(FileId(1), 152..153) [ConstVar(Var, No)]: int
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "<root>"@(dummy) [Module(No)]: <error>
 
 error in file FileId(1) at 163..164: mismatched types

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__require_positive_size_in_set_ty.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__require_positive_size_in_set_ty.snap
@@ -2,8 +2,8 @@
 source: compiler/toc_analysis/src/typeck/test.rs
 expression: "type _ : set of 1..0"
 ---
+"_"@(FileId(1), 5..6) [Type]: set[DefId(LibraryId(0), LocalDefId(1))] of range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No))
 "_"@(FileId(1), 9..20) [Set]: <error>
-"_"@(FileId(1), 5..6) [Type]: set[DefId(LibraryId(0), LocalDefId(0))] of range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No))
 "<root>"@(dummy) [Module(No)]: <error>
 
 error in file FileId(1) at 16..20: element range is too small

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__require_positive_size_in_subprogram_param.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__require_positive_size_in_subprogram_param.snap
@@ -3,8 +3,8 @@ source: compiler/toc_analysis/src/typeck/test.rs
 expression: "proc p(_:1..0) end p"
 ---
 "p"@(FileId(1), 5..6) [Subprogram(Procedure)]: procedure ( pass(value) range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No)), ) -> void
-"<unnamed>"@(dummy) [Undeclared]: <error>
 "_"@(FileId(1), 7..8) [Param(Value, No)]: range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No))
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "<root>"@(dummy) [Module(No)]: <error>
 
 error in file FileId(1) at 9..13: element range is too small

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__require_positive_size_in_subprogram_ty_param.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__require_positive_size_in_subprogram_ty_param.snap
@@ -2,9 +2,9 @@
 source: compiler/toc_analysis/src/typeck/test.rs
 expression: "type _ : proc p(_:1..0)"
 ---
-"<unnamed>"@(dummy) [Undeclared]: <error>
+"_"@(FileId(1), 5..6) [Type]: alias[DefId(LibraryId(0), LocalDefId(0))] of procedure ( pass(value) range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No)), ) -> void
 "_"@(FileId(1), 16..17) [Param(Value, No)]: <error>
-"_"@(FileId(1), 5..6) [Type]: alias[DefId(LibraryId(0), LocalDefId(2))] of procedure ( pass(value) range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No)), ) -> void
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "<root>"@(dummy) [Module(No)]: <error>
 
 error in file FileId(1) at 18..22: element range is too small

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__require_positive_size_in_subprogram_ty_result.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__require_positive_size_in_subprogram_ty_result.snap
@@ -2,8 +2,8 @@
 source: compiler/toc_analysis/src/typeck/test.rs
 expression: "type _ : fcn _() : 1..0"
 ---
+"_"@(FileId(1), 5..6) [Type]: alias[DefId(LibraryId(0), LocalDefId(0))] of function ( ) -> range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No))
 "<unnamed>"@(dummy) [Undeclared]: <error>
-"_"@(FileId(1), 5..6) [Type]: alias[DefId(LibraryId(0), LocalDefId(1))] of function ( ) -> range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No))
 "<root>"@(dummy) [Module(No)]: <error>
 
 error in file FileId(1) at 19..23: element range is too small

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__resolve_defs_on_field_lookup.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__resolve_defs_on_field_lookup.snap
@@ -6,9 +6,9 @@ expression: "module m\n    export ~.* n\n    module n\n        export o, p\n    
 "n"@(FileId(1), 37..38) [Module(No)]: <error>
 "o"@(FileId(1), 71..72) [ConstVar(Var, No)]: int
 "p"@(FileId(1), 92..93) [Type]: alias[DefId(LibraryId(0), LocalDefId(3))] of int
+"c"@(FileId(1), 129..130) [ConstVar(Var, No)]: alias[DefId(LibraryId(0), LocalDefId(3))] of int
 "o"@(FileId(1), 54..55) [Export]: int
 "p"@(FileId(1), 57..58) [Export]: alias[DefId(LibraryId(0), LocalDefId(3))] of int
 "n"@(FileId(1), 24..25) [Export]: <error>
-"c"@(FileId(1), 129..130) [ConstVar(Var, No)]: alias[DefId(LibraryId(0), LocalDefId(3))] of int
 "<root>"@(dummy) [Module(No)]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__set_member_op_in.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__set_member_op_in.snap
@@ -2,9 +2,9 @@
 source: compiler/toc_analysis/src/typeck/test.rs
 expression: "\n    type s : set of boolean\n    var a : s\n    var b : boolean\n\n    % should all produce booleans\n    var _v_res : boolean\n\n    _v_res := b in a\n    _v_res := true in a\n    % FIXME: add tests for range types\n    "
 ---
+"s"@(FileId(1), 10..11) [Type]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
 "s"@(FileId(1), 14..28) [Set]: <error>
-"s"@(FileId(1), 10..11) [Type]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
-"a"@(FileId(1), 37..38) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
+"a"@(FileId(1), 37..38) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
 "b"@(FileId(1), 51..52) [ConstVar(Var, No)]: boolean
 "_v_res"@(FileId(1), 106..112) [ConstVar(Var, No)]: boolean
 "<root>"@(dummy) [Module(No)]: <error>

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__set_member_op_not_in.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__set_member_op_not_in.snap
@@ -2,9 +2,9 @@
 source: compiler/toc_analysis/src/typeck/test.rs
 expression: "\n    type s : set of boolean\n    var a : s\n    var b : boolean\n\n    % should all produce booleans\n    var _v_res : boolean\n\n    _v_res := b ~in a\n    _v_res := true ~in a\n    % FIXME: add tests for range types\n    "
 ---
+"s"@(FileId(1), 10..11) [Type]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
 "s"@(FileId(1), 14..28) [Set]: <error>
-"s"@(FileId(1), 10..11) [Type]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
-"a"@(FileId(1), 37..38) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
+"a"@(FileId(1), 37..38) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
 "b"@(FileId(1), 51..52) [ConstVar(Var, No)]: boolean
 "_v_res"@(FileId(1), 106..112) [ConstVar(Var, No)]: boolean
 "<root>"@(dummy) [Module(No)]: <error>

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__set_member_op_wrong_types_in.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__set_member_op_wrong_types_in.snap
@@ -2,9 +2,9 @@
 source: compiler/toc_analysis/src/typeck/test.rs
 expression: "\n    type ts : set of boolean\n    var s : ts\n\n    % should all produce booleans\n    var _v_res : boolean\n\n    % not a set\n    _v_res := true in true\n    % incompatible element types\n    _v_res := 1 in s\n    "
 ---
+"ts"@(FileId(1), 10..12) [Type]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
 "ts"@(FileId(1), 15..29) [Set]: <error>
-"ts"@(FileId(1), 10..12) [Type]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
-"s"@(FileId(1), 38..39) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
+"s"@(FileId(1), 38..39) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
 "_v_res"@(FileId(1), 88..94) [ConstVar(Var, No)]: boolean
 "<root>"@(dummy) [Module(No)]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__set_member_op_wrong_types_not_in.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__set_member_op_wrong_types_not_in.snap
@@ -2,9 +2,9 @@
 source: compiler/toc_analysis/src/typeck/test.rs
 expression: "\n    type ts : set of boolean\n    var s : ts\n\n    % should all produce booleans\n    var _v_res : boolean\n\n    % not a set\n    _v_res := true ~in true\n    % incompatible element types\n    _v_res := 1 ~in s\n    "
 ---
+"ts"@(FileId(1), 10..12) [Type]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
 "ts"@(FileId(1), 15..29) [Set]: <error>
-"ts"@(FileId(1), 10..12) [Type]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
-"s"@(FileId(1), 38..39) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
+"s"@(FileId(1), 38..39) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
 "_v_res"@(FileId(1), 88..94) [ConstVar(Var, No)]: boolean
 "<root>"@(dummy) [Module(No)]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__set_ops_add.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__set_ops_add.snap
@@ -2,10 +2,10 @@
 source: compiler/toc_analysis/src/typeck/test.rs
 expression: "\n    type s : set of boolean\n    var a, b : s\n\n    % should all produce the same set\n    var _v_res : s\n\n    _v_res := a + b\n    _v_res := b + a\n    "
 ---
+"s"@(FileId(1), 10..11) [Type]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
 "s"@(FileId(1), 14..28) [Set]: <error>
-"s"@(FileId(1), 10..11) [Type]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
-"a"@(FileId(1), 37..38) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
-"b"@(FileId(1), 40..41) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
-"_v_res"@(FileId(1), 93..99) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
+"a"@(FileId(1), 37..38) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
+"b"@(FileId(1), 40..41) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
+"_v_res"@(FileId(1), 93..99) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
 "<root>"@(dummy) [Module(No)]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__set_ops_mul.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__set_ops_mul.snap
@@ -2,10 +2,10 @@
 source: compiler/toc_analysis/src/typeck/test.rs
 expression: "\n    type s : set of boolean\n    var a, b : s\n\n    % should all produce the same set\n    var _v_res : s\n\n    _v_res := a * b\n    _v_res := b * a\n    "
 ---
+"s"@(FileId(1), 10..11) [Type]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
 "s"@(FileId(1), 14..28) [Set]: <error>
-"s"@(FileId(1), 10..11) [Type]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
-"a"@(FileId(1), 37..38) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
-"b"@(FileId(1), 40..41) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
-"_v_res"@(FileId(1), 93..99) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
+"a"@(FileId(1), 37..38) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
+"b"@(FileId(1), 40..41) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
+"_v_res"@(FileId(1), 93..99) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
 "<root>"@(dummy) [Module(No)]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__set_ops_sub.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__set_ops_sub.snap
@@ -2,10 +2,10 @@
 source: compiler/toc_analysis/src/typeck/test.rs
 expression: "\n    type s : set of boolean\n    var a, b : s\n\n    % should all produce the same set\n    var _v_res : s\n\n    _v_res := a - b\n    _v_res := b - a\n    "
 ---
+"s"@(FileId(1), 10..11) [Type]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
 "s"@(FileId(1), 14..28) [Set]: <error>
-"s"@(FileId(1), 10..11) [Type]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
-"a"@(FileId(1), 37..38) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
-"b"@(FileId(1), 40..41) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
-"_v_res"@(FileId(1), 93..99) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
+"a"@(FileId(1), 37..38) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
+"b"@(FileId(1), 40..41) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
+"_v_res"@(FileId(1), 93..99) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
 "<root>"@(dummy) [Module(No)]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__set_ops_wrong_types_add.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__set_ops_wrong_types_add.snap
@@ -2,14 +2,14 @@
 source: compiler/toc_analysis/src/typeck/test.rs
 expression: "\n    type s1 : set of boolean\n    type s2 : set of boolean\n    var a : s1\n    var b : s2\n    var i : int\n\n    % should all produce the left set\n    var _v_res : s1\n\n    _v_res := a + b\n\n    % error types\n    _v_res := a + i\n    _v_res := i + a\n    "
 ---
+"s1"@(FileId(1), 10..12) [Type]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
 "s1"@(FileId(1), 15..29) [Set]: <error>
-"s1"@(FileId(1), 10..12) [Type]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
+"s2"@(FileId(1), 39..41) [Type]: set[DefId(LibraryId(0), LocalDefId(3))] of boolean
 "s2"@(FileId(1), 44..58) [Set]: <error>
-"s2"@(FileId(1), 39..41) [Type]: set[DefId(LibraryId(0), LocalDefId(2))] of boolean
-"a"@(FileId(1), 67..68) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
-"b"@(FileId(1), 82..83) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(2))] of boolean
+"a"@(FileId(1), 67..68) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
+"b"@(FileId(1), 82..83) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(3))] of boolean
 "i"@(FileId(1), 97..98) [ConstVar(Var, No)]: int
-"_v_res"@(FileId(1), 152..158) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
+"_v_res"@(FileId(1), 152..158) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
 "<root>"@(dummy) [Module(No)]: <error>
 
 error in file FileId(1) at 181..182: mismatched types for addition

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__set_ops_wrong_types_mul.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__set_ops_wrong_types_mul.snap
@@ -2,14 +2,14 @@
 source: compiler/toc_analysis/src/typeck/test.rs
 expression: "\n    type s1 : set of boolean\n    type s2 : set of boolean\n    var a : s1\n    var b : s2\n    var i : int\n\n    % should all produce the left set\n    var _v_res : s1\n\n    _v_res := a * b\n\n    % error types\n    _v_res := a * i\n    _v_res := i * a\n    "
 ---
+"s1"@(FileId(1), 10..12) [Type]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
 "s1"@(FileId(1), 15..29) [Set]: <error>
-"s1"@(FileId(1), 10..12) [Type]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
+"s2"@(FileId(1), 39..41) [Type]: set[DefId(LibraryId(0), LocalDefId(3))] of boolean
 "s2"@(FileId(1), 44..58) [Set]: <error>
-"s2"@(FileId(1), 39..41) [Type]: set[DefId(LibraryId(0), LocalDefId(2))] of boolean
-"a"@(FileId(1), 67..68) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
-"b"@(FileId(1), 82..83) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(2))] of boolean
+"a"@(FileId(1), 67..68) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
+"b"@(FileId(1), 82..83) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(3))] of boolean
 "i"@(FileId(1), 97..98) [ConstVar(Var, No)]: int
-"_v_res"@(FileId(1), 152..158) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
+"_v_res"@(FileId(1), 152..158) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
 "<root>"@(dummy) [Module(No)]: <error>
 
 error in file FileId(1) at 181..182: mismatched types for multiplication

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__set_ops_wrong_types_sub.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__set_ops_wrong_types_sub.snap
@@ -2,14 +2,14 @@
 source: compiler/toc_analysis/src/typeck/test.rs
 expression: "\n    type s1 : set of boolean\n    type s2 : set of boolean\n    var a : s1\n    var b : s2\n    var i : int\n\n    % should all produce the left set\n    var _v_res : s1\n\n    _v_res := a - b\n\n    % error types\n    _v_res := a - i\n    _v_res := i - a\n    "
 ---
+"s1"@(FileId(1), 10..12) [Type]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
 "s1"@(FileId(1), 15..29) [Set]: <error>
-"s1"@(FileId(1), 10..12) [Type]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
+"s2"@(FileId(1), 39..41) [Type]: set[DefId(LibraryId(0), LocalDefId(3))] of boolean
 "s2"@(FileId(1), 44..58) [Set]: <error>
-"s2"@(FileId(1), 39..41) [Type]: set[DefId(LibraryId(0), LocalDefId(2))] of boolean
-"a"@(FileId(1), 67..68) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
-"b"@(FileId(1), 82..83) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(2))] of boolean
+"a"@(FileId(1), 67..68) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
+"b"@(FileId(1), 82..83) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(3))] of boolean
 "i"@(FileId(1), 97..98) [ConstVar(Var, No)]: int
-"_v_res"@(FileId(1), 152..158) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
+"_v_res"@(FileId(1), 152..158) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
 "<root>"@(dummy) [Module(No)]: <error>
 
 error in file FileId(1) at 181..182: mismatched types for subtraction

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__string_manip_op_concat.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__string_manip_op_concat.snap
@@ -3,7 +3,6 @@ source: compiler/toc_analysis/src/typeck/test.rs
 expression: "\n    proc __ (var c_any : char(*), var s_any : string(*))\n    var c : char\n    var c_sz : char(6)\n    var s : string\n    var s_sz : string(6)\n\n    % special cases first\n    var _t00 := c + c\n    var _t02 := c + c_sz\n    var _t20 := c_sz + c\n    var _t22 := c_sz + c_sz\n\n    % the rest of them down here (should produce string)\n    var _t01 := c + c_any\n    var _t03 := c + s\n    var _t04 := c + s_any\n    var _t05 := c + s_sz\n\n    var _t10 := c_any + c\n    var _t30 := s + c\n    var _t40 := s_any + c\n    var _t50 := s_sz + c\n\n    var _t11 := c_any + c_any\n    var _t12 := c_any + c_sz\n    var _t13 := c_any + s\n    var _t14 := c_any + s_any\n    var _t15 := c_any + s_sz\n\n    var _t21 := c_sz + c_any\n    var _t31 := s + c_any\n    var _t41 := s_any + c_any\n    var _t51 := s_sz + c_any\n\n    var _t23 := c_sz + s\n    var _t24 := c_sz + s_any\n    var _t25 := c_sz + s_sz\n\n    var _t32 := s + c_sz\n    var _t42 := s_any + c_sz\n    var _t52 := s_sz + c_sz\n\n    var _t33 := s + s\n    var _t34 := s + s_any\n    var _t35 := s + s_sz\n\n    var _t43 := s_any + s\n    var _t53 := s_sz + s\n\n    var _t44 := s_any + s_any\n    var _t45 := s_any + s_sz\n\n    var _t54 := s_sz + s_any\n\n    var _t55 := s_sz + s_sz\n    end __\n    "
 ---
 "__"@(FileId(1), 10..12) [Subprogram(Procedure)]: procedure ( pass(var ref) char_n Any, pass(var ref) string_n Any, ) -> void
-"<unnamed>"@(dummy) [Undeclared]: <error>
 "c_any"@(FileId(1), 18..23) [Param(Reference(Var), No)]: char_n Any
 "s_any"@(FileId(1), 39..44) [Param(Reference(Var), No)]: string_n Any
 "c"@(FileId(1), 66..67) [ConstVar(Var, No)]: char
@@ -46,5 +45,6 @@ expression: "\n    proc __ (var c_any : char(*), var s_any : string(*))\n    var
 "_t45"@(FileId(1), 1117..1121) [ConstVar(Var, No)]: string
 "_t54"@(FileId(1), 1147..1151) [ConstVar(Var, No)]: string
 "_t55"@(FileId(1), 1177..1181) [ConstVar(Var, No)]: string
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "<root>"@(dummy) [Module(No)]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__string_manip_op_wrong_type_concat.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__string_manip_op_wrong_type_concat.snap
@@ -3,7 +3,6 @@ source: compiler/toc_analysis/src/typeck/test.rs
 expression: "\n    proc __ (var c_any : char(*), var s_any : string(*))\n    var c : char\n    var c_sz : char(6)\n    var s : string\n    var s_sz : string(6)\n    var i : int\n\n    var _e00 := c + i\n    var _e01 := c_any + i\n    var _e02 := c_sz + i\n    var _e03 := s + i\n    var _e04 := s_any + i\n    var _e05 := s_sz + i\n\n    var _e10 := i + c\n    var _e11 := i + c_any\n    var _e12 := i + c_sz\n    var _e13 := i + s\n    var _e14 := i + s_any\n    var _e15 := i + s_sz\n\n    % TODO: Uncomment to verify incompatible types\n    /*\n    var _e20 : char(13) := c_sz + c_sz\n    var _e21 : char(8) := c_sz + c\n    var _e22 : char(8) := c + c_sz\n    var _e23 : char(3) := c + c\n    var _e24 : char := c + c\n    */\n    end __\n    "
 ---
 "__"@(FileId(1), 10..12) [Subprogram(Procedure)]: procedure ( pass(var ref) char_n Any, pass(var ref) string_n Any, ) -> void
-"<unnamed>"@(dummy) [Undeclared]: <error>
 "c_any"@(FileId(1), 18..23) [Param(Reference(Var), No)]: char_n Any
 "s_any"@(FileId(1), 39..44) [Param(Reference(Var), No)]: string_n Any
 "c"@(FileId(1), 66..67) [ConstVar(Var, No)]: char
@@ -23,6 +22,7 @@ expression: "\n    proc __ (var c_any : char(*), var s_any : string(*))\n    var
 "_e13"@(FileId(1), 387..391) [ConstVar(Var, No)]: <error>
 "_e14"@(FileId(1), 409..413) [ConstVar(Var, No)]: <error>
 "_e15"@(FileId(1), 435..439) [ConstVar(Var, No)]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "<root>"@(dummy) [Module(No)]: <error>
 
 error in file FileId(1) at 177..178: mismatched types for string concatenation

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_constrained_ty_from_enums.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_constrained_ty_from_enums.snap
@@ -2,10 +2,10 @@
 source: compiler/toc_analysis/src/typeck/test.rs
 expression: "type e : enum(uwu, owo)\ntype c : e.uwu .. e.owo"
 ---
-"uwu"@(FileId(1), 14..17) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(2))] ( "uwu"@(FileId(1), 14..17), "owo"@(FileId(1), 19..22), )
-"owo"@(FileId(1), 19..22) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(2))] ( "uwu"@(FileId(1), 14..17), "owo"@(FileId(1), 19..22), )
+"e"@(FileId(1), 5..6) [Type]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "uwu"@(FileId(1), 14..17), "owo"@(FileId(1), 19..22), )
 "e"@(FileId(1), 9..23) [Enum]: <error>
-"e"@(FileId(1), 5..6) [Type]: enum[DefId(LibraryId(0), LocalDefId(2))] ( "uwu"@(FileId(1), 14..17), "owo"@(FileId(1), 19..22), )
-"c"@(FileId(1), 29..30) [Type]: alias[DefId(LibraryId(0), LocalDefId(4))] of range of `enum[DefId(LibraryId(0), LocalDefId(2))] ( "uwu"@(FileId(1), 14..17), "owo"@(FileId(1), 19..22), )` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No))
+"uwu"@(FileId(1), 14..17) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "uwu"@(FileId(1), 14..17), "owo"@(FileId(1), 19..22), )
+"owo"@(FileId(1), 19..22) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "uwu"@(FileId(1), 14..17), "owo"@(FileId(1), 19..22), )
+"c"@(FileId(1), 29..30) [Type]: alias[DefId(LibraryId(0), LocalDefId(4))] of range of `enum[DefId(LibraryId(0), LocalDefId(1))] ( "uwu"@(FileId(1), 14..17), "owo"@(FileId(1), 19..22), )` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No))
 "<root>"@(dummy) [Module(No)]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_enum_ty_from_type_alias.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_enum_ty_from_type_alias.snap
@@ -2,10 +2,10 @@
 source: compiler/toc_analysis/src/typeck/test.rs
 expression: "type e : enum(a, b, c)"
 ---
-"a"@(FileId(1), 14..15) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(3))] ( "a"@(FileId(1), 14..15), "b"@(FileId(1), 17..18), "c"@(FileId(1), 20..21), )
-"b"@(FileId(1), 17..18) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(3))] ( "a"@(FileId(1), 14..15), "b"@(FileId(1), 17..18), "c"@(FileId(1), 20..21), )
-"c"@(FileId(1), 20..21) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(3))] ( "a"@(FileId(1), 14..15), "b"@(FileId(1), 17..18), "c"@(FileId(1), 20..21), )
+"e"@(FileId(1), 5..6) [Type]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "a"@(FileId(1), 14..15), "b"@(FileId(1), 17..18), "c"@(FileId(1), 20..21), )
 "e"@(FileId(1), 9..22) [Enum]: <error>
-"e"@(FileId(1), 5..6) [Type]: enum[DefId(LibraryId(0), LocalDefId(3))] ( "a"@(FileId(1), 14..15), "b"@(FileId(1), 17..18), "c"@(FileId(1), 20..21), )
+"a"@(FileId(1), 14..15) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "a"@(FileId(1), 14..15), "b"@(FileId(1), 17..18), "c"@(FileId(1), 20..21), )
+"b"@(FileId(1), 17..18) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "a"@(FileId(1), 14..15), "b"@(FileId(1), 17..18), "c"@(FileId(1), 20..21), )
+"c"@(FileId(1), 20..21) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "a"@(FileId(1), 14..15), "b"@(FileId(1), 17..18), "c"@(FileId(1), 20..21), )
 "<root>"@(dummy) [Module(No)]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_enum_ty_from_var_decl.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_enum_ty_from_var_decl.snap
@@ -2,8 +2,8 @@
 source: compiler/toc_analysis/src/typeck/test.rs
 expression: "var _ : enum(nice)"
 ---
-"nice"@(FileId(1), 13..17) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "nice"@(FileId(1), 13..17), )
-"<anonymous>"@(FileId(1), 8..18) [Enum]: <error>
 "_"@(FileId(1), 4..5) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "nice"@(FileId(1), 13..17), )
+"<anonymous>"@(FileId(1), 8..18) [Enum]: <error>
+"nice"@(FileId(1), 13..17) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "nice"@(FileId(1), 13..17), )
 "<root>"@(dummy) [Module(No)]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_enum_ty_no_variants.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_enum_ty_no_variants.snap
@@ -2,7 +2,7 @@
 source: compiler/toc_analysis/src/typeck/test.rs
 expression: "type e : enum()"
 ---
+"e"@(FileId(1), 5..6) [Type]: enum[DefId(LibraryId(0), LocalDefId(1))] ( )
 "e"@(FileId(1), 9..15) [Enum]: <error>
-"e"@(FileId(1), 5..6) [Type]: enum[DefId(LibraryId(0), LocalDefId(0))] ( )
 "<root>"@(dummy) [Module(No)]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_for_implied_bounds_enum.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_for_implied_bounds_enum.snap
@@ -2,9 +2,9 @@
 source: compiler/toc_analysis/src/typeck/test.rs
 expression: "type b : enum(a) for _ : b end for"
 ---
-"a"@(FileId(1), 14..15) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "a"@(FileId(1), 14..15), )
-"b"@(FileId(1), 9..16) [Enum]: <error>
 "b"@(FileId(1), 5..6) [Type]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "a"@(FileId(1), 14..15), )
+"b"@(FileId(1), 9..16) [Enum]: <error>
+"a"@(FileId(1), 14..15) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "a"@(FileId(1), 14..15), )
 "_"@(FileId(1), 21..22) [ConstVar(Const, No)]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "a"@(FileId(1), 14..15), )
 "<root>"@(dummy) [Module(No)]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_for_normal_enum_bounds.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_for_normal_enum_bounds.snap
@@ -2,10 +2,10 @@
 source: compiler/toc_analysis/src/typeck/test.rs
 expression: "type e : enum(a, b, c) for : e.a .. e.c end for"
 ---
-"a"@(FileId(1), 14..15) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(3))] ( "a"@(FileId(1), 14..15), "b"@(FileId(1), 17..18), "c"@(FileId(1), 20..21), )
-"b"@(FileId(1), 17..18) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(3))] ( "a"@(FileId(1), 14..15), "b"@(FileId(1), 17..18), "c"@(FileId(1), 20..21), )
-"c"@(FileId(1), 20..21) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(3))] ( "a"@(FileId(1), 14..15), "b"@(FileId(1), 17..18), "c"@(FileId(1), 20..21), )
+"e"@(FileId(1), 5..6) [Type]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "a"@(FileId(1), 14..15), "b"@(FileId(1), 17..18), "c"@(FileId(1), 20..21), )
 "e"@(FileId(1), 9..22) [Enum]: <error>
-"e"@(FileId(1), 5..6) [Type]: enum[DefId(LibraryId(0), LocalDefId(3))] ( "a"@(FileId(1), 14..15), "b"@(FileId(1), 17..18), "c"@(FileId(1), 20..21), )
+"a"@(FileId(1), 14..15) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "a"@(FileId(1), 14..15), "b"@(FileId(1), 17..18), "c"@(FileId(1), 20..21), )
+"b"@(FileId(1), 17..18) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "a"@(FileId(1), 14..15), "b"@(FileId(1), 17..18), "c"@(FileId(1), 20..21), )
+"c"@(FileId(1), 20..21) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "a"@(FileId(1), 14..15), "b"@(FileId(1), 17..18), "c"@(FileId(1), 20..21), )
 "<root>"@(dummy) [Module(No)]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_get_stmt_invalid_opts_chars.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_get_stmt_invalid_opts_chars.snap
@@ -7,11 +7,11 @@ expression: "var i : int\nvar n : nat\nvar r : real\nvar c : char\nvar b: boolea
 "r"@(FileId(1), 28..29) [ConstVar(Var, No)]: real
 "c"@(FileId(1), 41..42) [ConstVar(Var, No)]: char
 "b"@(FileId(1), 54..55) [ConstVar(Var, No)]: boolean
-"a"@(FileId(1), 79..80) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(7))] ( "a"@(FileId(1), 79..80), "b"@(FileId(1), 82..83), )
-"b"@(FileId(1), 82..83) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(7))] ( "a"@(FileId(1), 79..80), "b"@(FileId(1), 82..83), )
+"en"@(FileId(1), 70..72) [Type]: enum[DefId(LibraryId(0), LocalDefId(6))] ( "a"@(FileId(1), 79..80), "b"@(FileId(1), 82..83), )
 "en"@(FileId(1), 74..84) [Enum]: <error>
-"en"@(FileId(1), 70..72) [Type]: enum[DefId(LibraryId(0), LocalDefId(7))] ( "a"@(FileId(1), 79..80), "b"@(FileId(1), 82..83), )
-"ef"@(FileId(1), 89..91) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(7))] ( "a"@(FileId(1), 79..80), "b"@(FileId(1), 82..83), )
+"a"@(FileId(1), 79..80) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(6))] ( "a"@(FileId(1), 79..80), "b"@(FileId(1), 82..83), )
+"b"@(FileId(1), 82..83) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(6))] ( "a"@(FileId(1), 79..80), "b"@(FileId(1), 82..83), )
+"ef"@(FileId(1), 89..91) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(6))] ( "a"@(FileId(1), 79..80), "b"@(FileId(1), 82..83), )
 "<root>"@(dummy) [Module(No)]: <error>
 
 error in file FileId(1) at 106..107: invalid get option

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_get_stmt_invalid_opts_lines.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_get_stmt_invalid_opts_lines.snap
@@ -8,11 +8,11 @@ expression: "var i : int\nvar n : nat\nvar r : real\nvar c : char\nvar b: boolea
 "c"@(FileId(1), 41..42) [ConstVar(Var, No)]: char
 "b"@(FileId(1), 54..55) [ConstVar(Var, No)]: boolean
 "cn"@(FileId(1), 69..71) [ConstVar(Var, No)]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
-"a"@(FileId(1), 96..97) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(8))] ( "a"@(FileId(1), 96..97), "b"@(FileId(1), 99..100), )
-"b"@(FileId(1), 99..100) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(8))] ( "a"@(FileId(1), 96..97), "b"@(FileId(1), 99..100), )
+"en"@(FileId(1), 87..89) [Type]: enum[DefId(LibraryId(0), LocalDefId(7))] ( "a"@(FileId(1), 96..97), "b"@(FileId(1), 99..100), )
 "en"@(FileId(1), 91..101) [Enum]: <error>
-"en"@(FileId(1), 87..89) [Type]: enum[DefId(LibraryId(0), LocalDefId(8))] ( "a"@(FileId(1), 96..97), "b"@(FileId(1), 99..100), )
-"ef"@(FileId(1), 106..108) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(8))] ( "a"@(FileId(1), 96..97), "b"@(FileId(1), 99..100), )
+"a"@(FileId(1), 96..97) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(7))] ( "a"@(FileId(1), 96..97), "b"@(FileId(1), 99..100), )
+"b"@(FileId(1), 99..100) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(7))] ( "a"@(FileId(1), 96..97), "b"@(FileId(1), 99..100), )
+"ef"@(FileId(1), 106..108) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(7))] ( "a"@(FileId(1), 96..97), "b"@(FileId(1), 99..100), )
 "<root>"@(dummy) [Module(No)]: <error>
 
 error in file FileId(1) at 119..120: invalid get option used

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_get_stmt_normal_items.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_get_stmt_normal_items.snap
@@ -10,10 +10,10 @@ expression: "var i : int\nvar n : nat\nvar r : real\nvar c : char\nvar b: boolea
 "cn"@(FileId(1), 69..71) [ConstVar(Var, No)]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
 "s"@(FileId(1), 86..87) [ConstVar(Var, No)]: string
 "sn"@(FileId(1), 101..103) [ConstVar(Var, No)]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
-"a"@(FileId(1), 130..131) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(10))] ( "a"@(FileId(1), 130..131), "b"@(FileId(1), 133..134), )
-"b"@(FileId(1), 133..134) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(10))] ( "a"@(FileId(1), 130..131), "b"@(FileId(1), 133..134), )
+"en"@(FileId(1), 121..123) [Type]: enum[DefId(LibraryId(0), LocalDefId(9))] ( "a"@(FileId(1), 130..131), "b"@(FileId(1), 133..134), )
 "en"@(FileId(1), 125..135) [Enum]: <error>
-"en"@(FileId(1), 121..123) [Type]: enum[DefId(LibraryId(0), LocalDefId(10))] ( "a"@(FileId(1), 130..131), "b"@(FileId(1), 133..134), )
-"ef"@(FileId(1), 140..142) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(10))] ( "a"@(FileId(1), 130..131), "b"@(FileId(1), 133..134), )
+"a"@(FileId(1), 130..131) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(9))] ( "a"@(FileId(1), 130..131), "b"@(FileId(1), 133..134), )
+"b"@(FileId(1), 133..134) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(9))] ( "a"@(FileId(1), 130..131), "b"@(FileId(1), 133..134), )
+"ef"@(FileId(1), 140..142) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(9))] ( "a"@(FileId(1), 130..131), "b"@(FileId(1), 133..134), )
 "<root>"@(dummy) [Module(No)]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_module_field_chained.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_module_field_chained.snap
@@ -6,9 +6,9 @@ expression: "module a export b module b export c module c export d\n    var d : 
 "b"@(FileId(1), 25..26) [Module(No)]: <error>
 "c"@(FileId(1), 43..44) [Module(No)]: <error>
 "d"@(FileId(1), 62..63) [ConstVar(Var, No)]: int
+"k"@(FileId(1), 92..93) [ConstVar(Var, No)]: int
 "d"@(FileId(1), 52..53) [Export]: int
 "c"@(FileId(1), 34..35) [Export]: <error>
 "b"@(FileId(1), 16..17) [Export]: <error>
-"k"@(FileId(1), 92..93) [ConstVar(Var, No)]: int
 "<root>"@(dummy) [Module(No)]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_module_field_normal.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_module_field_normal.snap
@@ -4,7 +4,7 @@ expression: "module a\n    export b\n    var b : int\nend a\nvar c := a.b"
 ---
 "a"@(FileId(1), 7..8) [Module(No)]: <error>
 "b"@(FileId(1), 30..31) [ConstVar(Var, No)]: int
-"b"@(FileId(1), 20..21) [Export]: int
 "c"@(FileId(1), 48..49) [ConstVar(Var, No)]: int
+"b"@(FileId(1), 20..21) [Export]: int
 "<root>"@(dummy) [Module(No)]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_module_field_not_exported.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_module_field_not_exported.snap
@@ -4,8 +4,8 @@ expression: "module a export b var b : int end a\nvar k := a.c\n"
 ---
 "a"@(FileId(1), 7..8) [Module(No)]: <error>
 "b"@(FileId(1), 22..23) [ConstVar(Var, No)]: int
-"b"@(FileId(1), 16..17) [Export]: int
 "k"@(FileId(1), 40..41) [ConstVar(Var, No)]: <error>
+"b"@(FileId(1), 16..17) [Export]: int
 "<root>"@(dummy) [Module(No)]: <error>
 
 error in file FileId(1) at 47..48: no field named `c` in expression

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_opaque_alias_of_enum.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_opaque_alias_of_enum.snap
@@ -4,15 +4,15 @@ expression: "var *_ : boolean\n\nmodule m\n    export opaque e, var a\n    type 
 ---
 "_"@(FileId(1), 5..6) [ConstVar(Var, No)]: boolean
 "m"@(FileId(1), 25..26) [Module(No)]: <error>
-"a"@(FileId(1), 72..73) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(3))] ( "a"@(FileId(1), 72..73), )
+"e"@(FileId(1), 63..64) [Type]: opaque[DefId(LibraryId(0), LocalDefId(2))] type to enum[DefId(LibraryId(0), LocalDefId(3))] ( "a"@(FileId(1), 72..73), )
 "e"@(FileId(1), 67..74) [Enum]: <error>
-"e"@(FileId(1), 63..64) [Type]: opaque[DefId(LibraryId(0), LocalDefId(4))] type to enum[DefId(LibraryId(0), LocalDefId(3))] ( "a"@(FileId(1), 72..73), )
-"a"@(FileId(1), 83..84) [ConstVar(Var, No)]: opaque[DefId(LibraryId(0), LocalDefId(4))] type to enum[DefId(LibraryId(0), LocalDefId(3))] ( "a"@(FileId(1), 72..73), )
+"a"@(FileId(1), 72..73) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(3))] ( "a"@(FileId(1), 72..73), )
+"a"@(FileId(1), 83..84) [ConstVar(Var, No)]: opaque[DefId(LibraryId(0), LocalDefId(2))] type to enum[DefId(LibraryId(0), LocalDefId(3))] ( "a"@(FileId(1), 72..73), )
 "not_ty"@(FileId(1), 167..173) [Type]: alias[DefId(LibraryId(0), LocalDefId(6))] of <error>
-"e"@(FileId(1), 45..46) [Export]: opaque[DefId(LibraryId(0), LocalDefId(4))] type to enum[DefId(LibraryId(0), LocalDefId(3))] ( "a"@(FileId(1), 72..73), )
-"a"@(FileId(1), 52..53) [Export]: opaque[DefId(LibraryId(0), LocalDefId(4))] type to enum[DefId(LibraryId(0), LocalDefId(3))] ( "a"@(FileId(1), 72..73), )
-"u"@(FileId(1), 191..192) [ConstVar(Var, No)]: opaque[DefId(LibraryId(0), LocalDefId(4))] type to enum[DefId(LibraryId(0), LocalDefId(3))] ( "a"@(FileId(1), 72..73), )
-"no_field"@(FileId(1), 228..236) [Type]: alias[DefId(LibraryId(0), LocalDefId(10))] of <error>
+"u"@(FileId(1), 191..192) [ConstVar(Var, No)]: opaque[DefId(LibraryId(0), LocalDefId(2))] type to enum[DefId(LibraryId(0), LocalDefId(3))] ( "a"@(FileId(1), 72..73), )
+"no_field"@(FileId(1), 228..236) [Type]: alias[DefId(LibraryId(0), LocalDefId(8))] of <error>
+"e"@(FileId(1), 45..46) [Export]: opaque[DefId(LibraryId(0), LocalDefId(2))] type to enum[DefId(LibraryId(0), LocalDefId(3))] ( "a"@(FileId(1), 72..73), )
+"a"@(FileId(1), 52..53) [Export]: opaque[DefId(LibraryId(0), LocalDefId(2))] type to enum[DefId(LibraryId(0), LocalDefId(3))] ( "a"@(FileId(1), 72..73), )
 "<root>"@(dummy) [Module(No)]: <error>
 
 error in file FileId(1) at 178..179: cannot use `a` as a type alias

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_opaque_alias_of_set.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_opaque_alias_of_set.snap
@@ -4,12 +4,12 @@ expression: "var *_ : boolean\n\nmodule m\n    export opaque s, var a\n    type 
 ---
 "_"@(FileId(1), 5..6) [ConstVar(Var, No)]: boolean
 "m"@(FileId(1), 25..26) [Module(No)]: <error>
+"s"@(FileId(1), 63..64) [Type]: opaque[DefId(LibraryId(0), LocalDefId(2))] type to set[DefId(LibraryId(0), LocalDefId(3))] of boolean
 "s"@(FileId(1), 67..81) [Set]: <error>
-"s"@(FileId(1), 63..64) [Type]: opaque[DefId(LibraryId(0), LocalDefId(3))] type to set[DefId(LibraryId(0), LocalDefId(2))] of boolean
-"a"@(FileId(1), 90..91) [ConstVar(Var, No)]: opaque[DefId(LibraryId(0), LocalDefId(3))] type to set[DefId(LibraryId(0), LocalDefId(2))] of boolean
-"s"@(FileId(1), 45..46) [Export]: opaque[DefId(LibraryId(0), LocalDefId(3))] type to set[DefId(LibraryId(0), LocalDefId(2))] of boolean
-"a"@(FileId(1), 52..53) [Export]: opaque[DefId(LibraryId(0), LocalDefId(3))] type to set[DefId(LibraryId(0), LocalDefId(2))] of boolean
+"a"@(FileId(1), 90..91) [ConstVar(Var, No)]: opaque[DefId(LibraryId(0), LocalDefId(2))] type to set[DefId(LibraryId(0), LocalDefId(3))] of boolean
 "vs"@(FileId(1), 147..149) [ConstVar(Var, No)]: <error>
+"s"@(FileId(1), 45..46) [Export]: opaque[DefId(LibraryId(0), LocalDefId(2))] type to set[DefId(LibraryId(0), LocalDefId(3))] of boolean
+"a"@(FileId(1), 52..53) [Export]: opaque[DefId(LibraryId(0), LocalDefId(2))] type to set[DefId(LibraryId(0), LocalDefId(3))] of boolean
 "<root>"@(dummy) [Module(No)]: <error>
 
 error in file FileId(1) at 153..156: cannot call or subscript `s`

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_opaque_ty_outside_module.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_opaque_ty_outside_module.snap
@@ -5,11 +5,11 @@ expression: "module k\n    export opaque ~.* t, f\n\n    type t : int\n\n    fcn
 "k"@(FileId(1), 7..8) [Module(No)]: <error>
 "t"@(FileId(1), 46..47) [Type]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
 "f"@(FileId(1), 63..64) [Subprogram(Function)]: function ( ) -> opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
-"<unnamed>"@(dummy) [Undeclared]: <error>
-"t"@(FileId(1), 31..32) [Export]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
-"f"@(FileId(1), 34..35) [Export]: function ( ) -> opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
 "a"@(FileId(1), 102..103) [ConstVar(Var, No)]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
 "b"@(FileId(1), 112..113) [ConstVar(Var, No)]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
 "c"@(FileId(1), 127..128) [ConstVar(Var, No)]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
+"<unnamed>"@(dummy) [Undeclared]: <error>
+"t"@(FileId(1), 31..32) [Export]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
+"f"@(FileId(1), 34..35) [Export]: function ( ) -> opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
 "<root>"@(dummy) [Module(No)]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_opaque_ty_poke_opaque_call_no_parens.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_opaque_ty_poke_opaque_call_no_parens.snap
@@ -6,9 +6,9 @@ expression: "module m\n    export opaque t, f\n    type t : int\n    fcn f : t l
 "t"@(FileId(1), 41..42) [Type]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
 "f"@(FileId(1), 57..58) [Subprogram(Function)]: function -> opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
 "a"@(FileId(1), 92..93) [ConstVar(Var, No)]: int
+"b"@(FileId(1), 130..131) [ConstVar(Var, No)]: int
 "t"@(FileId(1), 27..28) [Export]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
 "f"@(FileId(1), 30..31) [Export]: function -> opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
-"b"@(FileId(1), 130..131) [ConstVar(Var, No)]: int
 "<root>"@(dummy) [Module(No)]: <error>
 
 error in file FileId(1) at 141..144: mismatched types

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_opaque_ty_poke_opaque_call_param.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_opaque_ty_poke_opaque_call_param.snap
@@ -5,13 +5,13 @@ expression: "module m\n    export opaque t, a, p\n    type t : int\n    proc p(a
 "m"@(FileId(1), 7..8) [Module(No)]: <error>
 "t"@(FileId(1), 44..45) [Type]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
 "p"@(FileId(1), 61..62) [Subprogram(Procedure)]: procedure ( pass(value) opaque[DefId(LibraryId(0), LocalDefId(1))] type to int, ) -> void
-"<unnamed>"@(dummy) [Undeclared]: <error>
 "a"@(FileId(1), 63..64) [Param(Value, No)]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
 "a"@(FileId(1), 84..85) [ConstVar(Var, No)]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
+"a"@(FileId(1), 168..169) [ConstVar(Var, No)]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "t"@(FileId(1), 27..28) [Export]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
 "a"@(FileId(1), 30..31) [Export]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
 "p"@(FileId(1), 33..34) [Export]: procedure ( pass(value) opaque[DefId(LibraryId(0), LocalDefId(1))] type to int, ) -> void
-"a"@(FileId(1), 168..169) [ConstVar(Var, No)]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
 "<root>"@(dummy) [Module(No)]: <error>
 
 error in file FileId(1) at 208..209: mismatched types

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_opaque_ty_poke_opaque_call_parens.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_opaque_ty_poke_opaque_call_parens.snap
@@ -5,11 +5,11 @@ expression: "module m\n    export opaque t, f\n    type t : int\n    fcn f() : t
 "m"@(FileId(1), 7..8) [Module(No)]: <error>
 "t"@(FileId(1), 41..42) [Type]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
 "f"@(FileId(1), 57..58) [Subprogram(Function)]: function ( ) -> opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
-"<unnamed>"@(dummy) [Undeclared]: <error>
 "a"@(FileId(1), 94..95) [ConstVar(Var, No)]: int
+"b"@(FileId(1), 134..135) [ConstVar(Var, No)]: int
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "t"@(FileId(1), 27..28) [Export]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
 "f"@(FileId(1), 30..31) [Export]: function ( ) -> opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
-"b"@(FileId(1), 134..135) [ConstVar(Var, No)]: int
 "<root>"@(dummy) [Module(No)]: <error>
 
 error in file FileId(1) at 145..150: mismatched types

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_opaque_ty_poke_opaque_constvar.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_opaque_ty_poke_opaque_constvar.snap
@@ -5,9 +5,9 @@ expression: "module m\n    export opaque t, ~.* a\n    type t : char\n\n    var 
 "m"@(FileId(1), 7..8) [Module(No)]: <error>
 "t"@(FileId(1), 45..46) [Type]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
 "a"@(FileId(1), 63..64) [ConstVar(Var, No)]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
+"b"@(FileId(1), 121..122) [ConstVar(Var, No)]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
 "t"@(FileId(1), 27..28) [Export]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
 "a"@(FileId(1), 34..35) [Export]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
-"b"@(FileId(1), 121..122) [ConstVar(Var, No)]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
 "<root>"@(dummy) [Module(No)]: <error>
 
 error in file FileId(1) at 130..132: mismatched types

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_opaque_ty_poke_opaque_deref.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_opaque_ty_poke_opaque_deref.snap
@@ -6,10 +6,10 @@ expression: "module m\n    export opaque t, a\n    type t : int\n    var a : ^t\
 "t"@(FileId(1), 41..42) [Type]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
 "a"@(FileId(1), 57..58) [ConstVar(Var, No)]: pointer to opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
 "b"@(FileId(1), 72..73) [ConstVar(Var, No)]: int
-"t"@(FileId(1), 27..28) [Export]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
-"a"@(FileId(1), 30..31) [Export]: pointer to opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
 "b"@(FileId(1), 97..98) [ConstVar(Var, No)]: pointer to opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
 "c"@(FileId(1), 124..125) [ConstVar(Var, No)]: int
+"t"@(FileId(1), 27..28) [Export]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
+"a"@(FileId(1), 30..31) [Export]: pointer to opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
 "<root>"@(dummy) [Module(No)]: <error>
 
 error in file FileId(1) at 135..137: mismatched types

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_opaque_ty_poke_opaque_field.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_opaque_ty_poke_opaque_field.snap
@@ -6,9 +6,9 @@ expression: "module m\n    export opaque t, var a, b\n    type t : int\n\n    va
 "t"@(FileId(1), 48..49) [Type]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
 "a"@(FileId(1), 65..66) [ConstVar(Var, No)]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
 "b"@(FileId(1), 92..93) [ConstVar(Var, No)]: alias[DefId(LibraryId(0), LocalDefId(1))] of int
+"c"@(FileId(1), 153..154) [ConstVar(Var, No)]: int
 "t"@(FileId(1), 27..28) [Export]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
 "a"@(FileId(1), 34..35) [Export]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
 "b"@(FileId(1), 37..38) [Export]: alias[DefId(LibraryId(0), LocalDefId(1))] of int
-"c"@(FileId(1), 153..154) [ConstVar(Var, No)]: int
 "<root>"@(dummy) [Module(No)]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_opaque_ty_poke_opaque_for_bounds_explicit.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_opaque_ty_poke_opaque_for_bounds_explicit.snap
@@ -6,9 +6,9 @@ expression: "module m\n    export opaque t, v\n    type t : int\n    var v : t\n
 "t"@(FileId(1), 41..42) [Type]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
 "v"@(FileId(1), 57..58) [ConstVar(Var, No)]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
 "_"@(FileId(1), 71..72) [ConstVar(Const, No)]: alias[DefId(LibraryId(0), LocalDefId(1))] of int
+"_"@(FileId(1), 101..102) [ConstVar(Const, No)]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
 "t"@(FileId(1), 27..28) [Export]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
 "v"@(FileId(1), 30..31) [Export]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
-"_"@(FileId(1), 101..102) [ConstVar(Const, No)]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
 "<root>"@(dummy) [Module(No)]: <error>
 
 error in file FileId(1) at 105..115: mismatched types

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_opaque_ty_poke_opaque_for_bounds_implicit.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_opaque_ty_poke_opaque_for_bounds_implicit.snap
@@ -5,8 +5,8 @@ expression: "module m\n    export opaque t\n    type t : 1 .. 2\n    for _ : t e
 "m"@(FileId(1), 7..8) [Module(No)]: <error>
 "t"@(FileId(1), 38..39) [Type]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No))
 "_"@(FileId(1), 57..58) [ConstVar(Const, No)]: alias[DefId(LibraryId(0), LocalDefId(1))] of range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No))
-"t"@(FileId(1), 27..28) [Export]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No))
 "_"@(FileId(1), 82..83) [ConstVar(Const, No)]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No))
+"t"@(FileId(1), 27..28) [Export]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to range of `int` (Unevaluated(LibraryId(0), BodyId(0)) .. Expr(Unevaluated(LibraryId(0), BodyId(1)), No))
 "<root>"@(dummy) [Module(No)]: <error>
 
 error in file FileId(1) at 86..89: mismatched types

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_opaque_ty_poke_opaque_name.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_opaque_ty_poke_opaque_name.snap
@@ -6,9 +6,9 @@ expression: "module m\n    export opaque t, a, ~.* b\n    type t : int\n\n    va
 "t"@(FileId(1), 48..49) [Type]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
 "a"@(FileId(1), 65..66) [ConstVar(Var, No)]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
 "b"@(FileId(1), 79..80) [ConstVar(Var, No)]: alias[DefId(LibraryId(0), LocalDefId(1))] of int
+"c"@(FileId(1), 149..150) [ConstVar(Var, No)]: int
 "t"@(FileId(1), 27..28) [Export]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
 "a"@(FileId(1), 30..31) [Export]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
 "b"@(FileId(1), 37..38) [Export]: alias[DefId(LibraryId(0), LocalDefId(1))] of int
-"c"@(FileId(1), 149..150) [ConstVar(Var, No)]: int
 "<root>"@(dummy) [Module(No)]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_opaque_ty_poke_opaque_result.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_opaque_ty_poke_opaque_result.snap
@@ -5,9 +5,9 @@ expression: "module m\n    export opaque ~.* t\n    type t : int\n\n    % should
 "m"@(FileId(1), 7..8) [Module(No)]: <error>
 "t"@(FileId(1), 42..43) [Type]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
 "f"@(FileId(1), 86..87) [Subprogram(Function)]: function ( ) -> opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
+"k"@(FileId(1), 134..135) [Subprogram(Function)]: function ( ) -> opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
 "<unnamed>"@(dummy) [Undeclared]: <error>
 "t"@(FileId(1), 31..32) [Export]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
-"k"@(FileId(1), 134..135) [Subprogram(Function)]: function ( ) -> opaque[DefId(LibraryId(0), LocalDefId(1))] type to int
 "<unnamed>"@(dummy) [Undeclared]: <error>
 "<root>"@(dummy) [Module(No)]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_opaque_ty_poke_opaque_set_cons_param.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_opaque_ty_poke_opaque_set_cons_param.snap
@@ -4,16 +4,16 @@ expression: "module m\n    export opaque t, ~.* s, make\n    type t : char\n    
 ---
 "m"@(FileId(1), 7..8) [Module(No)]: <error>
 "t"@(FileId(1), 51..52) [Type]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
+"s"@(FileId(1), 69..70) [Type]: set[DefId(LibraryId(0), LocalDefId(3))] of opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
 "s"@(FileId(1), 73..81) [Set]: <error>
-"s"@(FileId(1), 69..70) [Type]: set[DefId(LibraryId(0), LocalDefId(2))] of opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
 "make"@(FileId(1), 91..95) [Subprogram(Function)]: function ( pass(value) char, ) -> opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
-"<unnamed>"@(dummy) [Undeclared]: <error>
 "c"@(FileId(1), 96..97) [Param(Value, No)]: char
-"a"@(FileId(1), 173..174) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(2))] of opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
+"a"@(FileId(1), 173..174) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(3))] of opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
+"vs"@(FileId(1), 241..243) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(3))] of opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "t"@(FileId(1), 27..28) [Export]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
-"s"@(FileId(1), 34..35) [Export]: set[DefId(LibraryId(0), LocalDefId(2))] of opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
+"s"@(FileId(1), 34..35) [Export]: set[DefId(LibraryId(0), LocalDefId(3))] of opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
 "make"@(FileId(1), 37..41) [Export]: function ( pass(value) char, ) -> opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
-"vs"@(FileId(1), 241..243) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(2))] of opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
 "<root>"@(dummy) [Module(No)]: <error>
 
 error in file FileId(1) at 253..256: mismatched types

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_opaque_ty_poke_opaque_set_elem_ty.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_opaque_ty_poke_opaque_set_elem_ty.snap
@@ -4,18 +4,18 @@ expression: "module m\n    export opaque ~.* t, ~.* s, make\n    type t : char\n
 ---
 "m"@(FileId(1), 7..8) [Module(No)]: <error>
 "t"@(FileId(1), 55..56) [Type]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
+"s"@(FileId(1), 73..74) [Type]: set[DefId(LibraryId(0), LocalDefId(3))] of opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
 "s"@(FileId(1), 77..85) [Set]: <error>
-"s"@(FileId(1), 73..74) [Type]: set[DefId(LibraryId(0), LocalDefId(2))] of opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
 "make"@(FileId(1), 94..98) [Subprogram(Function)]: function ( pass(value) char, ) -> opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
-"<unnamed>"@(dummy) [Undeclared]: <error>
 "c"@(FileId(1), 99..100) [Param(Value, No)]: char
-"t"@(FileId(1), 31..32) [Export]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
-"s"@(FileId(1), 38..39) [Export]: set[DefId(LibraryId(0), LocalDefId(2))] of opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
-"make"@(FileId(1), 41..45) [Export]: function ( pass(value) char, ) -> opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
+"xs"@(FileId(1), 182..184) [Type]: set[DefId(LibraryId(0), LocalDefId(7))] of opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
 "xs"@(FileId(1), 187..195) [Set]: <error>
-"xs"@(FileId(1), 182..184) [Type]: set[DefId(LibraryId(0), LocalDefId(10))] of opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
-"vs"@(FileId(1), 200..202) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(2))] of opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
+"vs"@(FileId(1), 200..202) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(3))] of opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
 "_"@(FileId(1), 239..240) [ConstVar(Var, No)]: boolean
+"<unnamed>"@(dummy) [Undeclared]: <error>
+"t"@(FileId(1), 31..32) [Export]: opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
+"s"@(FileId(1), 38..39) [Export]: set[DefId(LibraryId(0), LocalDefId(3))] of opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
+"make"@(FileId(1), 41..45) [Export]: function ( pass(value) char, ) -> opaque[DefId(LibraryId(0), LocalDefId(1))] type to char
 "<root>"@(dummy) [Module(No)]: <error>
 
 error in file FileId(1) at 194..195: mismatched types

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_put_stmt_invalid_extended_opts.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_put_stmt_invalid_extended_opts.snap
@@ -6,11 +6,11 @@ expression: "var c : char\nvar cn : char(4)\nvar s : string\nvar sn : string(4)\
 "cn"@(FileId(1), 17..19) [ConstVar(Var, No)]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
 "s"@(FileId(1), 34..35) [ConstVar(Var, No)]: string
 "sn"@(FileId(1), 49..51) [ConstVar(Var, No)]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
-"a"@(FileId(1), 78..79) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(6))] ( "a"@(FileId(1), 78..79), "b"@(FileId(1), 81..82), )
-"b"@(FileId(1), 81..82) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(6))] ( "a"@(FileId(1), 78..79), "b"@(FileId(1), 81..82), )
+"en"@(FileId(1), 69..71) [Type]: enum[DefId(LibraryId(0), LocalDefId(5))] ( "a"@(FileId(1), 78..79), "b"@(FileId(1), 81..82), )
 "en"@(FileId(1), 73..83) [Enum]: <error>
-"en"@(FileId(1), 69..71) [Type]: enum[DefId(LibraryId(0), LocalDefId(6))] ( "a"@(FileId(1), 78..79), "b"@(FileId(1), 81..82), )
-"ef"@(FileId(1), 88..90) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(6))] ( "a"@(FileId(1), 78..79), "b"@(FileId(1), 81..82), )
+"a"@(FileId(1), 78..79) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(5))] ( "a"@(FileId(1), 78..79), "b"@(FileId(1), 81..82), )
+"b"@(FileId(1), 81..82) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(5))] ( "a"@(FileId(1), 78..79), "b"@(FileId(1), 81..82), )
+"ef"@(FileId(1), 88..90) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(5))] ( "a"@(FileId(1), 78..79), "b"@(FileId(1), 81..82), )
 "<root>"@(dummy) [Module(No)]: <error>
 
 error in file FileId(1) at 109..110: invalid put option

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_put_stmt_normal_items.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_put_stmt_normal_items.snap
@@ -9,10 +9,10 @@ expression: "var i : int\nvar n : nat\nvar r : real\nvar c : char\nvar cn : char
 "cn"@(FileId(1), 54..56) [ConstVar(Var, No)]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(0)))
 "s"@(FileId(1), 71..72) [ConstVar(Var, No)]: string
 "sn"@(FileId(1), 86..88) [ConstVar(Var, No)]: string_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
-"a"@(FileId(1), 115..116) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(9))] ( "a"@(FileId(1), 115..116), "b"@(FileId(1), 118..119), )
-"b"@(FileId(1), 118..119) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(9))] ( "a"@(FileId(1), 115..116), "b"@(FileId(1), 118..119), )
+"en"@(FileId(1), 106..108) [Type]: enum[DefId(LibraryId(0), LocalDefId(8))] ( "a"@(FileId(1), 115..116), "b"@(FileId(1), 118..119), )
 "en"@(FileId(1), 110..120) [Enum]: <error>
-"en"@(FileId(1), 106..108) [Type]: enum[DefId(LibraryId(0), LocalDefId(9))] ( "a"@(FileId(1), 115..116), "b"@(FileId(1), 118..119), )
-"ef"@(FileId(1), 125..127) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(9))] ( "a"@(FileId(1), 115..116), "b"@(FileId(1), 118..119), )
+"a"@(FileId(1), 115..116) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(8))] ( "a"@(FileId(1), 115..116), "b"@(FileId(1), 118..119), )
+"b"@(FileId(1), 118..119) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(8))] ( "a"@(FileId(1), 115..116), "b"@(FileId(1), 118..119), )
+"ef"@(FileId(1), 125..127) [ConstVar(Var, No)]: enum[DefId(LibraryId(0), LocalDefId(8))] ( "a"@(FileId(1), 115..116), "b"@(FileId(1), 118..119), )
 "<root>"@(dummy) [Module(No)]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_cons_call_all.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_cons_call_all.snap
@@ -2,8 +2,8 @@
 source: compiler/toc_analysis/src/typeck/test.rs
 expression: "type s : set of boolean\nvar _ := s(all)\n"
 ---
+"s"@(FileId(1), 5..6) [Type]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
 "s"@(FileId(1), 9..23) [Set]: <error>
-"s"@(FileId(1), 5..6) [Type]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
-"_"@(FileId(1), 28..29) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
+"_"@(FileId(1), 28..29) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
 "<root>"@(dummy) [Module(No)]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_cons_call_all_err_extra_arg_end_range.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_cons_call_all_err_extra_arg_end_range.snap
@@ -2,9 +2,9 @@
 source: compiler/toc_analysis/src/typeck/test.rs
 expression: "type s : set of boolean\nvar _ := s(*, all, b .. * - b)\n"
 ---
+"s"@(FileId(1), 5..6) [Type]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
 "s"@(FileId(1), 9..23) [Set]: <error>
-"s"@(FileId(1), 5..6) [Type]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
-"_"@(FileId(1), 28..29) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
+"_"@(FileId(1), 28..29) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
 "<root>"@(dummy) [Module(No)]: <error>
 
 error in file FileId(1) at 33..34: constructor call has extra arguments

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_cons_call_all_err_extra_args_after.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_cons_call_all_err_extra_args_after.snap
@@ -2,10 +2,10 @@
 source: compiler/toc_analysis/src/typeck/test.rs
 expression: "type s : set of boolean\nvar b : boolean\nvar _ := s(all, b, b, b, b)\n"
 ---
+"s"@(FileId(1), 5..6) [Type]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
 "s"@(FileId(1), 9..23) [Set]: <error>
-"s"@(FileId(1), 5..6) [Type]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
 "b"@(FileId(1), 28..29) [ConstVar(Var, No)]: boolean
-"_"@(FileId(1), 44..45) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
+"_"@(FileId(1), 44..45) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
 "<root>"@(dummy) [Module(No)]: <error>
 
 error in file FileId(1) at 49..50: constructor call has extra arguments

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_cons_call_all_err_extra_args_before.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_cons_call_all_err_extra_args_before.snap
@@ -2,10 +2,10 @@
 source: compiler/toc_analysis/src/typeck/test.rs
 expression: "type s : set of boolean\nvar b : boolean\nvar _ := s(b, b, b, b, all)\n"
 ---
+"s"@(FileId(1), 5..6) [Type]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
 "s"@(FileId(1), 9..23) [Set]: <error>
-"s"@(FileId(1), 5..6) [Type]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
 "b"@(FileId(1), 28..29) [ConstVar(Var, No)]: boolean
-"_"@(FileId(1), 44..45) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
+"_"@(FileId(1), 44..45) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
 "<root>"@(dummy) [Module(No)]: <error>
 
 error in file FileId(1) at 49..50: constructor call has extra arguments

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_cons_call_all_err_extra_args_between.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_cons_call_all_err_extra_args_between.snap
@@ -2,10 +2,10 @@
 source: compiler/toc_analysis/src/typeck/test.rs
 expression: "type s : set of boolean\nvar b : boolean\nvar _ := s(b, b, all, b, b)\n"
 ---
+"s"@(FileId(1), 5..6) [Type]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
 "s"@(FileId(1), 9..23) [Set]: <error>
-"s"@(FileId(1), 5..6) [Type]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
 "b"@(FileId(1), 28..29) [ConstVar(Var, No)]: boolean
-"_"@(FileId(1), 44..45) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
+"_"@(FileId(1), 44..45) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
 "<root>"@(dummy) [Module(No)]: <error>
 
 error in file FileId(1) at 49..50: constructor call has extra arguments

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_cons_call_all_err_extra_args_range.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_cons_call_all_err_extra_args_range.snap
@@ -2,10 +2,10 @@
 source: compiler/toc_analysis/src/typeck/test.rs
 expression: "type s : set of boolean\nvar b : boolean\nvar _ := s(1 .. 2, all, 3 .. 4)\n"
 ---
+"s"@(FileId(1), 5..6) [Type]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
 "s"@(FileId(1), 9..23) [Set]: <error>
-"s"@(FileId(1), 5..6) [Type]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
 "b"@(FileId(1), 28..29) [ConstVar(Var, No)]: boolean
-"_"@(FileId(1), 44..45) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
+"_"@(FileId(1), 44..45) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
 "<root>"@(dummy) [Module(No)]: <error>
 
 error in file FileId(1) at 49..50: constructor call has extra arguments

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_cons_call_all_err_wrong_binding.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_cons_call_all_err_wrong_binding.snap
@@ -2,10 +2,10 @@
 source: compiler/toc_analysis/src/typeck/test.rs
 expression: "type s : set of boolean\ntype b : boolean\nvar _ := s(all, b)\n"
 ---
+"s"@(FileId(1), 5..6) [Type]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
 "s"@(FileId(1), 9..23) [Set]: <error>
-"s"@(FileId(1), 5..6) [Type]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
 "b"@(FileId(1), 29..30) [Type]: alias[DefId(LibraryId(0), LocalDefId(2))] of boolean
-"_"@(FileId(1), 45..46) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
+"_"@(FileId(1), 45..46) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
 "<root>"@(dummy) [Module(No)]: <error>
 
 error in file FileId(1) at 50..51: constructor call has extra arguments

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_cons_call_all_err_wrong_ty.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_cons_call_all_err_wrong_ty.snap
@@ -2,9 +2,9 @@
 source: compiler/toc_analysis/src/typeck/test.rs
 expression: "type s : set of boolean\nvar _ := s(all, 1)\n"
 ---
+"s"@(FileId(1), 5..6) [Type]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
 "s"@(FileId(1), 9..23) [Set]: <error>
-"s"@(FileId(1), 5..6) [Type]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
-"_"@(FileId(1), 28..29) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
+"_"@(FileId(1), 28..29) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
 "<root>"@(dummy) [Module(No)]: <error>
 
 error in file FileId(1) at 33..34: constructor call has extra arguments

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_cons_call_args_err_not_from_ty.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_cons_call_args_err_not_from_ty.snap
@@ -2,9 +2,9 @@
 source: compiler/toc_analysis/src/typeck/test.rs
 expression: "type s : set of boolean\nvar k : s\nk := k()\n"
 ---
+"s"@(FileId(1), 5..6) [Type]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
 "s"@(FileId(1), 9..23) [Set]: <error>
-"s"@(FileId(1), 5..6) [Type]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
-"k"@(FileId(1), 28..29) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
+"k"@(FileId(1), 28..29) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
 "<root>"@(dummy) [Module(No)]: <error>
 
 error in file FileId(1) at 39..40: cannot call or subscript `k`

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_cons_call_args_err_wrong_binding.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_cons_call_args_err_wrong_binding.snap
@@ -2,10 +2,10 @@
 source: compiler/toc_analysis/src/typeck/test.rs
 expression: "type s : set of boolean\ntype b : boolean\nvar _ := s(b)\n"
 ---
+"s"@(FileId(1), 5..6) [Type]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
 "s"@(FileId(1), 9..23) [Set]: <error>
-"s"@(FileId(1), 5..6) [Type]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
 "b"@(FileId(1), 29..30) [Type]: alias[DefId(LibraryId(0), LocalDefId(2))] of boolean
-"_"@(FileId(1), 45..46) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
+"_"@(FileId(1), 45..46) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
 "<root>"@(dummy) [Module(No)]: <error>
 
 error in file FileId(1) at 52..53: cannot use `b` as an expression

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_cons_call_args_err_wrong_ty.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_cons_call_args_err_wrong_ty.snap
@@ -2,9 +2,9 @@
 source: compiler/toc_analysis/src/typeck/test.rs
 expression: "type s : set of boolean\nvar _ := s(1, 2, 3)\n"
 ---
+"s"@(FileId(1), 5..6) [Type]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
 "s"@(FileId(1), 9..23) [Set]: <error>
-"s"@(FileId(1), 5..6) [Type]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
-"_"@(FileId(1), 28..29) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
+"_"@(FileId(1), 28..29) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
 "<root>"@(dummy) [Module(No)]: <error>
 
 error in file FileId(1) at 35..36: mismatched types

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_cons_call_empty_set.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_cons_call_empty_set.snap
@@ -2,8 +2,8 @@
 source: compiler/toc_analysis/src/typeck/test.rs
 expression: "type s : set of boolean\nvar _ := s()\n"
 ---
+"s"@(FileId(1), 5..6) [Type]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
 "s"@(FileId(1), 9..23) [Set]: <error>
-"s"@(FileId(1), 5..6) [Type]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
-"_"@(FileId(1), 28..29) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
+"_"@(FileId(1), 28..29) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
 "<root>"@(dummy) [Module(No)]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_cons_call_err_as_stmt.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_cons_call_err_as_stmt.snap
@@ -2,8 +2,8 @@
 source: compiler/toc_analysis/src/typeck/test.rs
 expression: "type s : set of boolean\ns()\n"
 ---
+"s"@(FileId(1), 5..6) [Type]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
 "s"@(FileId(1), 9..23) [Set]: <error>
-"s"@(FileId(1), 5..6) [Type]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
 "<root>"@(dummy) [Module(No)]: <error>
 
 error in file FileId(1) at 24..25: cannot use expression as a statement

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_cons_call_err_just_itself.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_cons_call_err_just_itself.snap
@@ -2,9 +2,9 @@
 source: compiler/toc_analysis/src/typeck/test.rs
 expression: "type s : set of boolean\nvar _ := s\ns\n"
 ---
+"s"@(FileId(1), 5..6) [Type]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
 "s"@(FileId(1), 9..23) [Set]: <error>
-"s"@(FileId(1), 5..6) [Type]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
-"_"@(FileId(1), 28..29) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
+"_"@(FileId(1), 28..29) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
 "<root>"@(dummy) [Module(No)]: <error>
 
 error in file FileId(1) at 33..34: cannot use `s` as an expression

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_cons_call_normal.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_cons_call_normal.snap
@@ -2,8 +2,8 @@
 source: compiler/toc_analysis/src/typeck/test.rs
 expression: "type s : set of boolean\nvar _ := s(true, false, true, false)\n"
 ---
+"s"@(FileId(1), 5..6) [Type]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
 "s"@(FileId(1), 9..23) [Set]: <error>
-"s"@(FileId(1), 5..6) [Type]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
-"_"@(FileId(1), 28..29) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
+"_"@(FileId(1), 28..29) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
 "<root>"@(dummy) [Module(No)]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_ty_from_type_alias.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_ty_from_type_alias.snap
@@ -2,8 +2,8 @@
 source: compiler/toc_analysis/src/typeck/test.rs
 expression: "type s : set of boolean var _ : s"
 ---
+"s"@(FileId(1), 5..6) [Type]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
 "s"@(FileId(1), 9..23) [Set]: <error>
-"s"@(FileId(1), 5..6) [Type]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
-"_"@(FileId(1), 28..29) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
+"_"@(FileId(1), 28..29) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
 "<root>"@(dummy) [Module(No)]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_ty_from_var_decl.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_ty_from_var_decl.snap
@@ -2,7 +2,7 @@
 source: compiler/toc_analysis/src/typeck/test.rs
 expression: "var _ : set of boolean"
 ---
+"_"@(FileId(1), 4..5) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(1))] of boolean
 "<anonymous>"@(FileId(1), 8..22) [Set]: <error>
-"_"@(FileId(1), 4..5) [ConstVar(Var, No)]: set[DefId(LibraryId(0), LocalDefId(0))] of boolean
 "<root>"@(dummy) [Module(No)]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_ty_large_range_integer.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_ty_large_range_integer.snap
@@ -3,10 +3,10 @@ source: compiler/toc_analysis/src/typeck/test.rs
 expression: "type bogos : int\ntype _si : set of bogos\ntype _sn : set of nat\n"
 ---
 "bogos"@(FileId(1), 5..10) [Type]: alias[DefId(LibraryId(0), LocalDefId(0))] of int
+"_si"@(FileId(1), 22..25) [Type]: set[DefId(LibraryId(0), LocalDefId(2))] of alias[DefId(LibraryId(0), LocalDefId(0))] of int
 "_si"@(FileId(1), 28..40) [Set]: <error>
-"_si"@(FileId(1), 22..25) [Type]: set[DefId(LibraryId(0), LocalDefId(1))] of alias[DefId(LibraryId(0), LocalDefId(0))] of int
+"_sn"@(FileId(1), 46..49) [Type]: set[DefId(LibraryId(0), LocalDefId(4))] of nat
 "_sn"@(FileId(1), 52..62) [Set]: <error>
-"_sn"@(FileId(1), 46..49) [Type]: set[DefId(LibraryId(0), LocalDefId(3))] of nat
 "<root>"@(dummy) [Module(No)]: <error>
 
 error in file FileId(1) at 35..40: element range is too large

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_ty_not_index_ty.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_ty_not_index_ty.snap
@@ -2,8 +2,8 @@
 source: compiler/toc_analysis/src/typeck/test.rs
 expression: "type _ : set of real"
 ---
+"_"@(FileId(1), 5..6) [Type]: set[DefId(LibraryId(0), LocalDefId(1))] of real
 "_"@(FileId(1), 9..20) [Set]: <error>
-"_"@(FileId(1), 5..6) [Type]: set[DefId(LibraryId(0), LocalDefId(0))] of real
 "<root>"@(dummy) [Module(No)]: <error>
 
 error in file FileId(1) at 16..20: mismatched types

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_ty_valid_index_ty.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_set_ty_valid_index_ty.snap
@@ -3,16 +3,16 @@ source: compiler/toc_analysis/src/typeck/test.rs
 expression: "% FIXME: Add corresponding test for range types\ntype r : char\ntype e : enum(v)\ntype _a : set of r\ntype _b : set of boolean\ntype _c : set of char\ntype _d : set of e\n"
 ---
 "r"@(FileId(1), 53..54) [Type]: alias[DefId(LibraryId(0), LocalDefId(0))] of char
-"v"@(FileId(1), 76..77) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(2))] ( "v"@(FileId(1), 76..77), )
-"e"@(FileId(1), 71..78) [Enum]: <error>
 "e"@(FileId(1), 67..68) [Type]: enum[DefId(LibraryId(0), LocalDefId(2))] ( "v"@(FileId(1), 76..77), )
+"e"@(FileId(1), 71..78) [Enum]: <error>
+"v"@(FileId(1), 76..77) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(2))] ( "v"@(FileId(1), 76..77), )
+"_a"@(FileId(1), 84..86) [Type]: set[DefId(LibraryId(0), LocalDefId(5))] of alias[DefId(LibraryId(0), LocalDefId(0))] of char
 "_a"@(FileId(1), 89..97) [Set]: <error>
-"_a"@(FileId(1), 84..86) [Type]: set[DefId(LibraryId(0), LocalDefId(4))] of alias[DefId(LibraryId(0), LocalDefId(0))] of char
+"_b"@(FileId(1), 103..105) [Type]: set[DefId(LibraryId(0), LocalDefId(7))] of boolean
 "_b"@(FileId(1), 108..122) [Set]: <error>
-"_b"@(FileId(1), 103..105) [Type]: set[DefId(LibraryId(0), LocalDefId(6))] of boolean
+"_c"@(FileId(1), 128..130) [Type]: set[DefId(LibraryId(0), LocalDefId(9))] of char
 "_c"@(FileId(1), 133..144) [Set]: <error>
-"_c"@(FileId(1), 128..130) [Type]: set[DefId(LibraryId(0), LocalDefId(8))] of char
+"_d"@(FileId(1), 150..152) [Type]: set[DefId(LibraryId(0), LocalDefId(11))] of enum[DefId(LibraryId(0), LocalDefId(2))] ( "v"@(FileId(1), 76..77), )
 "_d"@(FileId(1), 155..163) [Set]: <error>
-"_d"@(FileId(1), 150..152) [Type]: set[DefId(LibraryId(0), LocalDefId(10))] of enum[DefId(LibraryId(0), LocalDefId(2))] ( "v"@(FileId(1), 76..77), )
 "<root>"@(dummy) [Module(No)]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_args_err_cheat_ty.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_args_err_cheat_ty.snap
@@ -4,9 +4,9 @@ expression: "var tree : string\nprocedure boop(a, b : cheat int, var c : cheat i
 ---
 "tree"@(FileId(1), 4..8) [ConstVar(Var, No)]: string
 "boop"@(FileId(1), 28..32) [Subprogram(Procedure)]: procedure ( pass(value) cheat int, pass(value) cheat int, pass(var ref) cheat int, ) -> void
-"<unnamed>"@(dummy) [Undeclared]: <error>
 "a"@(FileId(1), 33..34) [Param(Value, No)]: int
 "b"@(FileId(1), 36..37) [Param(Value, No)]: int
 "c"@(FileId(1), 55..56) [Param(Reference(Var), No)]: int
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "<root>"@(dummy) [Module(No)]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_args_err_few.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_args_err_few.snap
@@ -3,10 +3,10 @@ source: compiler/toc_analysis/src/typeck/test.rs
 expression: "procedure boop(a, b, c : int) end boop\nboop(1, 2)\nboop(1)\n"
 ---
 "boop"@(FileId(1), 10..14) [Subprogram(Procedure)]: procedure ( pass(value) int, pass(value) int, pass(value) int, ) -> void
-"<unnamed>"@(dummy) [Undeclared]: <error>
 "a"@(FileId(1), 15..16) [Param(Value, No)]: int
 "b"@(FileId(1), 18..19) [Param(Value, No)]: int
 "c"@(FileId(1), 21..22) [Param(Value, No)]: int
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "<root>"@(dummy) [Module(No)]: <error>
 
 error in file FileId(1) at 39..43: expected 3 arguments, found 2

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_args_err_many.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_args_err_many.snap
@@ -3,10 +3,10 @@ source: compiler/toc_analysis/src/typeck/test.rs
 expression: "procedure boop(a, b, c : int) end boop\nboop(1, 2, 3, 4)\nboop(1, 2, 3, 4, 5)\n"
 ---
 "boop"@(FileId(1), 10..14) [Subprogram(Procedure)]: procedure ( pass(value) int, pass(value) int, pass(value) int, ) -> void
-"<unnamed>"@(dummy) [Undeclared]: <error>
 "a"@(FileId(1), 15..16) [Param(Value, No)]: int
 "b"@(FileId(1), 18..19) [Param(Value, No)]: int
 "c"@(FileId(1), 21..22) [Param(Value, No)]: int
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "<root>"@(dummy) [Module(No)]: <error>
 
 error in file FileId(1) at 39..43: expected 3 arguments, found 4

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_args_err_missing.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_args_err_missing.snap
@@ -3,7 +3,7 @@ source: compiler/toc_analysis/src/typeck/test.rs
 expression: "procedure boop(a : int) end boop\n% shouldn't die, not reporting an error is fine\nboop(())\n"
 ---
 "boop"@(FileId(1), 10..14) [Subprogram(Procedure)]: procedure ( pass(value) int, ) -> void
-"<unnamed>"@(dummy) [Undeclared]: <error>
 "a"@(FileId(1), 15..16) [Param(Value, No)]: int
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "<root>"@(dummy) [Module(No)]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_args_err_not_expr.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_args_err_not_expr.snap
@@ -4,10 +4,10 @@ expression: "type a : int\nprocedure boop(a, b : int, var c : int) end boop\nboo
 ---
 "a"@(FileId(1), 5..6) [Type]: alias[DefId(LibraryId(0), LocalDefId(0))] of int
 "boop"@(FileId(1), 23..27) [Subprogram(Procedure)]: procedure ( pass(value) int, pass(value) int, pass(var ref) int, ) -> void
-"<unnamed>"@(dummy) [Undeclared]: <error>
 "a"@(FileId(1), 28..29) [Param(Value, No)]: int
 "b"@(FileId(1), 31..32) [Param(Value, No)]: int
 "c"@(FileId(1), 44..45) [Param(Reference(Var), No)]: int
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "<root>"@(dummy) [Module(No)]: <error>
 
 error in file FileId(1) at 70..71: cannot pass `a` to this parameter

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_args_err_wrong_binding.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_args_err_wrong_binding.snap
@@ -3,10 +3,10 @@ source: compiler/toc_analysis/src/typeck/test.rs
 expression: "procedure boop(a, b : int, var c : int) end boop\nboop(1, 2, 3)\n"
 ---
 "boop"@(FileId(1), 10..14) [Subprogram(Procedure)]: procedure ( pass(value) int, pass(value) int, pass(var ref) int, ) -> void
-"<unnamed>"@(dummy) [Undeclared]: <error>
 "a"@(FileId(1), 15..16) [Param(Value, No)]: int
 "b"@(FileId(1), 18..19) [Param(Value, No)]: int
 "c"@(FileId(1), 31..32) [Param(Reference(Var), No)]: int
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "<root>"@(dummy) [Module(No)]: <error>
 
 error in file FileId(1) at 60..61: cannot pass expression to this parameter

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_args_err_wrong_ty.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_args_err_wrong_ty.snap
@@ -4,10 +4,10 @@ expression: "var tree : string\nprocedure boop(a, b : int, var c : int) end boop
 ---
 "tree"@(FileId(1), 4..8) [ConstVar(Var, No)]: string
 "boop"@(FileId(1), 28..32) [Subprogram(Procedure)]: procedure ( pass(value) int, pass(value) int, pass(var ref) int, ) -> void
-"<unnamed>"@(dummy) [Undeclared]: <error>
 "a"@(FileId(1), 33..34) [Param(Value, No)]: int
 "b"@(FileId(1), 36..37) [Param(Value, No)]: int
 "c"@(FileId(1), 49..50) [Param(Reference(Var), No)]: int
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "<root>"@(dummy) [Module(No)]: <error>
 
 error in file FileId(1) at 78..82: mismatched types

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_args_exact.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_args_exact.snap
@@ -4,9 +4,9 @@ expression: "var tree : int\nprocedure boop(a, b : int, var c : int) end boop\nb
 ---
 "tree"@(FileId(1), 4..8) [ConstVar(Var, No)]: int
 "boop"@(FileId(1), 25..29) [Subprogram(Procedure)]: procedure ( pass(value) int, pass(value) int, pass(var ref) int, ) -> void
-"<unnamed>"@(dummy) [Undeclared]: <error>
 "a"@(FileId(1), 30..31) [Param(Value, No)]: int
 "b"@(FileId(1), 33..34) [Param(Value, No)]: int
 "c"@(FileId(1), 46..47) [Param(Reference(Var), No)]: int
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "<root>"@(dummy) [Module(No)]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_as_expr.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_as_expr.snap
@@ -3,7 +3,7 @@ source: compiler/toc_analysis/src/typeck/test.rs
 expression: "function key() : int end key\nvar res := key()\n"
 ---
 "key"@(FileId(1), 9..12) [Subprogram(Function)]: function ( ) -> int
-"<unnamed>"@(dummy) [Undeclared]: <error>
 "res"@(FileId(1), 33..36) [ConstVar(Var, No)]: int
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "<root>"@(dummy) [Module(No)]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_as_expr_err.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_as_expr_err.snap
@@ -3,8 +3,8 @@ source: compiler/toc_analysis/src/typeck/test.rs
 expression: "procedure lime() end lime\nvar res := lime()\n"
 ---
 "lime"@(FileId(1), 10..14) [Subprogram(Procedure)]: procedure ( ) -> void
-"<unnamed>"@(dummy) [Undeclared]: <error>
 "res"@(FileId(1), 30..33) [ConstVar(Var, No)]: <error>
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "<root>"@(dummy) [Module(No)]: <error>
 
 error in file FileId(1) at 37..41: cannot call procedure here

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_as_stmt.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_as_stmt.snap
@@ -3,8 +3,8 @@ source: compiler/toc_analysis/src/typeck/test.rs
 expression: "function key() : int end key\nprocedure lime() end lime\nkey() lime()\n"
 ---
 "key"@(FileId(1), 9..12) [Subprogram(Function)]: function ( ) -> int
-"<unnamed>"@(dummy) [Undeclared]: <error>
 "lime"@(FileId(1), 39..43) [Subprogram(Procedure)]: procedure ( ) -> void
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "<unnamed>"@(dummy) [Undeclared]: <error>
 "<root>"@(dummy) [Module(No)]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_as_stmt_err.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_as_stmt_err.snap
@@ -3,8 +3,8 @@ source: compiler/toc_analysis/src/typeck/test.rs
 expression: "function key() : int end key\nprocedure lime() end lime\n% can't be used like this, need paren\nkey lime\n"
 ---
 "key"@(FileId(1), 9..12) [Subprogram(Function)]: function ( ) -> int
-"<unnamed>"@(dummy) [Undeclared]: <error>
 "lime"@(FileId(1), 39..43) [Subprogram(Procedure)]: procedure ( ) -> void
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "<unnamed>"@(dummy) [Undeclared]: <error>
 "<root>"@(dummy) [Module(No)]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_coerce_ref_arg_char_any.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_coerce_ref_arg_char_any.snap
@@ -3,9 +3,9 @@ source: compiler/toc_analysis/src/typeck/test.rs
 expression: "procedure p(var a : char(*)) end p\nvar c : char\nvar cs : char(6)\np(c) p(cs)\n"
 ---
 "p"@(FileId(1), 10..11) [Subprogram(Procedure)]: procedure ( pass(var ref) char_n Any, ) -> void
-"<unnamed>"@(dummy) [Undeclared]: <error>
 "a"@(FileId(1), 16..17) [Param(Reference(Var), No)]: char_n Any
 "c"@(FileId(1), 39..40) [ConstVar(Var, No)]: char
 "cs"@(FileId(1), 52..54) [ConstVar(Var, No)]: char_n Fixed(Unevaluated(LibraryId(0), BodyId(1)))
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "<root>"@(dummy) [Module(No)]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_coerce_ref_arg_char_any_err.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_coerce_ref_arg_char_any_err.snap
@@ -3,9 +3,9 @@ source: compiler/toc_analysis/src/typeck/test.rs
 expression: "procedure p(var a : char(*)) end p\nvar c : string\np(c)\n"
 ---
 "p"@(FileId(1), 10..11) [Subprogram(Procedure)]: procedure ( pass(var ref) char_n Any, ) -> void
-"<unnamed>"@(dummy) [Undeclared]: <error>
 "a"@(FileId(1), 16..17) [Param(Reference(Var), No)]: char_n Any
 "c"@(FileId(1), 39..40) [ConstVar(Var, No)]: string
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "<root>"@(dummy) [Module(No)]: <error>
 
 error in file FileId(1) at 52..53: mismatched types

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_coerce_ref_arg_cheated.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_coerce_ref_arg_cheated.snap
@@ -3,8 +3,8 @@ source: compiler/toc_analysis/src/typeck/test.rs
 expression: "procedure p(var a : cheat real) end p\nvar i : int\np(i)\n"
 ---
 "p"@(FileId(1), 10..11) [Subprogram(Procedure)]: procedure ( pass(var ref) cheat real, ) -> void
-"<unnamed>"@(dummy) [Undeclared]: <error>
 "a"@(FileId(1), 16..17) [Param(Reference(Var), No)]: real
 "i"@(FileId(1), 42..43) [ConstVar(Var, No)]: int
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "<root>"@(dummy) [Module(No)]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_coerce_ref_arg_err.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_coerce_ref_arg_err.snap
@@ -3,9 +3,9 @@ source: compiler/toc_analysis/src/typeck/test.rs
 expression: "procedure p(var a : real) end p\nvar i : int\np(i)\n"
 ---
 "p"@(FileId(1), 10..11) [Subprogram(Procedure)]: procedure ( pass(var ref) real, ) -> void
-"<unnamed>"@(dummy) [Undeclared]: <error>
 "a"@(FileId(1), 16..17) [Param(Reference(Var), No)]: real
 "i"@(FileId(1), 36..37) [ConstVar(Var, No)]: int
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "<root>"@(dummy) [Module(No)]: <error>
 
 error in file FileId(1) at 46..47: mismatched types

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_coerce_ref_arg_string_any.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_coerce_ref_arg_string_any.snap
@@ -3,8 +3,8 @@ source: compiler/toc_analysis/src/typeck/test.rs
 expression: "procedure p(var a : string(*)) end p\nvar c : string\np(c)\n"
 ---
 "p"@(FileId(1), 10..11) [Subprogram(Procedure)]: procedure ( pass(var ref) string_n Any, ) -> void
-"<unnamed>"@(dummy) [Undeclared]: <error>
 "a"@(FileId(1), 16..17) [Param(Reference(Var), No)]: string_n Any
 "c"@(FileId(1), 41..42) [ConstVar(Var, No)]: string
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "<root>"@(dummy) [Module(No)]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_coerce_ref_arg_string_any_err.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_coerce_ref_arg_string_any_err.snap
@@ -3,9 +3,9 @@ source: compiler/toc_analysis/src/typeck/test.rs
 expression: "procedure p(var a : string(*)) end p\nvar c : char\np(c)\n"
 ---
 "p"@(FileId(1), 10..11) [Subprogram(Procedure)]: procedure ( pass(var ref) string_n Any, ) -> void
-"<unnamed>"@(dummy) [Undeclared]: <error>
 "a"@(FileId(1), 16..17) [Param(Reference(Var), No)]: string_n Any
 "c"@(FileId(1), 41..42) [ConstVar(Var, No)]: char
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "<root>"@(dummy) [Module(No)]: <error>
 
 error in file FileId(1) at 52..53: mismatched types

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_coerce_value_arg.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_coerce_value_arg.snap
@@ -3,8 +3,8 @@ source: compiler/toc_analysis/src/typeck/test.rs
 expression: "procedure p(a : real) end p\nvar i : int\np(i)\n"
 ---
 "p"@(FileId(1), 10..11) [Subprogram(Procedure)]: procedure ( pass(value) real, ) -> void
-"<unnamed>"@(dummy) [Undeclared]: <error>
 "a"@(FileId(1), 12..13) [Param(Value, No)]: real
 "i"@(FileId(1), 32..33) [ConstVar(Var, No)]: int
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "<root>"@(dummy) [Module(No)]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_on_type_err.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_on_type_err.snap
@@ -2,8 +2,8 @@
 source: compiler/toc_analysis/src/typeck/test.rs
 expression: "type kall : procedure() kall"
 ---
+"kall"@(FileId(1), 5..9) [Type]: alias[DefId(LibraryId(0), LocalDefId(0))] of procedure ( ) -> void
 "<unnamed>"@(dummy) [Undeclared]: <error>
-"kall"@(FileId(1), 5..9) [Type]: alias[DefId(LibraryId(0), LocalDefId(1))] of procedure ( ) -> void
 "<root>"@(dummy) [Module(No)]: <error>
 
 error in file FileId(1) at 24..28: cannot use `kall` as a statement

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_wrong_arg_all_err.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_wrong_arg_all_err.snap
@@ -3,8 +3,8 @@ source: compiler/toc_analysis/src/typeck/test.rs
 expression: "procedure k(var j : int) end p\nk(all)\n"
 ---
 "k"@(FileId(1), 10..11) [Subprogram(Procedure)]: procedure ( pass(var ref) int, ) -> void
-"<unnamed>"@(dummy) [Undeclared]: <error>
 "j"@(FileId(1), 16..17) [Param(Reference(Var), No)]: int
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "<root>"@(dummy) [Module(No)]: <error>
 
 error in file FileId(1) at 33..36: cannot use `all` here

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_wrong_arg_range_err.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_call_wrong_arg_range_err.snap
@@ -3,8 +3,8 @@ source: compiler/toc_analysis/src/typeck/test.rs
 expression: "procedure k(var j : int) end p\nk(1 .. * - 2)\n"
 ---
 "k"@(FileId(1), 10..11) [Subprogram(Procedure)]: procedure ( pass(var ref) int, ) -> void
-"<unnamed>"@(dummy) [Undeclared]: <error>
 "j"@(FileId(1), 16..17) [Param(Reference(Var), No)]: int
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "<root>"@(dummy) [Module(No)]: <error>
 
 error in file FileId(1) at 33..43: cannot use range expression here

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_decl_named_res_use.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_decl_named_res_use.snap
@@ -3,8 +3,8 @@ source: compiler/toc_analysis/src/typeck/test.rs
 expression: "function sha() wa : int wa end sha"
 ---
 "sha"@(FileId(1), 9..12) [Subprogram(Function)]: function ( ) -> int
-"<unnamed>"@(dummy) [Undeclared]: <error>
 "wa"@(FileId(1), 15..17) [Param(Value, No)]: int
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "<root>"@(dummy) [Module(No)]: <error>
 
 error in file FileId(1) at 24..26: cannot use `wa` as a statement

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_param_infer_binding.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_param_infer_binding.snap
@@ -3,7 +3,6 @@ source: compiler/toc_analysis/src/typeck/test.rs
 expression: "function ka(register a : int, b : int, var c : int) r : int\n    bind\n        ra to a, % should fail\n        rb to b,\n        rc to c\n    r := 0 % should fail\nend ka"
 ---
 "ka"@(FileId(1), 9..11) [Subprogram(Function)]: function ( pass(value) register int, pass(value) int, pass(var ref) int, ) -> int
-"<unnamed>"@(dummy) [Undeclared]: <error>
 "a"@(FileId(1), 21..22) [Param(Value, Yes)]: int
 "b"@(FileId(1), 30..31) [Param(Value, No)]: int
 "c"@(FileId(1), 43..44) [Param(Reference(Var), No)]: int
@@ -11,6 +10,7 @@ expression: "function ka(register a : int, b : int, var c : int) r : int\n    bi
 "ra"@(FileId(1), 77..79) [Binding(Const, No)]: int
 "rb"@(FileId(1), 108..110) [Binding(Const, No)]: int
 "rc"@(FileId(1), 125..127) [Binding(Const, No)]: int
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "<root>"@(dummy) [Module(No)]: <error>
 
 error in file FileId(1) at 77..84: cannot bind `ra` to `a`

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_param_infer_ty.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_param_infer_ty.snap
@@ -4,9 +4,9 @@ expression: "type tyres : string\nfunction own(me : nat, pie : real) sammy : tyr
 ---
 "tyres"@(FileId(1), 5..10) [Type]: alias[DefId(LibraryId(0), LocalDefId(0))] of string
 "own"@(FileId(1), 29..32) [Subprogram(Function)]: function ( pass(value) nat, pass(value) real, ) -> alias[DefId(LibraryId(0), LocalDefId(0))] of string
-"<unnamed>"@(dummy) [Undeclared]: <error>
 "me"@(FileId(1), 33..35) [Param(Value, No)]: nat
 "pie"@(FileId(1), 43..46) [Param(Value, No)]: real
 "sammy"@(FileId(1), 55..60) [Param(Value, No)]: alias[DefId(LibraryId(0), LocalDefId(0))] of string
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "<root>"@(dummy) [Module(No)]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_ty_char_any_err.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_ty_char_any_err.snap
@@ -2,8 +2,8 @@
 source: compiler/toc_analysis/src/typeck/test.rs
 expression: "type _ : function () : char(*)"
 ---
+"_"@(FileId(1), 5..6) [Type]: alias[DefId(LibraryId(0), LocalDefId(0))] of function ( ) -> char_n Any
 "<unnamed>"@(dummy) [Undeclared]: <error>
-"_"@(FileId(1), 5..6) [Type]: alias[DefId(LibraryId(0), LocalDefId(1))] of function ( ) -> char_n Any
 "<root>"@(dummy) [Module(No)]: <error>
 
 error in file FileId(1) at 23..30: invalid storage type

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_ty_from_alias_function.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_ty_from_alias_function.snap
@@ -2,9 +2,9 @@
 source: compiler/toc_analysis/src/typeck/test.rs
 expression: "type sha : function (a : int, b : char) : int"
 ---
-"<unnamed>"@(dummy) [Undeclared]: <error>
+"sha"@(FileId(1), 5..8) [Type]: alias[DefId(LibraryId(0), LocalDefId(0))] of function ( pass(value) int, pass(value) char, ) -> int
 "a"@(FileId(1), 21..22) [Param(Value, No)]: <error>
 "b"@(FileId(1), 30..31) [Param(Value, No)]: <error>
-"sha"@(FileId(1), 5..8) [Type]: alias[DefId(LibraryId(0), LocalDefId(3))] of function ( pass(value) int, pass(value) char, ) -> int
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "<root>"@(dummy) [Module(No)]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_ty_from_alias_procedure.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_ty_from_alias_procedure.snap
@@ -2,9 +2,9 @@
 source: compiler/toc_analysis/src/typeck/test.rs
 expression: "type sha : procedure (a : int, b : char)"
 ---
-"<unnamed>"@(dummy) [Undeclared]: <error>
+"sha"@(FileId(1), 5..8) [Type]: alias[DefId(LibraryId(0), LocalDefId(0))] of procedure ( pass(value) int, pass(value) char, ) -> void
 "a"@(FileId(1), 22..23) [Param(Value, No)]: <error>
 "b"@(FileId(1), 31..32) [Param(Value, No)]: <error>
-"sha"@(FileId(1), 5..8) [Type]: alias[DefId(LibraryId(0), LocalDefId(3))] of procedure ( pass(value) int, pass(value) char, ) -> void
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "<root>"@(dummy) [Module(No)]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_ty_from_function.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_ty_from_function.snap
@@ -3,8 +3,8 @@ source: compiler/toc_analysis/src/typeck/test.rs
 expression: "function sha(a : int, b : char) : int end sha"
 ---
 "sha"@(FileId(1), 9..12) [Subprogram(Function)]: function ( pass(value) int, pass(value) char, ) -> int
-"<unnamed>"@(dummy) [Undeclared]: <error>
 "a"@(FileId(1), 13..14) [Param(Value, No)]: int
 "b"@(FileId(1), 22..23) [Param(Value, No)]: char
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "<root>"@(dummy) [Module(No)]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_ty_from_procedure.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_ty_from_procedure.snap
@@ -3,8 +3,8 @@ source: compiler/toc_analysis/src/typeck/test.rs
 expression: "procedure sha(a : int, b : char) end sha"
 ---
 "sha"@(FileId(1), 10..13) [Subprogram(Procedure)]: procedure ( pass(value) int, pass(value) char, ) -> void
-"<unnamed>"@(dummy) [Undeclared]: <error>
 "a"@(FileId(1), 14..15) [Param(Value, No)]: int
 "b"@(FileId(1), 23..24) [Param(Value, No)]: char
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "<root>"@(dummy) [Module(No)]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_ty_from_process.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_ty_from_process.snap
@@ -3,8 +3,8 @@ source: compiler/toc_analysis/src/typeck/test.rs
 expression: "process sha(a : int, b : char) end sha"
 ---
 "sha"@(FileId(1), 8..11) [Subprogram(Process)]: process ( pass(value) int, pass(value) char, ) -> void
-"<unnamed>"@(dummy) [Undeclared]: <error>
 "a"@(FileId(1), 12..13) [Param(Value, No)]: int
 "b"@(FileId(1), 21..22) [Param(Value, No)]: char
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "<root>"@(dummy) [Module(No)]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_ty_param_attrs.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_ty_param_attrs.snap
@@ -2,7 +2,7 @@
 source: compiler/toc_analysis/src/typeck/test.rs
 expression: "type _ : procedure (\n    ki : int,\n    var v : int,\n    register r : int,\n    var register vr : int,\n    ci : cheat int,\n    var vci : cheat int,\n    register rci : cheat int,\n    var register vrci : cheat int\n)"
 ---
-"<unnamed>"@(dummy) [Undeclared]: <error>
+"_"@(FileId(1), 5..6) [Type]: alias[DefId(LibraryId(0), LocalDefId(0))] of procedure ( pass(value) int, pass(var ref) int, pass(value) register int, pass(var ref) register int, pass(value) cheat int, pass(var ref) cheat int, pass(value) register cheat int, pass(var ref) register cheat int, ) -> void
 "ki"@(FileId(1), 25..27) [Param(Value, No)]: <error>
 "v"@(FileId(1), 43..44) [Param(Reference(Var), No)]: <error>
 "r"@(FileId(1), 65..66) [Param(Value, Yes)]: <error>
@@ -11,6 +11,6 @@ expression: "type _ : procedure (\n    ki : int,\n    var v : int,\n    register
 "vci"@(FileId(1), 129..132) [Param(Reference(Var), No)]: <error>
 "rci"@(FileId(1), 159..162) [Param(Value, Yes)]: <error>
 "vrci"@(FileId(1), 193..197) [Param(Reference(Var), Yes)]: <error>
-"_"@(FileId(1), 5..6) [Type]: alias[DefId(LibraryId(0), LocalDefId(9))] of procedure ( pass(value) int, pass(var ref) int, pass(value) register int, pass(var ref) register int, pass(value) cheat int, pass(var ref) cheat int, pass(value) register cheat int, pass(var ref) register cheat int, ) -> void
+"<unnamed>"@(dummy) [Undeclared]: <error>
 "<root>"@(dummy) [Module(No)]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_ty_string_any_err.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_subprog_ty_string_any_err.snap
@@ -2,8 +2,8 @@
 source: compiler/toc_analysis/src/typeck/test.rs
 expression: "type _ : function () : string(*)"
 ---
+"_"@(FileId(1), 5..6) [Type]: alias[DefId(LibraryId(0), LocalDefId(0))] of function ( ) -> string_n Any
 "<unnamed>"@(dummy) [Undeclared]: <error>
-"_"@(FileId(1), 5..6) [Type]: alias[DefId(LibraryId(0), LocalDefId(1))] of function ( ) -> string_n Any
 "<root>"@(dummy) [Module(No)]: <error>
 
 error in file FileId(1) at 23..32: invalid storage type

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_type_alias_path_field_not_ty.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_type_alias_path_field_not_ty.snap
@@ -2,9 +2,9 @@
 source: compiler/toc_analysis/src/typeck/test.rs
 expression: "type e : enum(v)\nvar a : e.v\n"
 ---
-"v"@(FileId(1), 14..15) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "v"@(FileId(1), 14..15), )
-"e"@(FileId(1), 9..16) [Enum]: <error>
 "e"@(FileId(1), 5..6) [Type]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "v"@(FileId(1), 14..15), )
+"e"@(FileId(1), 9..16) [Enum]: <error>
+"v"@(FileId(1), 14..15) [EnumVariant]: enum[DefId(LibraryId(0), LocalDefId(1))] ( "v"@(FileId(1), 14..15), )
 "a"@(FileId(1), 21..22) [ConstVar(Var, No)]: <error>
 "<root>"@(dummy) [Module(No)]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_type_alias_path_no_fields.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_type_alias_path_no_fields.snap
@@ -4,9 +4,9 @@ expression: "module a export b type b : int end a\nvar e : a.b.c := 1\nvar f : a
 ---
 "a"@(FileId(1), 7..8) [Module(No)]: <error>
 "b"@(FileId(1), 23..24) [Type]: alias[DefId(LibraryId(0), LocalDefId(1))] of int
-"b"@(FileId(1), 16..17) [Export]: alias[DefId(LibraryId(0), LocalDefId(1))] of int
 "e"@(FileId(1), 41..42) [ConstVar(Var, No)]: <error>
 "f"@(FileId(1), 60..61) [ConstVar(Var, No)]: <error>
+"b"@(FileId(1), 16..17) [Export]: alias[DefId(LibraryId(0), LocalDefId(1))] of int
 "<root>"@(dummy) [Module(No)]: <error>
 
 error in file FileId(1) at 49..50: no field named `c` in `b`

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_type_alias_path_normal.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_type_alias_path_normal.snap
@@ -5,8 +5,8 @@ expression: "module a export b module b export c type c : int end b end a\nvar d
 "a"@(FileId(1), 7..8) [Module(No)]: <error>
 "b"@(FileId(1), 25..26) [Module(No)]: <error>
 "c"@(FileId(1), 41..42) [Type]: alias[DefId(LibraryId(0), LocalDefId(2))] of int
+"d"@(FileId(1), 65..66) [ConstVar(Var, No)]: alias[DefId(LibraryId(0), LocalDefId(2))] of int
 "c"@(FileId(1), 34..35) [Export]: alias[DefId(LibraryId(0), LocalDefId(2))] of int
 "b"@(FileId(1), 16..17) [Export]: <error>
-"d"@(FileId(1), 65..66) [ConstVar(Var, No)]: alias[DefId(LibraryId(0), LocalDefId(2))] of int
 "<root>"@(dummy) [Module(No)]: <error>
 

--- a/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_type_alias_path_not_ty.snap
+++ b/compiler/toc_analysis/src/typeck/snapshots/toc_analysis__typeck__test__typeck_type_alias_path_not_ty.snap
@@ -4,8 +4,8 @@ expression: "module a export b var b : int end a\nvar e : a.b\n"
 ---
 "a"@(FileId(1), 7..8) [Module(No)]: <error>
 "b"@(FileId(1), 22..23) [ConstVar(Var, No)]: int
-"b"@(FileId(1), 16..17) [Export]: int
 "e"@(FileId(1), 40..41) [ConstVar(Var, No)]: <error>
+"b"@(FileId(1), 16..17) [Export]: int
 "<root>"@(dummy) [Module(No)]: <error>
 
 error in file FileId(1) at 46..47: cannot use `b` as a type alias

--- a/compiler/toc_hir/src/builder.rs
+++ b/compiler/toc_hir/src/builder.rs
@@ -1,32 +1,19 @@
 //! Helper builders for creating the HIR tree
 
-use std::collections::HashMap;
-
 use la_arena::Arena;
 use toc_span::{FileId, Span, SpanId, SpanTable};
 
-use crate::{
-    body, expr, item, library, stmt,
-    symbol::{self, NodeSpan, Symbol},
-    ty,
-};
+use crate::{body, expr, item, library, stmt, symbol, ty};
 
 /// Builder for constructing a [`Library`]
 ///
 /// [`Library`]: library::Library
 pub struct LibraryBuilder {
     library: library::Library,
-    node_defs: HashMap<NodeSpan, symbol::LocalDefId>,
-    assoc_defs: symbol::DefMap<Vec<symbol::LocalDefId>>,
 }
 
 impl LibraryBuilder {
-    pub fn new(
-        span_map: SpanTable,
-        defs: symbol::DefInfoTable,
-        node_defs: HashMap<NodeSpan, symbol::LocalDefId>,
-        assoc_defs: symbol::DefMap<Vec<symbol::LocalDefId>>,
-    ) -> Self {
+    pub fn new(span_map: SpanTable, defs: symbol::DefInfoTable) -> Self {
         Self {
             library: library::Library {
                 span_map,
@@ -38,8 +25,6 @@ impl LibraryBuilder {
                 type_map: Default::default(),
                 resolve_map: Default::default(),
             },
-            node_defs,
-            assoc_defs,
         }
     }
 
@@ -61,7 +46,7 @@ impl LibraryBuilder {
     /// [`LocalDefId`]: crate::symbol::LocalDefId
     pub fn add_def(
         &mut self,
-        name: Symbol,
+        name: symbol::Symbol,
         span: SpanId,
         kind: Option<symbol::SymbolKind>,
         pervasive: symbol::IsPervasive,
@@ -80,18 +65,6 @@ impl LibraryBuilder {
 
     pub fn intern_span(&mut self, span: Span) -> SpanId {
         self.span_map.intern_span(span)
-    }
-
-    /// Finds the def bound to a specific AST node.
-    /// Assumes that there is a def at the given `node_span`
-    pub fn node_def(&self, node_span: NodeSpan) -> symbol::LocalDefId {
-        self.node_defs[&node_span]
-    }
-
-    /// Finds defs assocatied with `local_def`
-    /// Assumes that there are associated defs
-    pub fn associated_defs(&self, local_def: symbol::LocalDefId) -> &Vec<symbol::LocalDefId> {
-        self.assoc_defs.get(local_def).unwrap()
     }
 
     pub fn make_body_with(

--- a/compiler/toc_hir/src/builder.rs
+++ b/compiler/toc_hir/src/builder.rs
@@ -90,10 +90,7 @@ impl LibraryBuilder {
 
     /// Finds defs assocatied with `local_def`
     /// Assumes that there are associated defs
-    pub fn associated_defs(
-        &self,
-        local_def: symbol::LocalDefId,
-    ) -> &Vec<symbol::LocalDefId> {
+    pub fn associated_defs(&self, local_def: symbol::LocalDefId) -> &Vec<symbol::LocalDefId> {
         self.assoc_defs.get(local_def).unwrap()
     }
 

--- a/compiler/toc_hir/src/builder.rs
+++ b/compiler/toc_hir/src/builder.rs
@@ -75,10 +75,6 @@ impl LibraryBuilder {
         self.add_body(body)
     }
 
-    pub fn local_def_mut(&mut self, def_id: symbol::LocalDefId) -> &mut symbol::DefInfo {
-        &mut self.defs[def_id.into()]
-    }
-
     pub fn freeze_root_items(self, root_items: Vec<(FileId, item::ItemId)>) -> Self {
         Self {
             library: library::Library {

--- a/compiler/toc_hir/src/item.rs
+++ b/compiler/toc_hir/src/item.rs
@@ -232,8 +232,8 @@ pub struct ExportItem {
     pub mutability: symbol::Mutability,
     pub qualify_as: QualifyAs,
     pub is_opaque: bool,
-    /// Associated item to export
-    pub item_id: ItemId,
+    /// Associated def to export
+    pub exported_def: symbol::LocalDefId,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/compiler/toc_hir/src/library.rs
+++ b/compiler/toc_hir/src/library.rs
@@ -70,7 +70,7 @@ pub struct Library {
     /// Table of all interned types
     pub(crate) type_map: ty::TypeTable,
     pub(crate) items: Arena<item::Item>,
-    pub(crate) defs: Arena<symbol::DefInfo>,
+    pub(crate) defs: symbol::DefInfoTable,
     pub(crate) bodies: Arena<body::Body>,
     pub(crate) resolve_map: ResolutionMap,
 }
@@ -99,8 +99,8 @@ impl Library {
         }
     }
 
-    pub fn local_def(&self, def_id: symbol::LocalDefId) -> &symbol::DefInfo {
-        &self.defs[def_id.into()]
+    pub fn local_def(&self, local_def: symbol::LocalDefId) -> &symbol::DefInfo {
+        self.defs.get_info(local_def)
     }
 
     pub fn lookup_type(&self, type_id: ty::TypeId) -> &ty::Type {
@@ -124,7 +124,7 @@ impl Library {
     }
 
     pub fn local_defs(&self) -> impl Iterator<Item = symbol::LocalDefId> + '_ {
-        self.defs.iter().map(|(id, _)| symbol::LocalDefId(id))
+        self.defs.iter().map(|(id, _)| id)
     }
 
     pub fn body_ids(&self) -> Vec<body::BodyId> {

--- a/compiler/toc_hir/src/symbol.rs
+++ b/compiler/toc_hir/src/symbol.rs
@@ -56,17 +56,14 @@ impl From<&str> for Symbol {
     }
 }
 
-/// A specific identifier in a [`Library`](crate::library::Library)
+// FIXME: This feels more like an AST or `toc_span` construct, move it elsewhere
+/// The span of a specific AST node in a [`Library`](crate::library::Library)
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct Ident(pub Symbol, pub SpanId);
+pub struct NodeSpan(pub SpanId);
 
-impl Ident {
-    pub fn symbol(self) -> Symbol {
-        self.0
-    }
-
+impl NodeSpan {
     pub fn span(self) -> SpanId {
-        self.1
+        self.0
     }
 }
 
@@ -103,6 +100,14 @@ impl DefInfoTable {
         };
         let index = self.defs.alloc(def);
         LocalDefId(index)
+    }
+
+    pub fn get_info(&self, local_def: LocalDefId) -> &DefInfo {
+        &self.defs[local_def.0]
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (LocalDefId, &'_ DefInfo)> + '_ {
+        self.defs.iter().map(|(id, info)| (LocalDefId(id), info))
     }
 }
 

--- a/compiler/toc_hir_lowering/src/collector.rs
+++ b/compiler/toc_hir_lowering/src/collector.rs
@@ -4,8 +4,8 @@ use std::collections::HashMap;
 
 use toc_hir::{
     symbol::{
-        syms, DefInfoTable, DefMap, IsMonitor, IsPervasive, IsRegister, LocalDefId, Mutability,
-        NodeSpan, SubprogramKind, Symbol, SymbolKind,
+        syms, DefInfoTable, IsMonitor, IsPervasive, IsRegister, LocalDefId, Mutability, NodeSpan,
+        SubprogramKind, Symbol, SymbolKind,
     },
     ty::PassBy,
 };
@@ -13,7 +13,7 @@ use toc_reporting::{CompileResult, MessageSink};
 use toc_span::{FileId, Span, SpanId, SpanTable, TextRange};
 use toc_syntax::{
     ast::{self, AstNode},
-    match_ast, SyntaxKind, WalkEvent,
+    match_ast,
 };
 
 use crate::LoweringDb;
@@ -22,7 +22,6 @@ use crate::LoweringDb;
 pub(crate) struct CollectRes {
     pub(crate) defs: DefInfoTable,
     pub(crate) node_defs: HashMap<NodeSpan, LocalDefId>,
-    pub(crate) assoc_defs: DefMap<Vec<LocalDefId>>,
     pub(crate) spans: SpanTable,
 }
 
@@ -41,50 +40,11 @@ pub(crate) fn collect_defs(
     CompileResult::new(res, messages.finish())
 }
 
-/// Whether we're entering or leaving a node
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum NodeState {
-    Enter,
-    Leave,
-}
-
-struct DefScope {
-    defs: Vec<Vec<LocalDefId>>,
-}
-
-impl DefScope {
-    fn new() -> Self {
-        Self { defs: vec![vec![]] }
-    }
-
-    fn introduce_def(&mut self, local_def: LocalDefId) {
-        self.defs
-            .last_mut()
-            .expect("root scope was popped off")
-            .push(local_def);
-    }
-
-    fn push_scope(&mut self) {
-        self.defs.push(vec![])
-    }
-
-    fn pop_scope(&mut self) -> Vec<LocalDefId> {
-        self.defs.pop().expect("root scope was popped off")
-    }
-}
-
-impl Default for DefScope {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 struct FileCollector<'a> {
     file: FileId,
     root: ast::Source,
     res: &'a mut CollectRes,
     _messages: &'a mut MessageSink,
-    scopes: DefScope,
 }
 
 impl<'a> FileCollector<'a> {
@@ -99,7 +59,6 @@ impl<'a> FileCollector<'a> {
             root,
             res,
             _messages: messages,
-            scopes: Default::default(),
         };
 
         ctx.collect_root();
@@ -112,130 +71,50 @@ impl<'a> FileCollector<'a> {
         // Doesn't matter if it's a unit, since def generation is the
         // same regardless
 
-        for event in self.root.syntax().preorder() {
+        for node in self.root.syntax().descendants() {
             // FIXME: Handle include globs
             // AAAAAAAAAAAAAAAAAAAAAAAAAAA
 
             // Pull out node & state
-            match event {
-                WalkEvent::Enter(node) => {
-                    let state = NodeState::Enter;
+            match_ast! {
+                match (node) {
+                    // Decls //
+                    ast::ConstVarDecl(decl) => self.collect_decl_constvar(decl),
+                    ast::TypeDecl(decl) => self.collect_decl_type(decl),
+                    ast::BindDecl(decl) => self.collect_decl_bind(decl),
+                    ast::ProcDecl(decl) => self.collect_decl_proc(decl),
+                    ast::FcnDecl(decl) => self.collect_decl_fcn(decl),
+                    ast::ProcessDecl(decl) => self.collect_decl_process(decl),
+                    ast::ExternalDecl(_decl) => {},
+                    ast::ForwardDecl(_decl) => {},
+                    ast::DeferredDecl(_decl) => {},
+                    ast::BodyDecl(_decl) => {},
+                    ast::ModuleDecl(decl) => self.collect_decl_module(decl),
+                    ast::ClassDecl(_decl) => {},
+                    ast::MonitorDecl(_decl) => {},
 
-                    match_ast! {
-                        match (node) {
-                            // Decls //
-                            ast::ConstVarDecl(decl) => self.collect_decl_constvar(decl),
-                            ast::TypeDecl(decl) => self.collect_decl_type(decl),
-                            ast::BindDecl(decl) => self.collect_decl_bind(decl),
-                            ast::ProcDecl(decl) => self.collect_decl_proc(decl),
-                            ast::FcnDecl(decl) => self.collect_decl_fcn(decl),
-                            ast::ProcessDecl(decl) => self.collect_decl_process(decl),
-                            ast::ExternalDecl(_decl) => {},
-                            ast::ForwardDecl(_decl) => {},
-                            ast::DeferredDecl(_decl) => {},
-                            ast::BodyDecl(_decl) => {},
-                            ast::ModuleDecl(decl) => self.collect_decl_module(decl, state),
-                            ast::ClassDecl(_decl) => {},
-                            ast::MonitorDecl(_decl) => {},
+                    ast::ImportItem(decl) => self.collect_decl_import(decl),
 
-                            ast::ImportItem(decl) => self.collect_decl_import(decl),
+                    // Notable stmts //
+                    ast::ForStmt(stmt) => self.collect_stmt_for(stmt),
+                    ast::HandlerStmt(_stmt) => {},
 
-                            // Notable stmts //
-                            ast::ForStmt(stmt) => self.collect_stmt_for(stmt),
-                            ast::HandlerStmt(_stmt) => {},
-
-                            // Scopes don't need to be precise, so long as they
-                            // prevent defs from escaping & being considered
-                            // export candidates
-                            ast::StmtList(stmt) => self.wrap_scope(stmt, state),
-
-                            // Types //
-                            ast::EnumType(ty) => self.collect_ty_enum(ty),
-                            ast::SetType(ty) => self.collect_ty_set(ty),
-                            ast::RecordType(_ty) => {},
-                            ast::UnionType(_ty) => {},
-                            ast::FcnType(ty) => self.collect_ty_fcn(ty),
-                            ast::ProcType(ty) => self.collect_ty_proc(ty),
-                            ast::CollectionType(_ty) => {},
-                            _ => {}
-                        }
-                    }
+                    // Types //
+                    ast::EnumType(ty) => self.collect_ty_enum(ty),
+                    ast::SetType(ty) => self.collect_ty_set(ty),
+                    ast::RecordType(_ty) => {},
+                    ast::UnionType(_ty) => {},
+                    ast::FcnType(ty) => self.collect_ty_fcn(ty),
+                    ast::ProcType(ty) => self.collect_ty_proc(ty),
+                    ast::CollectionType(_ty) => {},
+                    _ => {}
                 }
-                WalkEvent::Leave(node) => {
-                    let state = NodeState::Leave;
-
-                    // These are the only nodes which care about node exit
-                    match_ast! {
-                        match (node) {
-                            ast::ModuleDecl(decl) => self.collect_decl_module(decl, state),
-                            ast::ClassDecl(_decl) => {},
-                            ast::MonitorDecl(_decl) => {},
-                            ast::StmtList(stmt) => self.wrap_scope(stmt, state),
-                            _ => {}
-                        }
-                    }
-                }
-            };
-        }
-    }
-
-    /// Wraps stmt nodes in a scope, but only if it doesn't have a significant scope
-    /// (i.e. the scope isn't used to collect defs as export candidates)
-    fn wrap_scope(&mut self, node: ast::StmtList, state: NodeState) {
-        let is_significant_scope = node.syntax().parent().map_or(false, |parent| {
-            matches!(
-                parent.kind(),
-                SyntaxKind::Source
-                    | SyntaxKind::ModuleDecl
-                    | SyntaxKind::ClassDecl
-                    | SyntaxKind::MonitorDecl
-            )
-        });
-
-        if is_significant_scope {
-            return;
-        }
-
-        match state {
-            NodeState::Enter => {
-                self.scopes.push_scope();
-            }
-            NodeState::Leave => {
-                self.scopes.pop_scope();
             }
         }
     }
 
     fn intern_range(&mut self, range: TextRange) -> SpanId {
         self.res.spans.intern_span(Span::new(self.file, range))
-    }
-
-    fn add_exported_name(
-        &mut self,
-        name: ast::Name,
-        kind: Option<SymbolKind>,
-        is_pervasive: IsPervasive,
-    ) -> LocalDefId {
-        let local_def = self.add_name(name, kind, is_pervasive);
-        // introduce into export candidates
-        self.scopes.introduce_def(local_def);
-        local_def
-    }
-
-    fn add_exported_name_list(
-        &mut self,
-        name_list: ast::NameList,
-        kind: Option<SymbolKind>,
-        is_pervasive: IsPervasive,
-    ) -> Vec<LocalDefId> {
-        let defs = self.add_name_list(name_list, kind, is_pervasive);
-
-        // introduce into export candidates
-        for &local_def in &defs {
-            self.scopes.introduce_def(local_def);
-        }
-
-        defs
     }
 
     fn add_name_list(
@@ -269,21 +148,6 @@ impl<'a> FileCollector<'a> {
     fn bind_span(&mut self, local_def: LocalDefId, span: SpanId) {
         self.res.node_defs.insert(NodeSpan(span), local_def);
     }
-
-    fn lookup_name_def(&mut self, name: Option<ast::Name>) -> Option<LocalDefId> {
-        let name = name?.identifier_token().unwrap();
-
-        let span = self.intern_range(name.text_range());
-        let ident = NodeSpan(span);
-        let local_def = self
-            .res
-            .node_defs
-            .get(&ident)
-            .copied()
-            .expect("def didn't get added beforehand");
-
-        Some(local_def)
-    }
 }
 
 impl FileCollector<'_> {
@@ -294,7 +158,7 @@ impl FileCollector<'_> {
         let is_var = node.var_token().is_some();
         let mutability = Mutability::from_is_mutable(is_var);
 
-        self.add_exported_name_list(
+        self.add_name_list(
             node.decl_list().unwrap(),
             Some(SymbolKind::ConstVar(mutability, is_register.into())),
             is_pervasive.into(),
@@ -304,7 +168,7 @@ impl FileCollector<'_> {
     fn collect_decl_type(&mut self, node: ast::TypeDecl) {
         if let Some(name) = node.decl_name() {
             let is_pervasive = node.pervasive_attr().is_some();
-            self.add_exported_name(name, Some(SymbolKind::Type), is_pervasive.into());
+            self.add_name(name, Some(SymbolKind::Type), is_pervasive.into());
         }
     }
 
@@ -316,7 +180,7 @@ impl FileCollector<'_> {
 
                 // Bindings are never pervasive, since they aren't meant to escape
                 // the local scope
-                self.add_exported_name(
+                self.add_name(
                     name,
                     Some(SymbolKind::Binding(mutability, is_register.into())),
                     IsPervasive::No,
@@ -331,7 +195,7 @@ impl FileCollector<'_> {
 
         if let Some(name) = header.name() {
             let is_pervasive = header.pervasive_attr().is_some();
-            self.add_exported_name(
+            self.add_name(
                 name,
                 Some(SymbolKind::Subprogram(SubprogramKind::Procedure)),
                 is_pervasive.into(),
@@ -347,7 +211,7 @@ impl FileCollector<'_> {
 
         if let Some(name) = header.name() {
             let is_pervasive = header.pervasive_attr().is_some();
-            self.add_exported_name(
+            self.add_name(
                 name,
                 Some(SymbolKind::Subprogram(SubprogramKind::Function)),
                 is_pervasive.into(),
@@ -372,7 +236,7 @@ impl FileCollector<'_> {
 
         if let Some(name) = header.name() {
             let is_pervasive = header.pervasive_attr().is_some();
-            self.add_exported_name(
+            self.add_name(
                 name,
                 Some(SymbolKind::Subprogram(SubprogramKind::Process)),
                 is_pervasive.into(),
@@ -421,55 +285,27 @@ impl FileCollector<'_> {
         }
     }
 
-    fn collect_decl_module(&mut self, node: ast::ModuleDecl, state: NodeState) {
-        match state {
-            NodeState::Enter => {
-                // name
-                if let Some(name) = node.name() {
-                    let is_pervasive = node.pervasive_attr().is_some();
-                    self.add_exported_name(
-                        name,
-                        Some(SymbolKind::Module(IsMonitor::No)),
-                        is_pervasive.into(),
-                    );
-                }
-
-                self.scopes.push_scope();
-            }
-            NodeState::Leave => {
-                let candidates = self.scopes.pop_scope();
-
-                if let Some(local_def) = self.lookup_name_def(node.name()) {
-                    // associate defs as export candidates
-                    self.res.assoc_defs.insert(local_def, candidates);
-                }
-            }
+    fn collect_decl_module(&mut self, node: ast::ModuleDecl) {
+        // name
+        if let Some(name) = node.name() {
+            let is_pervasive = node.pervasive_attr().is_some();
+            self.add_name(
+                name,
+                Some(SymbolKind::Module(IsMonitor::No)),
+                is_pervasive.into(),
+            );
         }
     }
 
     fn collect_decl_import(&mut self, node: ast::ImportItem) {
         if let Some(name) = node.external_item().and_then(|item| item.name()) {
-            let local_def = self.add_name(name, Some(SymbolKind::Import), IsPervasive::No);
-
-            // Only consider as an export candidate if we aren't in a forward decl
-            // <ImportItem> => ImportList => ForwardDecl
-            // TODO: use a def scope instead once we deal with forward decls
-            let in_forward_decl = Some(node)
-                .and_then(|n| n.syntax().parent())
-                .and_then(ast::ImportList::cast)
-                .and_then(|n| n.syntax().parent())
-                .and_then(ast::ForwardDecl::cast)
-                .is_some();
-
-            if !in_forward_decl {
-                self.scopes.introduce_def(local_def);
-            }
+            self.add_name(name, Some(SymbolKind::Import), IsPervasive::No);
         }
     }
 
     fn collect_stmt_for(&mut self, node: ast::ForStmt) {
         if let Some(name) = node.name() {
-            self.add_exported_name(
+            self.add_name(
                 name,
                 Some(SymbolKind::ConstVar(Mutability::Const, IsRegister::No)),
                 IsPervasive::No,
@@ -478,16 +314,9 @@ impl FileCollector<'_> {
     }
 
     fn collect_ty_enum(&mut self, node: ast::EnumType) {
-        let variants = node
-            .fields()
-            .unwrap()
-            .names()
-            .map(|name| self.add_name(name, Some(SymbolKind::EnumVariant), IsPervasive::No))
-            .collect();
-
         let span = self.intern_range(node.syntax().text_range());
         let local_def = self.res.defs.add_def(
-            type_decl_name(node),
+            type_decl_name(&node),
             span,
             Some(SymbolKind::Enum),
             IsPervasive::No,
@@ -496,13 +325,19 @@ impl FileCollector<'_> {
         // bind it to the entire type node, since it doesn't have a name
         self.bind_span(local_def, span);
 
-        self.res.assoc_defs.insert(local_def, variants);
+        // Make the variant defs after the name so that adding new variants
+        // doesn't affect the primary enum def
+        self.add_name_list(
+            node.fields().unwrap(),
+            Some(SymbolKind::EnumVariant),
+            IsPervasive::No,
+        );
     }
 
     fn collect_ty_set(&mut self, node: ast::SetType) {
         let span = self.intern_range(node.syntax().text_range());
         let local_def = self.res.defs.add_def(
-            type_decl_name(node),
+            type_decl_name(&node),
             span,
             Some(SymbolKind::Set),
             IsPervasive::No,
@@ -524,7 +359,7 @@ impl FileCollector<'_> {
 }
 
 /// Gets the name from the enclosing `type` decl, or the [`Anonymous`](syms::Anonymous) symbol
-fn type_decl_name(ty: impl ast::AstNode) -> Symbol {
+fn type_decl_name(ty: &impl ast::AstNode) -> Symbol {
     ty.syntax()
         .parent()
         .and_then(ast::TypeDecl::cast)

--- a/compiler/toc_hir_lowering/src/collector.rs
+++ b/compiler/toc_hir_lowering/src/collector.rs
@@ -1,0 +1,464 @@
+//! Collecting all defs declared in a library
+
+use std::collections::HashMap;
+
+use toc_hir::{
+    symbol::{
+        DefInfoTable, DefMap, Ident, IsMonitor, IsPervasive, IsRegister, LocalDefId, Mutability,
+        SubprogramKind, SymbolKind,
+    },
+    ty::PassBy,
+};
+use toc_reporting::{CompileResult, MessageSink};
+use toc_span::{FileId, Span, SpanId, SpanTable, TextRange};
+use toc_syntax::{
+    ast::{self, AstNode},
+    match_ast, SyntaxKind, WalkEvent,
+};
+
+use crate::LoweringDb;
+
+#[derive(Debug, Default)]
+pub(crate) struct CollectRes {
+    pub(crate) defs: DefInfoTable,
+    pub(crate) ident_defs: HashMap<Ident, LocalDefId>,
+    pub(crate) export_candidates: DefMap<Vec<LocalDefId>>,
+    pub(crate) spans: SpanTable,
+}
+
+pub(crate) fn collect_defs(
+    db: &dyn LoweringDb,
+    reachable_files: &[FileId],
+) -> CompileResult<CollectRes> {
+    let mut res = CollectRes::default();
+    let mut messages = MessageSink::default();
+
+    for &file in reachable_files {
+        let root = ast::Source::cast(db.parse_file(file).result().syntax()).unwrap();
+        CollectCtx::collect(file, root, &mut res, &mut messages);
+    }
+
+    CompileResult::new(res, messages.finish())
+}
+
+/// Whether we're entering or leaving a node
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum NodeState {
+    Enter,
+    Leave,
+}
+
+struct DefScope {
+    defs: Vec<Vec<LocalDefId>>,
+}
+
+impl DefScope {
+    fn new() -> Self {
+        Self { defs: vec![vec![]] }
+    }
+
+    fn introduce_def(&mut self, local_def: LocalDefId) {
+        self.defs
+            .last_mut()
+            .expect("root scope was popped off")
+            .push(local_def);
+    }
+
+    fn push_scope(&mut self) {
+        self.defs.push(vec![])
+    }
+
+    fn pop_scope(&mut self) -> Vec<LocalDefId> {
+        self.defs.pop().expect("root scope was popped off")
+    }
+}
+
+impl Default for DefScope {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+struct CollectCtx<'a> {
+    file: FileId,
+    root: ast::Source,
+    res: &'a mut CollectRes,
+    _messages: &'a mut MessageSink,
+    scopes: DefScope,
+}
+
+impl<'a> CollectCtx<'a> {
+    fn collect(
+        file: FileId,
+        root: ast::Source,
+        res: &'a mut CollectRes,
+        messages: &'a mut MessageSink,
+    ) {
+        let mut ctx = Self {
+            file,
+            root,
+            res,
+            _messages: messages,
+            scopes: Default::default(),
+        };
+
+        ctx.collect_root();
+    }
+
+    fn collect_root(&mut self) {
+        // FIXME: generate defs for this import statement
+        // self.root.import_stmt();
+
+        // Doesn't matter if it's a unit, since def generation is the
+        // same regardless
+
+        for event in self.root.syntax().preorder() {
+            // Pull out node & state
+            let (node, state) = match event {
+                WalkEvent::Enter(n) => (n, NodeState::Enter),
+                WalkEvent::Leave(n) => (n, NodeState::Leave),
+            };
+
+            // FIXME: Handle include globs
+            // AAAAAAAAAAAAAAAAAAAAAAAAAAA
+
+            match_ast! {
+                match (node) {
+                    // Decls //
+                    ast::ConstVarDecl(decl) => self.collect_decl_constvar(decl, state),
+                    ast::TypeDecl(decl) => self.collect_decl_type(decl, state),
+                    ast::BindDecl(decl) => self.collect_decl_bind(decl, state),
+                    ast::ProcDecl(decl) => self.collect_decl_proc(decl, state),
+                    ast::FcnDecl(decl) => self.collect_decl_fcn(decl, state),
+                    ast::ProcessDecl(decl) => self.collect_decl_process(decl, state),
+                    ast::ExternalDecl(_decl) => {},
+                    ast::ForwardDecl(_decl) => {},
+                    ast::DeferredDecl(_decl) => {},
+                    ast::BodyDecl(_decl) => {},
+                    ast::ModuleDecl(decl) => self.collect_decl_module(decl, state),
+                    ast::ClassDecl(_decl) => {},
+                    ast::MonitorDecl(_decl) => {},
+
+                    // Notable stmts //
+                    ast::ForStmt(stmt) => self.collect_stmt_for(stmt, state),
+                    ast::HandlerStmt(_stmt) => {},
+
+                    // Scopes don't need to be precise, so long as they
+                    // prevent defs from escaping & being considered
+                    // export candidates
+                    ast::StmtList(stmt) => self.wrap_scope(stmt, state),
+
+                    // Types //
+                    ast::CollectionType(_ty) => {},
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    /// Wraps stmt nodes in a scope, but only if it doesn't have a significant scope
+    /// (i.e. the scope isn't used to collect defs as export candidates)
+    fn wrap_scope(&mut self, node: ast::StmtList, state: NodeState) {
+        let is_significant_scope = node.syntax().parent().map_or(false, |parent| {
+            matches!(
+                parent.kind(),
+                SyntaxKind::Source
+                    | SyntaxKind::ModuleDecl
+                    | SyntaxKind::ClassDecl
+                    | SyntaxKind::MonitorDecl
+            )
+        });
+
+        if is_significant_scope {
+            return;
+        }
+
+        match state {
+            NodeState::Enter => {
+                self.scopes.push_scope();
+            }
+            NodeState::Leave => {
+                self.scopes.pop_scope();
+            }
+        }
+    }
+
+    fn intern_range(&mut self, range: TextRange) -> SpanId {
+        self.res.spans.intern_span(Span::new(self.file, range))
+    }
+
+    fn add_exported_name(
+        &mut self,
+        name: ast::Name,
+        kind: Option<SymbolKind>,
+        is_pervasive: IsPervasive,
+    ) -> LocalDefId {
+        let local_def = self.add_name(name, kind, is_pervasive);
+        // introduce into export candidates
+        self.scopes.introduce_def(local_def);
+        local_def
+    }
+
+    fn add_exported_name_list(
+        &mut self,
+        name_list: ast::NameList,
+        kind: Option<SymbolKind>,
+        is_pervasive: IsPervasive,
+    ) -> Vec<LocalDefId> {
+        let defs = self.add_name_list(name_list, kind, is_pervasive);
+
+        // introduce into export candidates
+        for &local_def in &defs {
+            self.scopes.introduce_def(local_def);
+        }
+
+        defs
+    }
+
+    fn add_name_list(
+        &mut self,
+        name_list: ast::NameList,
+        kind: Option<SymbolKind>,
+        is_pervasive: IsPervasive,
+    ) -> Vec<LocalDefId> {
+        name_list
+            .names()
+            .map(|name| self.add_name(name, kind, is_pervasive))
+            .collect()
+    }
+
+    fn add_name(
+        &mut self,
+        name: ast::Name,
+        kind: Option<SymbolKind>,
+        is_pervasive: IsPervasive,
+    ) -> LocalDefId {
+        let name_tok = name.identifier_token().unwrap();
+        let name = name_tok.text();
+        let span = self.intern_range(name_tok.text_range());
+
+        let def_id = self.res.defs.add_def(name.into(), span, kind, is_pervasive);
+        self.res.ident_defs.insert(Ident(name.into(), span), def_id);
+
+        def_id
+    }
+
+    fn lookup_def(&mut self, name: Option<ast::Name>) -> Option<LocalDefId> {
+        let name = name?.identifier_token().unwrap();
+
+        let span = self.intern_range(name.text_range());
+        let ident = Ident(name.text().into(), span);
+        let local_def = self
+            .res
+            .ident_defs
+            .get(&ident)
+            .copied()
+            .expect("def didn't get added beforehand");
+
+        Some(local_def)
+    }
+}
+
+impl CollectCtx<'_> {
+    // Decls //
+    fn collect_decl_constvar(&mut self, node: ast::ConstVarDecl, state: NodeState) {
+        if matches!(state, NodeState::Leave) {
+            return;
+        }
+
+        let is_pervasive = node.pervasive_attr().is_some();
+        let is_register = node.register_attr().is_some();
+        let is_var = node.var_token().is_some();
+        let mutability = Mutability::from_is_mutable(is_var);
+
+        self.add_exported_name_list(
+            node.decl_list().unwrap(),
+            Some(SymbolKind::ConstVar(mutability, is_register.into())),
+            is_pervasive.into(),
+        );
+    }
+
+    fn collect_decl_type(&mut self, node: ast::TypeDecl, state: NodeState) {
+        if matches!(state, NodeState::Leave) {
+            return;
+        }
+
+        if let Some(name) = node.decl_name() {
+            let is_pervasive = node.pervasive_attr().is_some();
+            self.add_exported_name(name, Some(SymbolKind::Type), is_pervasive.into());
+        }
+    }
+
+    fn collect_decl_bind(&mut self, node: ast::BindDecl, state: NodeState) {
+        if matches!(state, NodeState::Leave) {
+            return;
+        }
+
+        for binding in node.bindings() {
+            if let Some(name) = binding.bind_as() {
+                let mutability = Mutability::from_is_mutable(binding.as_var().is_some());
+                let is_register = binding.to_register().is_some();
+
+                // Bindings are never pervasive, since they aren't meant to escape
+                // the local scope
+                self.add_exported_name(
+                    name,
+                    Some(SymbolKind::Binding(mutability, is_register.into())),
+                    IsPervasive::No,
+                );
+            }
+        }
+    }
+
+    fn collect_decl_proc(&mut self, node: ast::ProcDecl, state: NodeState) {
+        // scope wrapping handled by `wrap_scope`
+        if matches!(state, NodeState::Leave) {
+            return;
+        }
+
+        // name + param names
+        let header = node.proc_header().unwrap();
+
+        if let Some(name) = header.name() {
+            let is_pervasive = header.pervasive_attr().is_some();
+            self.add_exported_name(
+                name,
+                Some(SymbolKind::Subprogram(SubprogramKind::Procedure)),
+                is_pervasive.into(),
+            );
+        }
+
+        self.collect_formals_spec(header.params());
+    }
+
+    fn collect_decl_fcn(&mut self, node: ast::FcnDecl, state: NodeState) {
+        // scope wrapping handled by `wrap_scope`
+        if matches!(state, NodeState::Leave) {
+            return;
+        }
+
+        // name + param names + maybe result name
+        let header = node.fcn_header().unwrap();
+
+        if let Some(name) = header.name() {
+            let is_pervasive = header.pervasive_attr().is_some();
+            self.add_exported_name(
+                name,
+                Some(SymbolKind::Subprogram(SubprogramKind::Function)),
+                is_pervasive.into(),
+            );
+        }
+
+        self.collect_formals_spec(header.params());
+
+        if let Some(res_name) = header.fcn_result().and_then(|res| res.name()) {
+            // ???: Does this need to be pass by value? (can it be pass by const ref?)
+            self.add_name(
+                res_name,
+                Some(SymbolKind::Param(PassBy::Value, IsRegister::No)),
+                IsPervasive::No,
+            );
+        }
+    }
+
+    fn collect_decl_process(&mut self, node: ast::ProcessDecl, state: NodeState) {
+        // scope wrapping handled by `wrap_scope`
+        if matches!(state, NodeState::Leave) {
+            return;
+        }
+
+        // name + param names
+        let header = node.process_header().unwrap();
+
+        if let Some(name) = header.name() {
+            let is_pervasive = header.pervasive_attr().is_some();
+            self.add_exported_name(
+                name,
+                Some(SymbolKind::Subprogram(SubprogramKind::Process)),
+                is_pervasive.into(),
+            );
+        }
+
+        self.collect_formals_spec(header.params());
+    }
+
+    fn collect_formals_spec(&mut self, param_spec: Option<ast::ParamSpec>) {
+        let param_spec = match param_spec {
+            Some(it) => it,
+            _ => return,
+        };
+
+        for param in param_spec.param_decl() {
+            match param {
+                ast::ParamDecl::ConstVarParam(param) => {
+                    let is_register = param.bind_to_register().is_some();
+                    let pass_by = match param.pass_as_ref() {
+                        None => PassBy::Value,
+                        Some(_) => PassBy::Reference(Mutability::Var),
+                    };
+
+                    self.add_name_list(
+                        param.param_names().unwrap(),
+                        Some(SymbolKind::Param(pass_by, is_register.into())),
+                        IsPervasive::No,
+                    );
+                }
+                ast::ParamDecl::SubprogType(param) => {
+                    let name = match param {
+                        ast::SubprogType::FcnType(header) => header.name(),
+                        ast::SubprogType::ProcType(header) => header.name(),
+                    };
+
+                    if let Some(name) = name {
+                        self.add_name(
+                            name,
+                            Some(SymbolKind::Param(PassBy::Value, IsRegister::No)),
+                            IsPervasive::No,
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    fn collect_decl_module(&mut self, node: ast::ModuleDecl, state: NodeState) {
+        match state {
+            NodeState::Enter => {
+                // name
+                if let Some(name) = node.name() {
+                    let is_pervasive = node.pervasive_attr().is_some();
+                    self.add_exported_name(
+                        name,
+                        Some(SymbolKind::Module(IsMonitor::No)),
+                        is_pervasive.into(),
+                    );
+                }
+
+                self.scopes.push_scope();
+            }
+            NodeState::Leave => {
+                let candidates = self.scopes.pop_scope();
+
+                if let Some(local_def) = self.lookup_def(node.name()) {
+                    // associate defs as export candidates
+                    self.res.export_candidates.insert(local_def, candidates);
+                }
+            }
+        }
+    }
+
+    fn collect_stmt_for(&mut self, node: ast::ForStmt, state: NodeState) {
+        // scope wrapping handled by `wrap_scope`
+        if matches!(state, NodeState::Leave) {
+            return;
+        }
+
+        if let Some(name) = node.name() {
+            self.add_exported_name(
+                name,
+                Some(SymbolKind::ConstVar(Mutability::Const, IsRegister::No)),
+                IsPervasive::No,
+            );
+        }
+    }
+}

--- a/compiler/toc_hir_lowering/src/lib.rs
+++ b/compiler/toc_hir_lowering/src/lib.rs
@@ -17,9 +17,9 @@
 // FileDB should only care about giving unique file handles corresponding to text sources.
 // Other DBs will deal with what they map to (e.g. a separate DB managing all of the CSTs)
 
+mod collector;
 mod lower;
 mod resolver;
-mod collector;
 
 use toc_hir::{library::LoweredLibrary, library_graph::LibraryGraph};
 use toc_reporting::CompileResult;

--- a/compiler/toc_hir_lowering/src/lib.rs
+++ b/compiler/toc_hir_lowering/src/lib.rs
@@ -19,6 +19,7 @@
 
 mod lower;
 mod resolver;
+mod collector;
 
 use toc_hir::{library::LoweredLibrary, library_graph::LibraryGraph};
 use toc_reporting::CompileResult;

--- a/compiler/toc_hir_lowering/src/lower.rs
+++ b/compiler/toc_hir_lowering/src/lower.rs
@@ -66,6 +66,11 @@ where
         }
 
         let reachable_files: Vec<_> = self.depend_graph(library_root).unit_sources().collect();
+
+        // Collect all the defs in the library
+        let (collect_res, msgs) = crate::collector::collect_defs(db, &reachable_files).take();
+        messages = messages.combine(msgs);
+
         let mut root_items = vec![];
         let mut library = builder::LibraryBuilder::default();
 

--- a/compiler/toc_hir_lowering/src/lower/stmt.rs
+++ b/compiler/toc_hir_lowering/src/lower/stmt.rs
@@ -741,6 +741,7 @@ impl super::BodyLowering<'_, '_> {
                 .into_iter()
                 .map(|(export_name, item_id)| {
                     let item = self.ctx.library.item(item_id);
+                    let exported_def = item.def_id;
                     let is_opaque = if !matches!(item.kind, item::ItemKind::Type(_)) {
                         // Opaque is only applicable to types
                         false
@@ -772,7 +773,7 @@ impl super::BodyLowering<'_, '_> {
                         mutability,
                         qualify_as,
                         is_opaque,
-                        item_id,
+                        exported_def,
                     }
                 })
                 .collect()
@@ -817,6 +818,7 @@ impl super::BodyLowering<'_, '_> {
 
                     if let Some(item_id) = item {
                         let item = self.ctx.library.item(item_id);
+                        let exported_def = item.def_id;
 
                         // Report when opaqueness is not applicable
                         let is_opaque = if is_opaque
@@ -911,7 +913,7 @@ impl super::BodyLowering<'_, '_> {
                             mutability,
                             qualify_as,
                             is_opaque,
-                            item_id,
+                            exported_def,
                         })
                     } else {
                         let span = Span::new(self.ctx.file, name.syntax().text_range());

--- a/compiler/toc_hir_lowering/src/lower/stmt.rs
+++ b/compiler/toc_hir_lowering/src/lower/stmt.rs
@@ -346,7 +346,8 @@ impl super::BodyLowering<'_, '_> {
                     let coerced_type = param.coerce_type().is_some();
                     let param_ty = self.lower_required_type(param.param_ty());
 
-                    let names = self.ctx
+                    let names = self
+                        .ctx
                         .collect_name_defs_with_missing(param.param_names().unwrap(), missing_name);
 
                     for name in names {

--- a/compiler/toc_hir_lowering/src/lower/ty.rs
+++ b/compiler/toc_hir_lowering/src/lower/ty.rs
@@ -270,8 +270,8 @@ impl super::BodyLowering<'_, '_> {
 
     fn lower_enum_type(&mut self, ty: ast::EnumType) -> Option<ty::TypeKind> {
         let node_span = self.ctx.node_span(ty.syntax().text_range());
-        let def_id = self.ctx.library.node_def(node_span);
-        let variants = self.ctx.library.associated_defs(def_id).clone();
+        let def_id = self.ctx.node_def(node_span);
+        let variants = self.ctx.collect_optional_name_defs(ty.fields().unwrap());
 
         Some(ty::TypeKind::Enum(ty::Enum { def_id, variants }))
     }
@@ -389,7 +389,7 @@ impl super::BodyLowering<'_, '_> {
 
     fn lower_set_type(&mut self, ty: ast::SetType) -> Option<ty::TypeKind> {
         let node_span = self.ctx.node_span(ty.syntax().text_range());
-        let def_id = self.ctx.library.node_def(node_span);
+        let def_id = self.ctx.node_def(node_span);
         let elem = self.lower_required_type(ty.elem_ty());
 
         Some(ty::TypeKind::Set(ty::Set {

--- a/compiler/toc_hir_lowering/src/resolver.rs
+++ b/compiler/toc_hir_lowering/src/resolver.rs
@@ -455,13 +455,6 @@ impl<'a> ResolveCtx<'a> {
                 this.introduce_def(item.def_id, DeclareKind::Declared);
 
                 if let Some(param_list) = &item.param_list {
-                    // Make sure there aren't any duplicate names
-                    this.with_scope(ScopeKind::SubprogramHeader, |this| {
-                        for param_def in &param_list.names {
-                            this.introduce_def(*param_def, DeclareKind::Declared);
-                        }
-                    });
-
                     for param in &param_list.tys {
                         this.resolve_type(param.param_ty);
                     }
@@ -479,16 +472,11 @@ impl<'a> ResolveCtx<'a> {
                 this.with_scope(ScopeKind::Subprogram, |this| {
                     this.with_scope(ScopeKind::Block, |this| {
                         // Introduce params
+                        // `AlwaysShadow` takes care of reporting duplicate params,
+                        // while also properly shadowing external names
                         if let Some(param_list) = &item.param_list {
                             for &param_def in &param_list.names {
-                                let def_info = &this.library.local_def(param_def);
-                                let name = def_info.name;
-                                this.scopes.def_sym(
-                                    name,
-                                    param_def,
-                                    DeclareKind::Declared,
-                                    def_info.pervasive.into(),
-                                );
+                                this.introduce_def(param_def, DeclareKind::AlwaysShadow);
                             }
                         }
 

--- a/compiler/toc_hir_lowering/src/resolver/scopes.rs
+++ b/compiler/toc_hir_lowering/src/resolver/scopes.rs
@@ -123,7 +123,7 @@ impl ScopeKind {
     fn import_boundary(&self) -> ImportBoundary {
         match self {
             ScopeKind::Root | ScopeKind::Module => ImportBoundary::Explicit,
-            ScopeKind::Subprogram  => ImportBoundary::Implicit,
+            ScopeKind::Subprogram => ImportBoundary::Implicit,
             _ => ImportBoundary::None,
         }
     }

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_import_stmt-4.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_import_stmt-4.snap
@@ -19,7 +19,7 @@ Library@(dummy)
           Subprogram@(FileId(1), 27..76): "_"@(FileId(1), 32..33)
             Void@(FileId(1), 27..33)
             Import@(FileId(1), 49..50): SameAsItem local("a"@(FileId(1), 9..10))
-            Import@(FileId(1), 52..57): Explicit(Var, SpanId(11)) local("b"@(FileId(1), 12..13))
-            Import@(FileId(1), 59..66): Explicit(Const, SpanId(14)) local("c"@(FileId(1), 15..16))
+            Import@(FileId(1), 52..57): Explicit(Var, SpanId(13)) local("b"@(FileId(1), 12..13))
+            Import@(FileId(1), 59..66): Explicit(Const, SpanId(15)) local("c"@(FileId(1), 15..16))
             StmtBody@(FileId(1), 71..71): []
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_import_stmt.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_import_stmt.snap
@@ -18,7 +18,7 @@ Library@(dummy)
         StmtItem@(FileId(1), 27..78): ItemId(6)
           Module@(FileId(1), 27..78): "_"@(FileId(1), 34..35)
             Import@(FileId(1), 51..52): SameAsItem local("a"@(FileId(1), 9..10))
-            Import@(FileId(1), 54..59): Explicit(Var, SpanId(10)) local("b"@(FileId(1), 12..13))
-            Import@(FileId(1), 61..68): Explicit(Const, SpanId(13)) local("c"@(FileId(1), 15..16))
+            Import@(FileId(1), 54..59): Explicit(Var, SpanId(12)) local("b"@(FileId(1), 12..13))
+            Import@(FileId(1), 61..68): Explicit(Const, SpanId(14)) local("c"@(FileId(1), 15..16))
             StmtBody@(FileId(1), 73..73): []
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_range_expr-3.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_range_expr-3.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler/toc_hir_lowering/tests/lowering.rs
-assertion_line: 61
 expression: "proc call end call var _ := call(1..*)"
-
 ---
 Library@(dummy)
   Root@(dummy): FileId(1) -> ItemId(2)
@@ -17,6 +15,6 @@ Library@(dummy)
             ExprBody@(FileId(1), 28..38)
               CallExpr@(FileId(1), 28..38): [...]
                 Name@(FileId(1), 28..32): "call"@(FileId(1), 5..9)
-                Range@(FileId(1), 33..37): FromStart(ExprId(1)) .. AtEnd(SpanId(10))
+                Range@(FileId(1), 33..37): FromStart(ExprId(1)) .. AtEnd(SpanId(11))
                   Literal@(FileId(1), 33..34): Integer(1)
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_range_expr-5.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_range_expr-5.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler/toc_hir_lowering/tests/lowering.rs
-assertion_line: 61
 expression: "proc call end call var _ := call(*..1)"
-
 ---
 Library@(dummy)
   Root@(dummy): FileId(1) -> ItemId(2)
@@ -17,6 +15,6 @@ Library@(dummy)
             ExprBody@(FileId(1), 28..38)
               CallExpr@(FileId(1), 28..38): [...]
                 Name@(FileId(1), 28..32): "call"@(FileId(1), 5..9)
-                Range@(FileId(1), 33..37): AtEnd(SpanId(9)) .. FromStart(ExprId(1))
+                Range@(FileId(1), 33..37): AtEnd(SpanId(10)) .. FromStart(ExprId(1))
                   Literal@(FileId(1), 36..37): Integer(1)
 

--- a/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_range_expr.snap
+++ b/compiler/toc_hir_lowering/tests/snapshots/lowering__lower_range_expr.snap
@@ -1,8 +1,6 @@
 ---
 source: compiler/toc_hir_lowering/tests/lowering.rs
-assertion_line: 61
 expression: "proc call end call var _ := call(*)"
-
 ---
 Library@(dummy)
   Root@(dummy): FileId(1) -> ItemId(2)
@@ -17,5 +15,5 @@ Library@(dummy)
             ExprBody@(FileId(1), 28..35)
               CallExpr@(FileId(1), 28..35): [...]
                 Name@(FileId(1), 28..32): "call"@(FileId(1), 5..9)
-                Range@(FileId(1), 33..34): AtEnd(SpanId(9))
+                Range@(FileId(1), 33..34): AtEnd(SpanId(10))
 

--- a/compiler/toc_hir_pretty/src/graph.rs
+++ b/compiler/toc_hir_pretty/src/graph.rs
@@ -634,12 +634,12 @@ impl<'out, 'hir> HirVisitor for PrettyVisitor<'out, 'hir> {
                         format!("ex_{idx}_def_id"),
                         self.display_def_id(export.def_id),
                     ),
-                    Layout::NamedPort(format!("ex_{idx}_item_id"), "item_id".into()),
+                    Layout::NamedPort(format!("ex_{idx}_exported_def"), "exported_def".into()),
                 ]));
 
                 self.emit_edge(
-                    format!("{export_table}:ex_{idx}_item_id"),
-                    self.item_id(export.item_id),
+                    format!("{export_table}:ex_{idx}_exported_def"),
+                    self.def_id(export.def_id),
                 );
 
                 v_layout.push(Layout::Hbox(h_layout));

--- a/compiler/toc_syntax/src/lib.rs
+++ b/compiler/toc_syntax/src/lib.rs
@@ -443,6 +443,9 @@ pub type SyntaxToken = rowan::SyntaxToken<Lang>;
 #[allow(unused)]
 pub type SyntaxElement = rowan::NodeOrToken<SyntaxNode, SyntaxToken>;
 
+// Other rowan re-exports
+pub use rowan::WalkEvent;
+
 // Operators
 
 pub const MIN_REF_BINDING_POWER: u8 = 19;


### PR DESCRIPTION
Refactors extracted from #109

Most significant change is that def ids are allocated in lexical order, as opposed to post-order